### PR TITLE
feat(system): manifest endpoint — GET /__mirrorstack/platform/manifest

### DIFF
--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -1,0 +1,69 @@
+// Package migration reads the module's sql/ directory to determine the
+// latest migration version. The version is exposed via the manifest endpoint
+// so the platform can map module versions to migration numbers on deploy.
+//
+// Module developers embed their migrations via:
+//
+//	//go:embed sql/*
+//	var sqlFiles embed.FS
+//
+// and pass sqlFiles to ms.Config.SQL.
+package migration
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"strconv"
+)
+
+// migrationFilePattern matches files named like "0000_initial.up.sql".
+// The leading numeric prefix is the version. Down-migration files
+// (".down.sql") are intentionally excluded — only up-files determine the
+// current schema version.
+var migrationFilePattern = regexp.MustCompile(`^(\d+)_.*\.up\.sql$`)
+
+// LatestVersion returns the highest migration version string in the sql/
+// directory of fsys. Returns "" if fsys is nil, the sql/ directory does not
+// exist, or no .up.sql files are present.
+//
+// The returned version is the leading numeric prefix as it appears in the
+// filename (e.g., "0008") so the platform sees the same string format the
+// module developer wrote. Versions are compared numerically — a module that
+// mixes widths ("9", "10") still resolves correctly.
+func LatestVersion(fsys fs.FS) (string, error) {
+	if fsys == nil {
+		return "", nil
+	}
+	entries, err := fs.ReadDir(fsys, "sql")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("mirrorstack/migration: read sql/ dir: %w", err)
+	}
+
+	var (
+		bestStr string
+		bestNum = -1
+	)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := migrationFilePattern.FindStringSubmatch(e.Name())
+		if m == nil {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		if n > bestNum {
+			bestNum = n
+			bestStr = m[1]
+		}
+	}
+	return bestStr, nil
+}

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -1,0 +1,124 @@
+package migration
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestLatestVersion_NilFS(t *testing.T) {
+	t.Parallel()
+
+	got, err := LatestVersion(nil)
+	if err != nil {
+		t.Errorf("LatestVersion(nil) err = %v, want nil", err)
+	}
+	if got != "" {
+		t.Errorf("LatestVersion(nil) = %q, want empty", got)
+	}
+}
+
+func TestLatestVersion_NoSQLDir(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"README.md": &fstest.MapFile{Data: []byte("hello")},
+	}
+	got, err := LatestVersion(fsys)
+	if err != nil {
+		t.Errorf("err = %v, want nil for missing sql/ dir", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty when sql/ dir absent", got)
+	}
+}
+
+func TestLatestVersion_PicksHighest(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"sql/0000_initial.up.sql":      &fstest.MapFile{Data: []byte("CREATE TABLE items (id SERIAL);")},
+		"sql/0000_initial.down.sql":    &fstest.MapFile{Data: []byte("DROP TABLE items;")},
+		"sql/0001_add_title.up.sql":    &fstest.MapFile{Data: []byte("ALTER TABLE items ADD title TEXT;")},
+		"sql/0001_add_title.down.sql":  &fstest.MapFile{Data: []byte("ALTER TABLE items DROP COLUMN title;")},
+		"sql/0008_add_index.up.sql":    &fstest.MapFile{Data: []byte("CREATE INDEX ON items(title);")},
+		"sql/0008_add_index.down.sql":  &fstest.MapFile{Data: []byte("DROP INDEX items_title_idx;")},
+	}
+	got, err := LatestVersion(fsys)
+	if err != nil {
+		t.Fatalf("LatestVersion: %v", err)
+	}
+	if got != "0008" {
+		t.Errorf("LatestVersion = %q, want 0008", got)
+	}
+}
+
+func TestLatestVersion_IgnoresDownFiles(t *testing.T) {
+	t.Parallel()
+
+	// Even if a down-only file has a higher version, it shouldn't count.
+	fsys := fstest.MapFS{
+		"sql/0001_a.up.sql":   &fstest.MapFile{Data: []byte("")},
+		"sql/0009_b.down.sql": &fstest.MapFile{Data: []byte("")},
+	}
+	got, _ := LatestVersion(fsys)
+	if got != "0001" {
+		t.Errorf("got %q, want 0001 (.down.sql files must be ignored)", got)
+	}
+}
+
+func TestLatestVersion_IgnoresNonMigrationFiles(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"sql/0001_a.up.sql":   &fstest.MapFile{Data: []byte("")},
+		"sql/README.md":       &fstest.MapFile{Data: []byte("")},
+		"sql/queries/list.sql": &fstest.MapFile{Data: []byte("")}, // sqlc query file (not a migration)
+	}
+	got, _ := LatestVersion(fsys)
+	if got != "0001" {
+		t.Errorf("got %q, want 0001 (non-migration files must be ignored)", got)
+	}
+}
+
+func TestLatestVersion_EmptySQLDir(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"sql/.gitkeep": &fstest.MapFile{Data: []byte("")},
+	}
+	got, err := LatestVersion(fsys)
+	if err != nil {
+		t.Errorf("err = %v, want nil for empty sql/ dir", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty for empty sql/ dir", got)
+	}
+}
+
+func TestLatestVersion_PreservesZeroPadding(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"sql/0042_a.up.sql": &fstest.MapFile{Data: []byte("")},
+	}
+	got, _ := LatestVersion(fsys)
+	if got != "0042" {
+		t.Errorf("got %q, want 0042 (must preserve zero-padding from filename)", got)
+	}
+}
+
+func TestLatestVersion_MixedWidthsSortNumerically(t *testing.T) {
+	t.Parallel()
+
+	// Regression: a string sort would put "9" after "10" because '9' > '1'.
+	// LatestVersion must compare numerically so a module that mixes widths
+	// still resolves the highest version correctly.
+	fsys := fstest.MapFS{
+		"sql/9_old.up.sql": &fstest.MapFile{Data: []byte("")},
+		"sql/10_new.up.sql": &fstest.MapFile{Data: []byte("")},
+	}
+	got, _ := LatestVersion(fsys)
+	if got != "10" {
+		t.Errorf("got %q, want 10 (numeric comparison, not string sort)", got)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,153 @@
+// Package registry collects per-module declarations (routes, events, schedules)
+// for the manifest endpoint to expose to the platform on deploy.
+//
+// Routes are recorded by Module.Platform/Public/Internal as the developer
+// registers handlers. Events and schedules are placeholders for issue #9
+// (ms.OnEvent / ms.Emit / ms.Cron) — the registry exposes empty defaults so
+// the manifest payload shape is stable.
+package registry
+
+import (
+	"maps"
+	"slices"
+	"sync"
+)
+
+// Scope identifies which auth boundary a route belongs to. The three values
+// match the three Module.Platform/Public/Internal entry points.
+type Scope string
+
+const (
+	ScopePlatform Scope = "platform"
+	ScopePublic   Scope = "public"
+	ScopeInternal Scope = "internal"
+)
+
+// AllScopes returns the canonical ordering of scopes. The manifest endpoint
+// iterates this so every scope appears in the payload even when no routes
+// are registered for it.
+func AllScopes() []Scope {
+	return []Scope{ScopePlatform, ScopePublic, ScopeInternal}
+}
+
+type Route struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+}
+
+type Schedule struct {
+	Name string `json:"name"`
+	Cron string `json:"cron"`
+}
+
+// Registry is the per-module registry of routes/events/schedules.
+// All operations are safe for concurrent use.
+type Registry struct {
+	mu         sync.RWMutex
+	routes     map[Scope][]Route
+	emits      []string
+	subscribes map[string]string // event name → internal path
+	schedules  []Schedule
+}
+
+func New() *Registry {
+	return &Registry{
+		routes:     make(map[Scope][]Route),
+		subscribes: make(map[string]string),
+	}
+}
+
+// AddRoute records a route under the given scope. First-wins: duplicate
+// (scope, method, path) triples are dropped.
+func (r *Registry) AddRoute(scope Scope, method, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.routes[scope] {
+		if existing.Method == method && existing.Path == path {
+			return
+		}
+	}
+	r.routes[scope] = append(r.routes[scope], Route{Method: method, Path: path})
+}
+
+// Routes returns a copy of all routes grouped by scope. Every scope in
+// AllScopes() is present in the result with at least an empty slice, so
+// callers can rely on the field shape without nil checks.
+func (r *Registry) Routes() map[Scope][]Route {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[Scope][]Route, len(AllScopes()))
+	for _, scope := range AllScopes() {
+		out[scope] = slices.Clone(r.routes[scope])
+		if out[scope] == nil {
+			out[scope] = []Route{}
+		}
+	}
+	return out
+}
+
+// AddEmit declares that the module emits an event of the given name.
+// First-wins: duplicate names are dropped.
+func (r *Registry) AddEmit(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if slices.Contains(r.emits, name) {
+		return
+	}
+	r.emits = append(r.emits, name)
+}
+
+// Emits returns a non-nil copy of all declared emit events.
+func (r *Registry) Emits() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.emits == nil {
+		return []string{}
+	}
+	return slices.Clone(r.emits)
+}
+
+// AddSubscribe declares that the module subscribes to an event from another
+// module. The handler is mounted at path on the Internal scope. First-wins:
+// a second AddSubscribe for the same event name is dropped.
+func (r *Registry) AddSubscribe(name, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.subscribes[name]; exists {
+		return
+	}
+	r.subscribes[name] = path
+}
+
+// Subscribes returns a non-nil copy of all event subscriptions.
+func (r *Registry) Subscribes() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.subscribes == nil {
+		return map[string]string{}
+	}
+	return maps.Clone(r.subscribes)
+}
+
+// AddSchedule registers a cron job. First-wins by name: a second
+// AddSchedule with the same name is dropped.
+func (r *Registry) AddSchedule(name, cron string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.schedules {
+		if existing.Name == name {
+			return
+		}
+	}
+	r.schedules = append(r.schedules, Schedule{Name: name, Cron: cron})
+}
+
+// Schedules returns a non-nil copy of all scheduled jobs.
+func (r *Registry) Schedules() []Schedule {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.schedules == nil {
+		return []Schedule{}
+	}
+	return slices.Clone(r.schedules)
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -30,6 +30,14 @@ func AllScopes() []Scope {
 	return []Scope{ScopePlatform, ScopePublic, ScopeInternal}
 }
 
+// IsValid reports whether s is one of the three known scopes.
+// AddRoute panics on unknown scopes — the type accepts arbitrary strings,
+// but only ScopePlatform/ScopePublic/ScopeInternal are valid scope keys in
+// the manifest payload, and only SDK-internal code should be calling AddRoute.
+func (s Scope) IsValid() bool {
+	return s == ScopePlatform || s == ScopePublic || s == ScopeInternal
+}
+
 type Route struct {
 	Method string `json:"method"`
 	Path   string `json:"path"`
@@ -58,8 +66,12 @@ func New() *Registry {
 }
 
 // AddRoute records a route under the given scope. First-wins: duplicate
-// (scope, method, path) triples are dropped.
+// (scope, method, path) triples are dropped. Panics on an unknown scope —
+// only SDK-internal code calls this, so an unknown value is a programmer error.
 func (r *Registry) AddRoute(scope Scope, method, path string) {
+	if !scope.IsValid() {
+		panic("mirrorstack/registry: unknown scope " + string(scope))
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.routes[scope] {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -37,6 +37,33 @@ func TestAddRoute_DropsDuplicates(t *testing.T) {
 	}
 }
 
+func TestAddRoute_PanicsOnUnknownScope(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for unknown scope")
+		}
+	}()
+	r := New()
+	r.AddRoute(Scope("../etc/passwd"), "GET", "/x")
+}
+
+func TestScope_IsValid(t *testing.T) {
+	t.Parallel()
+
+	for _, valid := range []Scope{ScopePlatform, ScopePublic, ScopeInternal} {
+		if !valid.IsValid() {
+			t.Errorf("scope %q should be valid", valid)
+		}
+	}
+	for _, invalid := range []Scope{"", "Platform", "admin", "../etc"} {
+		if invalid.IsValid() {
+			t.Errorf("scope %q should NOT be valid", invalid)
+		}
+	}
+}
+
 func TestRoutes_AlwaysHasAllScopes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,186 @@
+package registry
+
+import "testing"
+
+func TestAddRoute_GroupsByScope(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddRoute(ScopePlatform, "GET", "/items")
+	r.AddRoute(ScopePlatform, "POST", "/items")
+	r.AddRoute(ScopePublic, "GET", "/items")
+	r.AddRoute(ScopeInternal, "POST", "/events/foo")
+
+	got := r.Routes()
+	if len(got[ScopePlatform]) != 2 {
+		t.Errorf("platform routes = %d, want 2", len(got[ScopePlatform]))
+	}
+	if len(got[ScopePublic]) != 1 {
+		t.Errorf("public routes = %d, want 1", len(got[ScopePublic]))
+	}
+	if len(got[ScopeInternal]) != 1 {
+		t.Errorf("internal routes = %d, want 1", len(got[ScopeInternal]))
+	}
+}
+
+func TestAddRoute_DropsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddRoute(ScopePlatform, "GET", "/items")
+	r.AddRoute(ScopePlatform, "GET", "/items")
+	r.AddRoute(ScopePlatform, "GET", "/items")
+
+	got := r.Routes()
+	if len(got[ScopePlatform]) != 1 {
+		t.Errorf("expected 1 route after 3 identical adds, got %d", len(got[ScopePlatform]))
+	}
+}
+
+func TestRoutes_AlwaysHasAllScopes(t *testing.T) {
+	t.Parallel()
+
+	// Empty registry must still return all three scopes as empty slices, so
+	// the manifest payload shape is stable.
+	r := New()
+	got := r.Routes()
+	for _, scope := range AllScopes() {
+		v, ok := got[scope]
+		if !ok {
+			t.Errorf("scope %q missing from empty Routes()", scope)
+		}
+		if v == nil {
+			t.Errorf("scope %q is nil, want empty slice", scope)
+		}
+	}
+}
+
+func TestRoutes_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddRoute(ScopePlatform, "GET", "/items")
+
+	first := r.Routes()
+	first[ScopePlatform] = append(first[ScopePlatform], Route{Method: "POST", Path: "/injected"})
+
+	second := r.Routes()
+	if len(second[ScopePlatform]) != 1 {
+		t.Errorf("Routes() returned a shared slice: caller mutation leaked back")
+	}
+}
+
+func TestEmits_DropsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddEmit("user.created")
+	r.AddEmit("user.created")
+	r.AddEmit("user.deleted")
+
+	got := r.Emits()
+	if len(got) != 2 {
+		t.Errorf("emits = %v, want 2 distinct events", got)
+	}
+}
+
+func TestEmits_EmptyReturnsNonNil(t *testing.T) {
+	t.Parallel()
+	if got := New().Emits(); got == nil {
+		t.Error("empty Emits() returned nil, want []string{}")
+	}
+}
+
+func TestSubscribes_KeyedByEventName(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddSubscribe("oauth.user_deleted", "/internal/events/on-user-deleted")
+	r.AddSubscribe("billing.payment_succeeded", "/internal/events/on-payment")
+
+	got := r.Subscribes()
+	if got["oauth.user_deleted"] != "/internal/events/on-user-deleted" {
+		t.Errorf("oauth.user_deleted path = %q", got["oauth.user_deleted"])
+	}
+	if got["billing.payment_succeeded"] != "/internal/events/on-payment" {
+		t.Errorf("billing path = %q", got["billing.payment_succeeded"])
+	}
+}
+
+func TestSubscribes_FirstWins(t *testing.T) {
+	t.Parallel()
+
+	// Match AddRoute / AddEmit semantics: a second AddSubscribe for the same
+	// event name must NOT silently overwrite the first.
+	r := New()
+	r.AddSubscribe("user.created", "/internal/events/handler-a")
+	r.AddSubscribe("user.created", "/internal/events/handler-b")
+
+	got := r.Subscribes()
+	if got["user.created"] != "/internal/events/handler-a" {
+		t.Errorf("user.created = %q, want first-wins handler-a", got["user.created"])
+	}
+}
+
+func TestSubscribes_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddSubscribe("a", "/path-a")
+
+	first := r.Subscribes()
+	first["b"] = "/injected"
+
+	second := r.Subscribes()
+	if _, ok := second["b"]; ok {
+		t.Error("Subscribes() returned a shared map: caller mutation leaked back")
+	}
+}
+
+func TestSubscribes_EmptyReturnsNonNil(t *testing.T) {
+	t.Parallel()
+	if got := New().Subscribes(); got == nil {
+		t.Error("empty Subscribes() returned nil, want map{}")
+	}
+}
+
+func TestSchedules_Recorded(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddSchedule("cleanup-temp", "0 3 * * *")
+	r.AddSchedule("daily-report", "0 9 * * *")
+
+	got := r.Schedules()
+	if len(got) != 2 {
+		t.Fatalf("schedules = %v, want 2", got)
+	}
+	if got[0].Name != "cleanup-temp" || got[0].Cron != "0 3 * * *" {
+		t.Errorf("schedules[0] = %+v, want {cleanup-temp, 0 3 * * *}", got[0])
+	}
+}
+
+func TestSchedules_DropsDuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	// Two schedules with the same name (even with different crons) is a
+	// configuration mistake — first-wins matches AddRoute / AddEmit.
+	r := New()
+	r.AddSchedule("cleanup", "0 3 * * *")
+	r.AddSchedule("cleanup", "0 5 * * *")
+
+	got := r.Schedules()
+	if len(got) != 1 {
+		t.Fatalf("schedules = %d, want 1 (first-wins by name)", len(got))
+	}
+	if got[0].Cron != "0 3 * * *" {
+		t.Errorf("schedules[0].Cron = %q, want 0 3 * * * (first wins)", got[0].Cron)
+	}
+}
+
+func TestSchedules_EmptyReturnsNonNil(t *testing.T) {
+	t.Parallel()
+	if got := New().Schedules(); got == nil {
+		t.Error("empty Schedules() returned nil, want []Schedule{}")
+	}
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -230,6 +230,18 @@ func (m *Module) Internal(fn func(r chi.Router)) {
 // each route's middleware chain, which we re-apply on the main router via
 // .With(...).Method(...) so the routing behavior is identical to the previous
 // .Group()-based implementation.
+//
+// We rely on chi.Walk including the sub-router's Use() middlewares in the
+// callback's middlewares slice — this is how chi v5 propagates route-level
+// middleware chains. If a future chi version changes that behavior,
+// TestManifest_RegisteredScopesStillRouteCorrectly is the regression guard
+// (it asserts platform routes still return 401 without auth).
+//
+// chi.Walk only returns an error if the WalkFunc returns one — ours never
+// does. A non-nil error here would mean chi itself failed to walk its own
+// route tree, which indicates a misconfigured module that should not start.
+// Panic instead of silently leaving the registry and router in inconsistent
+// states (some routes recorded but not re-registered, or vice versa).
 func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Handler) http.Handler, fn func(r chi.Router)) {
 	sub := chi.NewRouter()
 	if scopeMiddleware != nil {
@@ -237,11 +249,13 @@ func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Ha
 	}
 	fn(sub)
 
-	_ = chi.Walk(sub, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+	if err := chi.Walk(sub, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
 		m.registry.AddRoute(scope, method, route)
 		m.router.With(middlewares...).Method(method, route, handler)
 		return nil
-	})
+	}); err != nil {
+		panic("mirrorstack: scopedRoutes(" + string(scope) + ") chi.Walk failed: " + err.Error())
+	}
 }
 
 // RequirePermission returns chi middleware that checks AppRole against allowed roles.

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -6,6 +6,7 @@ package mirrorstack
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 	"github.com/mirrorstack-ai/app-module-sdk/system"
@@ -29,6 +31,12 @@ type Config struct {
 	ID   string // Unique module identifier (required)
 	Name string // Default display name (platform can override)
 	Icon string // Default Material icon name (platform can override)
+
+	// SQL is an optional filesystem containing the module's sql/ directory
+	// (typically an embed.FS from `//go:embed sql/*`). The manifest endpoint
+	// reads it to determine the latest migration version. The lifecycle
+	// routes (issue #8) will reuse it to apply migrations.
+	SQL fs.FS
 }
 
 // Module is the core SDK instance.
@@ -36,6 +44,7 @@ type Module struct {
 	config    Config
 	router    *chi.Mux
 	logger    *log.Logger
+	registry  *registry.Registry
 	poolCache *db.PoolCache // production: per-app DB pools
 	devDBOnce sync.Once     // dev mode: lazy DB init
 	devDB     *db.DB
@@ -58,6 +67,7 @@ func New(cfg Config) (*Module, error) {
 		config:     cfg,
 		router:     chi.NewRouter(),
 		logger:     log.New(os.Stderr, "mirrorstack: ", log.LstdFlags),
+		registry:   registry.New(),
 		poolCache:  db.NewPoolCache(),
 		cacheCache: cache.NewClientCache(),
 	}
@@ -197,23 +207,40 @@ func (m *Module) resolveStorage(ctx context.Context) (*storage.Client, error) {
 // Platform registers routes with platform auth scope.
 // Default: admin only. Use auth.RequirePermission for member/viewer access.
 func (m *Module) Platform(fn func(r chi.Router)) {
-	m.router.Group(func(r chi.Router) {
-		r.Use(auth.PlatformAuth())
-		fn(r)
-	})
+	m.scopedRoutes(registry.ScopePlatform, auth.PlatformAuth(), fn)
 }
 
 // Public registers routes with public auth scope (anyone, including anonymous).
 func (m *Module) Public(fn func(r chi.Router)) {
-	m.router.Group(fn)
+	m.scopedRoutes(registry.ScopePublic, nil, fn)
 }
 
 // Internal registers routes with internal auth scope (platform-to-module only).
 // Validates X-MS-Internal-Secret via constant-time comparison.
 func (m *Module) Internal(fn func(r chi.Router)) {
-	m.router.Group(func(r chi.Router) {
-		r.Use(auth.InternalAuth())
-		fn(r)
+	m.scopedRoutes(registry.ScopeInternal, auth.InternalAuth(), fn)
+}
+
+// scopedRoutes records every route fn registers under the given scope, then
+// re-attaches them to the main router with the scope's auth middleware.
+//
+// We use a sub-router + chi.Walk so the manifest endpoint can list every
+// declared route per scope. Walking after fn() returns gives us the full
+// route table (chi accumulates path prefixes from r.Route automatically) plus
+// each route's middleware chain, which we re-apply on the main router via
+// .With(...).Method(...) so the routing behavior is identical to the previous
+// .Group()-based implementation.
+func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Handler) http.Handler, fn func(r chi.Router)) {
+	sub := chi.NewRouter()
+	if scopeMiddleware != nil {
+		sub.Use(scopeMiddleware)
+	}
+	fn(sub)
+
+	_ = chi.Walk(sub, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+		m.registry.AddRoute(scope, method, route)
+		m.router.With(middlewares...).Method(method, route, handler)
+		return nil
 	})
 }
 
@@ -266,7 +293,11 @@ func (m *Module) mountSystemRoutes() {
 		r.Get("/health", system.Health) // intentionally public — no auth
 		r.Route("/platform", func(r chi.Router) {
 			r.Use(auth.InternalAuth())
-			// manifest, lifecycle — mounted by future issues
+			r.Get("/manifest", system.ManifestHandler(
+				m.config.ID, m.config.Name, m.config.Icon,
+				m.config.SQL, m.registry,
+			))
+			// lifecycle — mounted by future issues
 		})
 	})
 }

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -217,10 +217,12 @@ func TestSystemPlatformRoutes_RequireInternalSecret(t *testing.T) {
 	t.Setenv("MS_INTERNAL_SECRET", "platform-secret")
 	m, _ := New(Config{ID: "test", Name: "Test"})
 
-	// Without secret → 401
+	// Without secret → 401. Asserting exactly 401 (not just !=200) so an
+	// accidental route removal — which would return 404 — fails this test
+	// instead of providing false assurance about the auth boundary.
 	rec := doRequest(t, m.Router(), "GET", "/__mirrorstack/platform/manifest")
-	if rec.Code == 200 {
-		t.Error("expected non-200 for system platform route without secret")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without secret, got %d", rec.Code)
 	}
 }
 

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -1,12 +1,16 @@
 package mirrorstack
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/fstest"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+	"github.com/mirrorstack-ai/app-module-sdk/system"
 )
 
 func resetDefault(t *testing.T) {
@@ -217,6 +221,112 @@ func TestSystemPlatformRoutes_RequireInternalSecret(t *testing.T) {
 	rec := doRequest(t, m.Router(), "GET", "/__mirrorstack/platform/manifest")
 	if rec.Code == 200 {
 		t.Error("expected non-200 for system platform route without secret")
+	}
+}
+
+// --- Manifest endpoint ---
+
+func TestManifest_Returns200WithSecret(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "platform-secret")
+	m, _ := New(Config{ID: "media", Name: "Media", Icon: "perm_media"})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "platform-secret")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if got.ID != "media" || got.Defaults.Name != "Media" || got.Defaults.Icon != "perm_media" {
+		t.Errorf("manifest identity wrong: %+v", got)
+	}
+}
+
+func TestManifest_RoutesFromAllScopes_RegisteredViaModule(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media", Name: "Media"})
+
+	m.Platform(func(r chi.Router) {
+		r.Get("/items", func(w http.ResponseWriter, r *http.Request) {})
+		r.Post("/items", func(w http.ResponseWriter, r *http.Request) {})
+	})
+	m.Public(func(r chi.Router) {
+		r.Get("/feed", func(w http.ResponseWriter, r *http.Request) {})
+	})
+	m.Internal(func(r chi.Router) {
+		r.Post("/events/on-user-deleted", func(w http.ResponseWriter, r *http.Request) {})
+	})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+
+	if len(got.Routes[registry.ScopePlatform]) != 2 {
+		t.Errorf("platform routes = %d, want 2: %v", len(got.Routes[registry.ScopePlatform]), got.Routes[registry.ScopePlatform])
+	}
+	if len(got.Routes[registry.ScopePublic]) != 1 {
+		t.Errorf("public routes = %d, want 1: %v", len(got.Routes[registry.ScopePublic]), got.Routes[registry.ScopePublic])
+	}
+	if len(got.Routes[registry.ScopeInternal]) != 1 {
+		t.Errorf("internal routes = %d, want 1: %v", len(got.Routes[registry.ScopeInternal]), got.Routes[registry.ScopeInternal])
+	}
+}
+
+func TestManifest_MigrationFromConfig(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	sqlFS := fstest.MapFS{
+		"sql/0000_initial.up.sql":   &fstest.MapFile{Data: []byte("")},
+		"sql/0008_add_index.up.sql": &fstest.MapFile{Data: []byte("")},
+	}
+	m, _ := New(Config{ID: "media", Name: "Media", SQL: sqlFS})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+
+	if got.Migration != "0008" {
+		t.Errorf("migration = %q, want 0008", got.Migration)
+	}
+}
+
+func TestManifest_RegisteredScopesStillRouteCorrectly(t *testing.T) {
+	// Verify that the chi.Walk + re-register approach in scopedRoutes preserves
+	// the original routing behavior. Routes registered via Platform/Public/Internal
+	// must still be reachable AND still enforce auth.
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "test"})
+
+	m.Platform(func(r chi.Router) {
+		r.Get("/admin/items", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	m.Public(func(r chi.Router) {
+		r.Get("/public/feed", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("public"))
+		})
+	})
+
+	// Public route — no auth needed
+	if rec := doRequest(t, m.Router(), "GET", "/public/feed"); rec.Code != 200 {
+		t.Errorf("public route: code = %d, want 200", rec.Code)
+	}
+	// Platform route without auth → 401
+	if rec := doRequest(t, m.Router(), "GET", "/admin/items"); rec.Code != 401 {
+		t.Errorf("platform route without auth: code = %d, want 401", rec.Code)
+	}
+	// Platform route with auth → 200
+	if rec := doRequestWithRole(t, m.Router(), "GET", "/admin/items", auth.RoleAdmin); rec.Code != 200 {
+		t.Errorf("platform route with admin: code = %d, want 200", rec.Code)
 	}
 }
 

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -48,9 +48,11 @@ func ManifestHandler(id, name, icon string, sqlFS fs.FS, reg *registry.Registry)
 		version, err := migration.LatestVersion(sqlFS)
 		if err != nil {
 			// Don't fail the manifest — return empty migration so the platform
-			// can still discover the module. Log so an unreadable sql/ dir
-			// surfaces in CloudWatch.
-			log.Printf("mirrorstack: manifest migration version: %v", err)
+			// can still discover the module. Log a sanitized message: in dev
+			// mode with os.DirFS the wrapped error would include the resolved
+			// filesystem path, which is dev-environment noise we don't want
+			// in CloudWatch. The operator can re-check Config.SQL locally.
+			log.Printf("mirrorstack: manifest migration version unavailable (check Config.SQL is set correctly)")
 		}
 
 		httputil.JSON(w, http.StatusOK, ManifestPayload{

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -1,0 +1,65 @@
+package system
+
+import (
+	"io/fs"
+	"log"
+	"net/http"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+)
+
+// ManifestPayload is the JSON shape returned by GET /__mirrorstack/platform/manifest.
+// The platform reads this on deploy to discover module identity, capabilities,
+// and the current migration version.
+type ManifestPayload struct {
+	ID        string                            `json:"id"`
+	Defaults  ManifestDefaults                  `json:"defaults"`
+	Migration string                            `json:"migration"`
+	Routes    map[registry.Scope][]registry.Route `json:"routes"`
+	Events    ManifestEvents                    `json:"events"`
+	Schedules []registry.Schedule               `json:"schedules"`
+}
+
+// ManifestDefaults is the default display name and icon. The platform may
+// override these per-app installation.
+type ManifestDefaults struct {
+	Name string `json:"name"`
+	Icon string `json:"icon"`
+}
+
+// ManifestEvents declares which events the module emits and which it subscribes to.
+type ManifestEvents struct {
+	Emits      []string          `json:"emits"`
+	Subscribes map[string]string `json:"subscribes"`
+}
+
+// ManifestHandler returns an http.HandlerFunc that serves the module manifest.
+// The migration version is read from sqlFS at request time so a hot-reloaded
+// build picks up new migrations without a restart. sqlFS may be nil — the
+// migration field will be empty.
+//
+// Empty-collection normalization (every scope present, no nil maps/slices) is
+// the Registry's responsibility — Routes/Emits/Subscribes/Schedules all return
+// non-nil zero values.
+func ManifestHandler(id, name, icon string, sqlFS fs.FS, reg *registry.Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		version, err := migration.LatestVersion(sqlFS)
+		if err != nil {
+			// Don't fail the manifest — return empty migration so the platform
+			// can still discover the module. Log so an unreadable sql/ dir
+			// surfaces in CloudWatch.
+			log.Printf("mirrorstack: manifest migration version: %v", err)
+		}
+
+		httputil.JSON(w, http.StatusOK, ManifestPayload{
+			ID:        id,
+			Defaults:  ManifestDefaults{Name: name, Icon: icon},
+			Migration: version,
+			Routes:    reg.Routes(),
+			Events:    ManifestEvents{Emits: reg.Emits(), Subscribes: reg.Subscribes()},
+			Schedules: reg.Schedules(),
+		})
+	}
+}

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -1,0 +1,142 @@
+package system
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+)
+
+func decodeManifest(t *testing.T, h http.HandlerFunc) ManifestPayload {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	return got
+}
+
+func TestManifest_IDAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, registry.New()))
+
+	if got.ID != "media" {
+		t.Errorf("id = %q, want media", got.ID)
+	}
+	if got.Defaults.Name != "Media" {
+		t.Errorf("defaults.name = %q, want Media", got.Defaults.Name)
+	}
+	if got.Defaults.Icon != "perm_media" {
+		t.Errorf("defaults.icon = %q, want perm_media", got.Defaults.Icon)
+	}
+}
+
+func TestManifest_RoutesFromAllScopes(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	reg.AddRoute(registry.ScopePlatform, "GET", "/items")
+	reg.AddRoute(registry.ScopePlatform, "POST", "/items")
+	reg.AddRoute(registry.ScopePublic, "GET", "/items")
+	reg.AddRoute(registry.ScopeInternal, "POST", "/events/on-user-deleted")
+
+	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, reg))
+
+	if len(got.Routes[registry.ScopePlatform]) != 2 {
+		t.Errorf("platform routes = %d, want 2", len(got.Routes[registry.ScopePlatform]))
+	}
+	if len(got.Routes[registry.ScopePublic]) != 1 {
+		t.Errorf("public routes = %d, want 1", len(got.Routes[registry.ScopePublic]))
+	}
+	if len(got.Routes[registry.ScopeInternal]) != 1 {
+		t.Errorf("internal routes = %d, want 1", len(got.Routes[registry.ScopeInternal]))
+	}
+}
+
+func TestManifest_EmptyScopesPresent(t *testing.T) {
+	t.Parallel()
+
+	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, registry.New()))
+
+	for _, scope := range registry.AllScopes() {
+		s, ok := got.Routes[scope]
+		if !ok {
+			t.Errorf("routes.%s missing from manifest, want empty array", scope)
+		}
+		if s == nil {
+			t.Errorf("routes.%s is nil, want empty array []", scope)
+		}
+	}
+}
+
+func TestManifest_EventsAndSchedules(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	reg.AddEmit("created")
+	reg.AddSubscribe("oauth.user_deleted", "/internal/events/on-user-deleted")
+	reg.AddSchedule("cleanup-temp", "0 3 * * *")
+
+	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, reg))
+
+	if len(got.Events.Emits) != 1 || got.Events.Emits[0] != "created" {
+		t.Errorf("events.emits = %v, want [created]", got.Events.Emits)
+	}
+	if got.Events.Subscribes["oauth.user_deleted"] != "/internal/events/on-user-deleted" {
+		t.Errorf("events.subscribes mismatch: %v", got.Events.Subscribes)
+	}
+	if len(got.Schedules) != 1 || got.Schedules[0].Name != "cleanup-temp" {
+		t.Errorf("schedules = %v, want [{cleanup-temp ...}]", got.Schedules)
+	}
+}
+
+func TestManifest_EmptyEventsAndSchedules_NotNull(t *testing.T) {
+	t.Parallel()
+
+	// Verify the JSON has [] / {} not null when nothing is declared.
+	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
+	rec := httptest.NewRecorder()
+	ManifestHandler("media", "Media", "perm_media", nil, registry.New()).ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	for _, want := range []string{`"emits":[]`, `"subscribes":{}`, `"schedules":[]`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("manifest body missing %q\nbody: %s", want, body)
+		}
+	}
+}
+
+func TestManifest_MigrationVersion(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"sql/0000_initial.up.sql":   &fstest.MapFile{Data: []byte("")},
+		"sql/0008_add_index.up.sql": &fstest.MapFile{Data: []byte("")},
+	}
+
+	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", fsys, registry.New()))
+
+	if got.Migration != "0008" {
+		t.Errorf("migration = %q, want 0008", got.Migration)
+	}
+}
+
+func TestManifest_NilSQL_EmptyMigration(t *testing.T) {
+	t.Parallel()
+
+	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, registry.New()))
+	if got.Migration != "" {
+		t.Errorf("migration = %q, want empty when SQL fs is nil", got.Migration)
+	}
+}


### PR DESCRIPTION
Closes #6.

## Summary

Implements the manifest endpoint that exposes module identity, routes, events, schedules, and migration version. The platform calls this on deploy to discover module capabilities.

## What's new

### \`internal/registry\` package
Per-Module collection of routes/events/schedules. Replaces stringly-typed scope keys with a typed \`Scope\` (\`ScopePlatform\`/\`ScopePublic\`/\`ScopeInternal\`). Empty-collection normalization lives in the Registry getters, so the manifest payload shape is stable regardless of what was registered. All four \`Add*\` methods are first-wins on duplicates for consistency.

### \`internal/migration\` package
\`LatestVersion(fs.FS)\` reads the module's \`sql/\` directory for the highest \`.up.sql\` file. Versions are compared **numerically** (so \`9 < 10\`), but the returned string preserves the filename's zero-padding (\`\"0008\"\`, not \`\"8\"\`).

### \`system/manifest.go\`
\`ManifestHandler\` returns the JSON payload. Migration version is read from \`Config.SQL\` at request time so a hot-reloaded build picks up new migrations without a restart.

### Module wiring
\`Config\` gains an \`SQL fs.FS\` field. Module developers pass an \`embed.FS\`:

\`\`\`go
//go:embed sql/*
var sqlFS embed.FS

ms.Init(ms.Config{ID: \"media\", SQL: sqlFS})
\`\`\`

\`Module.Platform\` / \`Public\` / \`Internal\` now build a sub-router, run \`fn()\`, then \`chi.Walk\` to record routes in the registry **AND** re-register each route on the main router with its accumulated middleware chain. Routing behavior is identical to the previous \`.Group()\` approach (verified by all existing tests plus a new regression).

The \`/__mirrorstack/platform/manifest\` route is mounted under the existing \`InternalAuth()\` group — only the platform should call it.

## Response shape

\`\`\`json
{
  \"id\": \"media\",
  \"defaults\": { \"name\": \"Media\", \"icon\": \"perm_media\" },
  \"migration\": \"0008\",
  \"routes\": {
    \"platform\": [{ \"method\": \"GET\", \"path\": \"/items\" }],
    \"public\": [{ \"method\": \"GET\", \"path\": \"/feed\" }],
    \"internal\": [{ \"method\": \"POST\", \"path\": \"/events/on-user-deleted\" }]
  },
  \"events\": { \"emits\": [], \"subscribes\": {} },
  \"schedules\": []
}
\`\`\`

Events and schedules are intentionally empty stubs in v1 — issue #9 (\`OnEvent\`/\`Emit\`/\`Cron\`) will populate them. The fields exist now so the platform can rely on the payload shape.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` passes — all 11 packages green
- [x] **\`internal/registry\`**: 13 tests — scope grouping, dedup, copy-on-read, empty-registry-returns-non-nil for all 4 collections, first-wins consistency for AddRoute/AddEmit/AddSubscribe/AddSchedule
- [x] **\`internal/migration\`**: 8 tests — nil FS, missing dir, picks highest, **mixed-width numeric sort regression** (\`9 < 10\`), ignores \`.down\`/non-migration files, empty dir, zero-padding preservation
- [x] **\`system/manifest\`**: 7 tests — identity, routes from all scopes, empty scopes present, events/schedules, empty-events JSON shape (\`[]\`/\`{}\` not \`null\`), migration from FS, nil FS
- [x] **\`mirrorstack\`** (E2E through real router): 4 tests — 200 with secret, routes from all scopes via \`Module.Platform/Public/Internal\`, migration from \`Config.SQL\`, **chi.Walk re-registration regression** (routes still reachable AND still enforce auth)

## Breaking changes

None to module developers. Internal: \`Module.scopedRoutes\` is a new private helper; the public \`Platform\`/\`Public\`/\`Internal\` signatures are unchanged.

## Follow-up

#28 tracks consolidating \`auth.permissions\` (currently a package-global registry) into the per-Module \`internal/registry\` — deferred from this PR to avoid scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)