### PR TITLE
refactor(auth): fail-fast on missing MS_INTERNAL_SECRET (#36)

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -33,7 +33,20 @@ func PublicAuth() func(http.Handler) http.Handler {
 
 // InternalAuth returns middleware that validates the internal secret.
 // Reads MS_INTERNAL_SECRET env var at construction time.
+//
+// When MS_INTERNAL_SECRET is unset, requests get 503 in Lambda mode (so
+// platform alerting can split operator misconfig from wrong-secret events)
+// and 401 otherwise (dev intentionally runs without a secret). Module.Start()
+// also fail-fasts on the missing-secret case in Lambda mode, but a caller
+// can still bypass Start() via Module.Router().ServeHTTP — this branch is
+// the runtime safety net for that case.
 func InternalAuth() func(http.Handler) http.Handler {
+	return internalAuth(isLambdaEnv())
+}
+
+// internalAuth is the test seam; inLambda is injected so tests don't mutate
+// process env captured at package init.
+func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 	expected := os.Getenv("MS_INTERNAL_SECRET")
 	if expected == "" {
 		// SECURITY: never echo the `expected` value (or any prefix/suffix of it)
@@ -44,8 +57,24 @@ func InternalAuth() func(http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if expected == "" {
+				if inLambda {
+					// SECURITY: generic body. The detailed reason is in the
+					// construction-time log line above; the 503 status itself
+					// is the platform's alerting signal. We don't want to
+					// confirm "this endpoint exists and the module is broken"
+					// to anonymous callers reaching us pre-WAF.
+					httputil.JSON(w, http.StatusServiceUnavailable, httputil.ErrorResponse{
+						Error: "service unavailable",
+					})
+					return
+				}
+				httputil.JSON(w, http.StatusUnauthorized, httputil.ErrorResponse{Error: "internal authentication required"})
+				return
+			}
+
 			secret := r.Header.Get("X-MS-Internal-Secret")
-			if expected == "" || !constantTimeEqual(secret, expected) {
+			if !constantTimeEqual(secret, expected) {
 				httputil.JSON(w, http.StatusUnauthorized, httputil.ErrorResponse{Error: "internal authentication required"})
 				return
 			}
@@ -56,4 +85,10 @@ func InternalAuth() func(http.Handler) http.Handler {
 
 func constantTimeEqual(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// isLambdaEnv duplicates internal/runtime.IsLambda to avoid an import cycle
+// (runtime imports auth).
+func isLambdaEnv() bool {
+	return os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != ""
 }

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -109,9 +110,11 @@ func TestInternalAuth_ValidSecret(t *testing.T) {
 	}
 }
 
-func TestInternalAuth_NoEnvVar(t *testing.T) {
+func TestInternalAuth_NoSecret_NotLambda(t *testing.T) {
+	// Dev / HTTP server: secret intentionally absent → preserve the historical
+	// 401 so local tooling probing endpoints sees an auth-failure shape.
 	t.Setenv("MS_INTERNAL_SECRET", "")
-	handler := InternalAuth()(http.HandlerFunc(okHandler))
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
 
 	req := httptest.NewRequest("POST", "/event", nil)
 	req.Header.Set("X-MS-Internal-Secret", "anything")
@@ -119,6 +122,62 @@ func TestInternalAuth_NoEnvVar(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusUnauthorized {
-		t.Errorf("expected 401 when env not set, got %d", rec.Code)
+		t.Errorf("expected 401 not-lambda + no secret, got %d", rec.Code)
+	}
+}
+
+func TestInternalAuth_NoSecret_InLambda(t *testing.T) {
+	// Lambda + no secret = operator misconfiguration. Return 503 so the
+	// platform's alerting can distinguish it from wrong-secret events (401).
+	// Module.Start() also fail-fasts on this state, so this branch is the
+	// runtime safety net for any path that bypasses Start.
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	handler := internalAuth(true)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/event", nil)
+	req.Header.Set("X-MS-Internal-Secret", "anything")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 in-lambda + no secret, got %d", rec.Code)
+	}
+	// SECURITY: body MUST be generic. Confirming "misconfigured" or
+	// "internal secret" to anonymous callers is recon. The 503 status itself
+	// is the platform's signal; the detailed reason is in the server log.
+	body := rec.Body.String()
+	if strings.Contains(body, "misconfigured") || strings.Contains(body, "internal secret") {
+		t.Errorf("503 body leaks operator state: %q", body)
+	}
+}
+
+func TestInternalAuth_WrongSecret_InLambda_Still401(t *testing.T) {
+	// Only the no-secret-configured state escalates to 503 in Lambda. Wrong
+	// secret stays 401 so platform alerts can distinguish attacker /
+	// misrouted traffic from operator misconfiguration.
+	t.Setenv("MS_INTERNAL_SECRET", "test-secret-123")
+	handler := internalAuth(true)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/event", nil)
+	req.Header.Set("X-MS-Internal-Secret", "wrong-secret")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 wrong-secret in-lambda, got %d", rec.Code)
+	}
+}
+
+func TestIsLambdaEnv(t *testing.T) {
+	// Regression guard: this duplicates internal/runtime.IsLambda because of
+	// an import cycle (see middleware.go). If AWS_LAMBDA_FUNCTION_NAME ever
+	// stops being the right signal, both call sites need updating.
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "")
+	if isLambdaEnv() {
+		t.Error("expected isLambdaEnv() = false when AWS_LAMBDA_FUNCTION_NAME unset")
+	}
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "test-fn")
+	if !isLambdaEnv() {
+		t.Error("expected isLambdaEnv() = true when AWS_LAMBDA_FUNCTION_NAME set")
 	}
 }

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -277,6 +277,12 @@ func RequirePermission(name string, roles ...string) func(http.Handler) http.Han
 // Start auto-detects Lambda vs HTTP and starts serving.
 func (m *Module) Start() error {
 	if runtime.IsLambda() {
+		// Fail-fast in Lambda: a missing secret turns every platform call
+		// into a 503; surface it as an init failure instead. Dev/HTTP
+		// intentionally permits no-secret.
+		if err := requireInternalSecret(); err != nil {
+			return err
+		}
 		handler := runtime.NewLambdaHandler(m.router)
 		lambda.Start(handler)
 		return nil
@@ -290,6 +296,15 @@ func (m *Module) Start() error {
 	m.logger.Printf("%s module (%s) listening on %s", m.config.Name, m.config.ID, addr)
 	if err := http.ListenAndServe(addr, m.router); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
+	}
+	return nil
+}
+
+// requireInternalSecret errors if MS_INTERNAL_SECRET is unset — used by
+// Module.Start() in Lambda mode to fail init before lambda.Start handoff.
+func requireInternalSecret() error {
+	if os.Getenv("MS_INTERNAL_SECRET") == "" {
+		return errors.New("mirrorstack: MS_INTERNAL_SECRET not set — required for platform routes in Lambda mode")
 	}
 	return nil
 }

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -424,6 +424,25 @@ func TestStart_BeforeInit(t *testing.T) {
 	_ = Start()
 }
 
+func TestRequireInternalSecret(t *testing.T) {
+	// Pulled out as its own helper because Module.Start() in Lambda mode
+	// calls lambda.Start() which we cannot drive from a unit test. The
+	// helper is the only piece of fail-fast logic we own; once it returns
+	// nil, Start() hands off to the AWS Lambda runtime.
+	t.Run("missing", func(t *testing.T) {
+		t.Setenv("MS_INTERNAL_SECRET", "")
+		if err := requireInternalSecret(); err == nil {
+			t.Error("expected error when MS_INTERNAL_SECRET is unset")
+		}
+	})
+	t.Run("present", func(t *testing.T) {
+		t.Setenv("MS_INTERNAL_SECRET", "any-non-empty-value")
+		if err := requireInternalSecret(); err != nil {
+			t.Errorf("expected nil error when secret set, got %v", err)
+		}
+	})
+}
+
 func TestScopesPanic_BeforeInit(t *testing.T) {
 	fns := map[string]func(){
 		"Platform": func() { Platform(func(r chi.Router) {}) },


### PR DESCRIPTION
## Summary

A misconfigured Lambda used to silently 401 every platform call. The deploy looked healthy until someone hit `/__mirrorstack/platform/*`. Two defenses now make the misconfiguration loud.

### A. `Module.Start()` fail-fast

`Module.Start()` in Lambda mode now calls `requireInternalSecret()` and returns an error before `lambda.Start` handoff. A boot without the secret surfaces as a Lambda init failure (which the platform alerts on) instead of silent runtime errors.

### B. `auth.InternalAuth()` returns 503 in Lambda + no-secret

`auth.InternalAuth()` returns **503** instead of **401** when the secret is unset AND the process is running in Lambda. The platform's alerting can now distinguish "module is broken" (503) from "wrong-secret traffic" (401). Dev/HTTP mode preserves the legacy 401 since local tooling intentionally runs without a secret.

The 503 body is intentionally generic (`"service unavailable"`) to avoid confirming endpoint existence + broken state to anonymous callers reaching the middleware pre-WAF. The detailed reason stays in the construction-time log line.

## Implementation notes

- `internalAuth(inLambda bool)` is the package-private test seam; `InternalAuth()` is the public wrapper that calls `isLambdaEnv()` to derive the flag.
- `isLambdaEnv()` reads `AWS_LAMBDA_FUNCTION_NAME` directly because `internal/runtime/lambda.go` imports `auth` — the reverse import would create a cycle.
- `requireInternalSecret()` is a top-level helper so it's unit-testable without spawning a real Lambda runtime (`Module.Start` hands off to `lambda.Start`, which we can't drive from tests).

## Out-of-scope follow-ups

1. **`AWS_LAMBDA_FUNCTION_NAME` literal duplication** — the `auth.isLambdaEnv()` check is now the **5th** site that reads this env var directly (`internal/runtime/detect.go`, `auth/middleware.go`, `db/db.go`, `storage/storage.go`, `cache/cache.go`). A tiny `internal/lambdaenv` leaf package could consolidate them all without breaking the cycle. Worth a separate cleanup issue — leaving it here would expand scope.

2. **Construction-time env capture** — `internalAuth` captures both `expected` and `inLambda` at `New()` time. This is pre-existing behavior (the original `InternalAuth` already captured `expected`); the convention is `t.Setenv("MS_INTERNAL_SECRET", ...)` BEFORE `New()` in tests. Switching to per-request reads is a behavior change that deserves its own discussion.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race ./...` all packages green
- [x] New tests:
  - `TestInternalAuth_NoSecret_NotLambda` — dev mode preserves 401
  - `TestInternalAuth_NoSecret_InLambda` — Lambda mode returns 503 + body is generic (does NOT leak "misconfigured" / "internal secret")
  - `TestInternalAuth_WrongSecret_InLambda_Still401` — wrong-secret stays 401 in Lambda
  - `TestIsLambdaEnv` — env-var derivation regression guard
  - `TestRequireInternalSecret` — pass / fail of the Start() pre-check helper

## Reviews applied

`/simplify` ran 3 review agents (reuse / quality / security+efficiency). Key findings addressed:

- **MED — info disclosure (security)**: 503 body now generic.
- **Doc overclaim**: softened "InternalAuth should never see this state in production" to acknowledge the `Module.Router().ServeHTTP` bypass case.
- **Comment trimming**: 4 over-long doc comments compressed to WHY-only.
- **Test naming**: `_Dev`/`_Lambda` → `_NotLambda`/`_InLambda` to name the actual condition under test.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)