### PR TITLE
fix(cache): hardening — ClientCache + breaking Module.Cache signature

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -36,6 +36,9 @@ func PublicAuth() func(http.Handler) http.Handler {
 func InternalAuth() func(http.Handler) http.Handler {
 	expected := os.Getenv("MS_INTERNAL_SECRET")
 	if expected == "" {
+		// SECURITY: never echo the `expected` value (or any prefix/suffix of it)
+		// in this log line — Lambda log output goes to CloudWatch which is
+		// commonly accessible to many roles in the org.
 		log.Printf("mirrorstack: WARNING — MS_INTERNAL_SECRET not set, all internal routes will be rejected")
 	}
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -23,12 +23,13 @@ const defaultDevURL = "redis://localhost:6379"
 // ErrCacheMiss is returned by Get when the key does not exist.
 var ErrCacheMiss = errors.New("mirrorstack/cache: key not found")
 
-// Cacher is the interface for cache operations.
+// Cacher is the interface module developers see when they call Module.Cache(ctx).
+// Close is intentionally NOT exposed: the underlying *Client is owned by the SDK's
+// ClientCache and must not be closed by handler code.
 type Cacher interface {
 	Set(ctx context.Context, key, value string, ttl time.Duration) error
 	Get(ctx context.Context, key string) (string, error)
 	Del(ctx context.Context, key string) error
-	Close() error
 }
 
 // Client wraps a go-redis client with app-scoped key prefixing.
@@ -68,6 +69,9 @@ func New(ctx context.Context, redisURL string) (*Client, error) {
 // NewFromCredential creates a Client from platform-injected credentials.
 // Enforces TLS for production ElastiCache connections.
 func NewFromCredential(ctx context.Context, cred Credential) (*Client, error) {
+	if err := cred.validate(); err != nil {
+		return nil, err
+	}
 	opts := &redis.Options{
 		Addr:      cred.Endpoint,
 		Username:  cred.Username,

--- a/cache/client_cache.go
+++ b/cache/client_cache.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"context"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/refcache"
+)
+
+const defaultMaxClients = 100
+
+// ClientCache manages per-(endpoint, username) Redis clients. It is a thin
+// wrapper around refcache.Cache that adds credential validation, key derivation,
+// and client construction. The refcount + LRU + double-checked-locking lifecycle
+// is implemented in refcache.
+type ClientCache struct {
+	cache *refcache.Cache[*Client]
+}
+
+// NewClientCache creates a ClientCache with default settings.
+func NewClientCache() *ClientCache {
+	return &ClientCache{
+		cache: refcache.New[*Client](defaultMaxClients, "mirrorstack/cache: client", func(c *Client) {
+			_ = c.Close()
+		}),
+	}
+}
+
+// Get returns a client for the given credential plus a release closure. The
+// client is refcount-pinned until release runs, so concurrent eviction cannot
+// close it. Pair every Get with a deferred release call.
+func (c *ClientCache) Get(ctx context.Context, cred Credential) (*Client, func(), error) {
+	if err := cred.validate(); err != nil {
+		return nil, nil, err
+	}
+	return c.cache.Get(cred.cacheKey(), func() (*Client, error) {
+		return NewFromCredential(ctx, cred)
+	})
+}
+
+// Close closes all cached clients.
+func (c *ClientCache) Close() {
+	c.cache.Close()
+}

--- a/cache/client_cache_test.go
+++ b/cache/client_cache_test.go
@@ -1,0 +1,67 @@
+package cache
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCredential_Validate(t *testing.T) {
+	t.Parallel()
+
+	const secret = "super-secret-token-xyz"
+	full := Credential{Endpoint: "redis.example.com:6379", Username: "mod_media", Token: secret}
+	if err := full.validate(); err != nil {
+		t.Errorf("full credential should validate, got %v", err)
+	}
+
+	cases := []struct {
+		name string
+		cred Credential
+	}{
+		{"missing endpoint", Credential{Username: "mod_media", Token: secret}},
+		{"missing username", Credential{Endpoint: "redis.example.com:6379", Token: secret}},
+		{"missing token", Credential{Endpoint: "redis.example.com:6379", Username: "mod_media"}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cred.validate()
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if tt.cred.Token != "" && strings.Contains(err.Error(), tt.cred.Token) {
+				t.Errorf("validation error leaked token: %v", err)
+			}
+		})
+	}
+}
+
+func TestCredential_CacheKey_ExcludesToken(t *testing.T) {
+	t.Parallel()
+
+	a := Credential{Endpoint: "redis.example.com:6379", Username: "mod_media", Token: "old-token"}
+	b := Credential{Endpoint: "redis.example.com:6379", Username: "mod_media", Token: "new-token"}
+
+	if a.cacheKey() != b.cacheKey() {
+		t.Errorf("cacheKey should ignore Token (so rotation reuses client): %q vs %q", a.cacheKey(), b.cacheKey())
+	}
+	if strings.Contains(a.cacheKey(), "old-token") {
+		t.Errorf("cacheKey leaked token: %q", a.cacheKey())
+	}
+}
+
+// TestClientCache_Get_RejectsInvalidCredential verifies the wrapper's validate
+// step runs before delegating to refcache. The refcount/eviction/factory logic
+// itself is covered by internal/refcache tests.
+func TestClientCache_Get_RejectsInvalidCredential(t *testing.T) {
+	t.Parallel()
+
+	cache := NewClientCache()
+	defer cache.Close()
+
+	_, _, err := cache.Get(context.Background(), Credential{})
+	if err == nil {
+		t.Error("expected error for empty credential")
+	}
+}

--- a/cache/credential.go
+++ b/cache/credential.go
@@ -1,6 +1,9 @@
 package cache
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 type contextKey string
 
@@ -11,6 +14,20 @@ type Credential struct {
 	Endpoint string `json:"endpoint"` // host:port
 	Username string `json:"username"` // per-module ACL user (e.g., "mod_media")
 	Token    string `json:"token"`    // IAM auth token
+}
+
+// validate checks that all required fields are populated.
+func (c Credential) validate() error {
+	if c.Endpoint == "" || c.Username == "" || c.Token == "" {
+		return fmt.Errorf("mirrorstack/cache: credential missing required fields (endpoint=%q username=%q)", c.Endpoint, c.Username)
+	}
+	return nil
+}
+
+// cacheKey returns the ClientCache key for this credential. Token is intentionally
+// excluded so token rotation reuses the existing client rather than churning it.
+func (c Credential) cacheKey() string {
+	return c.Endpoint + "|" + c.Username
 }
 
 // WithCredential returns a context with the cache credential set.

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -36,15 +36,14 @@ type Module struct {
 	config    Config
 	router    *chi.Mux
 	logger    *log.Logger
-	poolCache *db.PoolCache  // production: per-app DB pools
-	devDBOnce sync.Once      // dev mode: lazy DB init
+	poolCache *db.PoolCache // production: per-app DB pools
+	devDBOnce sync.Once     // dev mode: lazy DB init
 	devDB     *db.DB
 	devDBErr  error
-	devCacheOnce sync.Once                // dev mode: lazy cache init
+	cacheCache   *cache.ClientCache // production: per-app Redis clients
+	devCacheOnce sync.Once          // dev mode: lazy cache init
 	devCache     *cache.Client
 	devCacheErr  error
-	prodCacheMap map[string]*cache.Client // production: keyed by endpoint|username
-	prodCacheMu  sync.Mutex
 	devStorageOnce sync.Once // dev mode: lazy storage init
 	devStorage     *storage.Client
 	devStorageErr  error
@@ -56,10 +55,11 @@ func New(cfg Config) (*Module, error) {
 		return nil, errors.New("mirrorstack: Config.ID is required")
 	}
 	m := &Module{
-		config:    cfg,
-		router:    chi.NewRouter(),
-		logger:    log.New(os.Stderr, "mirrorstack: ", log.LstdFlags),
-		poolCache: db.NewPoolCache(),
+		config:     cfg,
+		router:     chi.NewRouter(),
+		logger:     log.New(os.Stderr, "mirrorstack: ", log.LstdFlags),
+		poolCache:  db.NewPoolCache(),
+		cacheCache: cache.NewClientCache(),
 	}
 	m.mountSystemRoutes()
 	return m, nil
@@ -132,47 +132,38 @@ func (m *Module) resolvePool(ctx context.Context) (*pgxpool.Pool, func(), error)
 
 // Cache returns a scoped cache client. Keys are auto-prefixed with {appID}:{moduleID}:.
 //
-//	c, err := mod.Cache(r.Context())
+//	c, release, err := mod.Cache(r.Context())
 //	if err != nil { ... }
-//	c.Set("views:123", "42", 5*time.Minute)
-//	val, err := c.Get("views:123")
-func (m *Module) Cache(ctx context.Context) (cache.Cacher, error) {
-	client, err := m.resolveCache(ctx)
+//	defer release()
+//	c.Set(ctx, "views:123", "42", 5*time.Minute)
+//	val, err := c.Get(ctx, "views:123")
+func (m *Module) Cache(ctx context.Context) (cache.Cacher, func(), error) {
+	client, releaseClient, err := m.resolveCache(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// Always apply prefix — never return unprefixed base client
 	appID := ""
 	if a := auth.Get(ctx); a != nil {
 		appID = a.AppID
 	}
-	return client.ForApp(appID, m.config.ID), nil
+	return client.ForApp(appID, m.config.ID), releaseClient, nil
 }
 
-func (m *Module) resolveCache(ctx context.Context) (*cache.Client, error) {
-	// Production: credential from Lambda payload, keyed by endpoint|username
+// resolveCache returns the underlying cache client and a release closure.
+// Production uses ClientCache (refcount-pinned). Dev uses a single shared
+// client (no-op release).
+func (m *Module) resolveCache(ctx context.Context) (*cache.Client, func(), error) {
 	if cred := cache.CredentialFrom(ctx); cred != nil {
-		key := cred.Endpoint + "|" + cred.Username
-		m.prodCacheMu.Lock()
-		defer m.prodCacheMu.Unlock()
-		if m.prodCacheMap == nil {
-			m.prodCacheMap = make(map[string]*cache.Client)
-		}
-		if c, ok := m.prodCacheMap[key]; ok {
-			return c, nil
-		}
-		c, err := cache.NewFromCredential(context.Background(), *cred)
-		if err != nil {
-			return nil, err
-		}
-		m.prodCacheMap[key] = c
-		return c, nil
+		return m.cacheCache.Get(ctx, *cred)
 	}
-	// Dev: REDIS_URL env var
 	m.devCacheOnce.Do(func() {
 		m.devCache, m.devCacheErr = cache.Open(context.Background())
 	})
-	return m.devCache, m.devCacheErr
+	if m.devCacheErr != nil {
+		return nil, nil, m.devCacheErr
+	}
+	return m.devCache, func() {}, nil
 }
 
 // Storage returns a scoped storage client. Keys are auto-prefixed with the app/module path.
@@ -262,12 +253,9 @@ func (m *Module) Close() {
 	if m.devDB != nil {
 		m.devDB.Close()
 	}
-	m.prodCacheMu.Lock()
-	for k, c := range m.prodCacheMap {
-		c.Close()
-		delete(m.prodCacheMap, k)
+	if m.cacheCache != nil {
+		m.cacheCache.Close()
 	}
-	m.prodCacheMu.Unlock()
 	if m.devCache != nil {
 		m.devCache.Close()
 	}
@@ -326,7 +314,7 @@ func Tx(ctx context.Context, fn func(q db.Querier) error) error {
 }
 
 // Cache returns a scoped cache client on the default module.
-func Cache(ctx context.Context) (cache.Cacher, error) {
+func Cache(ctx context.Context) (cache.Cacher, func(), error) {
 	return mustDefault("Cache").Cache(ctx)
 }
 


### PR DESCRIPTION
## Summary

Follow-up hardening for the cache package (Issue #12, already merged). Applies the same multi-tenant resource-pool hardening that the db package received in #26 — both layers had the same shape of bugs.

## What was wrong

- \`prodCacheMap\` was unbounded — no LRU eviction, no growth limit. Memory grows with the number of distinct (endpoint, username) tuples a Lambda container sees.
- Mutex held during \`cache.NewFromCredential\` (TLS handshake) — serialized cold-start across all goroutines in a Lambda container, same H-5 pattern fixed in db.
- No refcount protection against eviction-during-use races.
- \`Cacher\` interface exposed \`Close()\`, letting handler code accidentally close a client the SDK was still managing for other invocations (leaky abstraction).

## What changed

### \`cache.ClientCache\` (new)

Thin wrapper around \`refcache.Cache[*Client]\` (introduced in #26). Provides refcount-pinned + LRU + double-checked locking + singleflight via the shared internal package. \`defaultMaxClients = 100\` for typical Lambda concurrency.

### \`cache.Credential.validate()\` and \`cacheKey()\`

- \`validate()\` checks Endpoint/Username/Token; called from \`NewFromCredential\` to fail fast on missing fields
- \`cacheKey()\` excludes Token so token rotation reuses the existing client

### \`Cacher\` interface — BREAKING

\`Close() error\` removed from the interface. The concrete \`*cache.Client.Close()\` still exists for \`ClientCache\` internal use, but module developers receiving a \`Cacher\` from \`Module.Cache(ctx)\` can no longer close the underlying client out from under the SDK.

### \`Module.Cache()\` — BREAKING

Signature: \`(Cacher, error)\` → \`(Cacher, func(), error)\`. Matches \`Module.DB()\` / \`Module.Tx()\` pattern. Caller MUST defer \`release()\` to decrement the refcount.

\`prodCacheMap\` removed from \`Module\` struct in favor of \`cacheCache *cache.ClientCache\`. \`Module.Close()\` updated to call \`cacheCache.Close()\`. Convenience \`mirrorstack.Cache()\` updated to match.

### \`auth/middleware.go\`

SECURITY comment near \`MS_INTERNAL_SECRET\` warning log forbidding future contributors from echoing the secret value (CloudWatch is widely accessible).

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` passes (full SDK)
- [x] \`cache/client_cache_test.go\` — \`Credential.validate\` (3 missing-field cases + token leak guard), \`cacheKey\` excludes token, \`ClientCache.Get\` rejects invalid credential
- [x] \`internal/refcache\` lifecycle tests (12 tests, including singleflight coalescing) cover the underlying cache behavior

## Breaking changes

Two deliberate API breaks for module developers:

1. \`cache.Cacher\` no longer has \`Close() error\`. Type assertion to \`*cache.Client\` still works if a developer needs to close the concrete type (they shouldn't).
2. \`ms.Cache(ctx)\` returns \`(Cacher, func(), error)\` instead of \`(Cacher, error)\`. Callers must add \`defer release()\` like they already do for \`ms.DB(ctx)\`.

\`\`\`go
// before
c, err := ms.Cache(r.Context())

// after
c, release, err := ms.Cache(r.Context())
defer release()
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)