### PR TITLE
feat(events): ms.OnEvent / ms.Emit / ms.Cron (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ Keys auto-prefixed: developer writes `"views:123"`, Redis stores `"app_abc123:mo
 
 ### Events & scheduling
 
-- [ ] `ms.OnEvent()` — subscribe to events from other modules
-- [ ] `ms.Emit()` — declare emitted events
-- [ ] `ms.Cron()` — register scheduled jobs
+- [x] `ms.OnEvent()` — subscribe to events from other modules
+- [x] `ms.Emit()` — declare emitted events
+- [x] `ms.Cron()` — register scheduled jobs
 
 ### System routes (`/__mirrorstack/`)
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Keys auto-prefixed: developer writes `"views:123"`, Redis stores `"app_abc123:mo
 ### Events & scheduling
 
 - [x] `ms.OnEvent()` — subscribe to events from other modules
-- [x] `ms.Emit()` — declare emitted events
+- [x] `ms.Emits()` — declare emitted events
 - [x] `ms.Cron()` — register scheduled jobs
 
 ### System routes (`/__mirrorstack/`)

--- a/cron.go
+++ b/cron.go
@@ -6,7 +6,9 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-const cronPathPrefix = "/crons/"
+// cronPathPrefix mounts under /__mirrorstack/ to reserve a platform-owned
+// namespace. See eventPathPrefix in event.go for the rationale.
+const cronPathPrefix = "/__mirrorstack/crons/"
 
 // Cron registers a handler to run on a cron schedule. The handler is mounted
 // on this module's Internal scope at /crons/{name}. The schedule is recorded

--- a/cron.go
+++ b/cron.go
@@ -6,14 +6,14 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// cronPathPrefix mounts under /__mirrorstack/ to reserve a platform-owned
-// namespace. See eventPathPrefix in event.go for the rationale.
+// cronPathPrefix mounts under the reserved /__mirrorstack/ namespace.
+// See eventPathPrefix in event.go for the collision-prevention rationale.
 const cronPathPrefix = "/__mirrorstack/crons/"
 
 // Cron registers a handler to run on a cron schedule. The handler is mounted
-// on this module's Internal scope at /crons/{name}. The schedule is recorded
-// in the manifest so the platform's scheduler knows what URL to POST when
-// the cron fires.
+// on this module's Internal scope at /__mirrorstack/crons/{name}. The
+// schedule is recorded in the manifest so the platform's scheduler knows
+// what URL to POST when the cron fires.
 //
 // The schedule string is passed through to the platform unchanged —
 // validation happens platform-side so module developers see one error format

--- a/cron.go
+++ b/cron.go
@@ -1,0 +1,43 @@
+package mirrorstack
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const cronPathPrefix = "/crons/"
+
+// Cron registers a handler to run on a cron schedule. The handler is mounted
+// on this module's Internal scope at /crons/{name}. The schedule is recorded
+// in the manifest so the platform's scheduler knows what URL to POST to when
+// the cron fires.
+//
+// The cron string is passed through to the platform unchanged — validation
+// happens platform-side so module developers see one error format regardless
+// of the scheduler implementation.
+//
+// Call from startup code. Panics on empty schedule, an invalid name (see
+// validateRegistrationName), or duplicate name registration.
+//
+//	mod.Cron("cleanup-temp", "0 3 * * *", cleanupHandler)
+func (m *Module) Cron(name, cron string, handler http.HandlerFunc) {
+	validateRegistrationName("Cron", name)
+	if cron == "" {
+		panic("mirrorstack: Cron(" + name + ") schedule cannot be empty")
+	}
+	if m.registry.HasSchedule(name) {
+		panic("mirrorstack: Cron(" + name + ") registered twice")
+	}
+	path := cronPathPrefix + name
+	m.Internal(func(r chi.Router) {
+		r.Post(path, handler)
+	})
+	m.registry.AddSchedule(name, cron, path)
+}
+
+// Cron registers a cron job on the default Module created by Init(). Panics
+// before Init — matches Platform/Public/Internal.
+func Cron(name, cron string, handler http.HandlerFunc) {
+	mustDefault("Cron").Cron(name, cron, handler)
+}

--- a/cron.go
+++ b/cron.go
@@ -10,34 +10,36 @@ const cronPathPrefix = "/crons/"
 
 // Cron registers a handler to run on a cron schedule. The handler is mounted
 // on this module's Internal scope at /crons/{name}. The schedule is recorded
-// in the manifest so the platform's scheduler knows what URL to POST to when
+// in the manifest so the platform's scheduler knows what URL to POST when
 // the cron fires.
 //
-// The cron string is passed through to the platform unchanged — validation
-// happens platform-side so module developers see one error format regardless
-// of the scheduler implementation.
+// The schedule string is passed through to the platform unchanged —
+// validation happens platform-side so module developers see one error format
+// regardless of the scheduler implementation.
 //
-// Call from startup code. Panics on empty schedule, an invalid name (see
-// validateRegistrationName), or duplicate name registration.
+// Names must not contain path separators (/, \), whitespace, dot-segments
+// (..), or null bytes. Do not rely on r.RemoteAddr to identify the
+// scheduler; in Lambda + API Gateway it is always the AGW IP. Call from
+// startup code, not a request handler.
+//
+// Panics on empty schedule, an invalid name, or duplicate name registration.
 //
 //	mod.Cron("cleanup-temp", "0 3 * * *", cleanupHandler)
-func (m *Module) Cron(name, cron string, handler http.HandlerFunc) {
-	validateRegistrationName("Cron", name)
-	if cron == "" {
+func (m *Module) Cron(name, schedule string, handler http.HandlerFunc) {
+	if schedule == "" {
 		panic("mirrorstack: Cron(" + name + ") schedule cannot be empty")
 	}
-	if m.registry.HasSchedule(name) {
+	path := cronPathPrefix + name
+	if !m.registry.AddSchedule(name, schedule, path) {
 		panic("mirrorstack: Cron(" + name + ") registered twice")
 	}
-	path := cronPathPrefix + name
 	m.Internal(func(r chi.Router) {
 		r.Post(path, handler)
 	})
-	m.registry.AddSchedule(name, cron, path)
 }
 
 // Cron registers a cron job on the default Module created by Init(). Panics
 // before Init — matches Platform/Public/Internal.
-func Cron(name, cron string, handler http.HandlerFunc) {
-	mustDefault("Cron").Cron(name, cron, handler)
+func Cron(name, schedule string, handler http.HandlerFunc) {
+	mustDefault("Cron").Cron(name, schedule, handler)
 }

--- a/cron_test.go
+++ b/cron_test.go
@@ -17,7 +17,7 @@ func TestCron_HandlerReachableViaInternalScope(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	rec := doRequestWithSecret(t, m.Router(), "POST", "/crons/cleanup-temp", "secret")
+	rec := doRequestWithSecret(t, m.Router(), "POST", "/__mirrorstack/crons/cleanup-temp", "secret")
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -28,14 +28,14 @@ func TestCron_HandlerReachableViaInternalScope(t *testing.T) {
 
 func TestCron_RequiresInternalSecret(t *testing.T) {
 	// Defense-in-depth: cron handlers are platform-only. If a future
-	// refactor moves /crons/* to a public scope, this test fails.
+	// refactor moves /__mirrorstack/crons/* to a public scope, this test fails.
 	m := newTestModuleWithSecret(t, "media")
 
 	m.Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not run without internal secret")
 	})
 
-	rec := doRequest(t, m.Router(), "POST", "/crons/cleanup")
+	rec := doRequest(t, m.Router(), "POST", "/__mirrorstack/crons/cleanup")
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 (no secret)", rec.Code)
 	}
@@ -59,11 +59,11 @@ func TestCron_AppearsInManifestSchedules(t *testing.T) {
 	for _, s := range got.Schedules {
 		switch s.Name {
 		case "cleanup-temp":
-			if s.Cron != "0 3 * * *" || s.Path != "/crons/cleanup-temp" {
+			if s.Cron != "0 3 * * *" || s.Path != "/__mirrorstack/crons/cleanup-temp" {
 				t.Errorf("cleanup-temp = %+v", s)
 			}
 		case "daily-report":
-			if s.Cron != "0 9 * * *" || s.Path != "/crons/daily-report" {
+			if s.Cron != "0 9 * * *" || s.Path != "/__mirrorstack/crons/daily-report" {
 				t.Errorf("daily-report = %+v", s)
 			}
 		default:
@@ -104,7 +104,7 @@ func TestCron_TopLevelPanicsBeforeInit(t *testing.T) {
 func TestCron_PanicsOnInvalidName(t *testing.T) {
 	// SECURITY regression guard: a name like "../admin" would let chi normalize
 	// the registered pattern to "/admin", letting the handler escape the
-	// /crons/ namespace AND making the manifest disagree with the actual
+	// /__mirrorstack/crons/ namespace AND making the manifest disagree with the actual
 	// route. The empty case is covered separately by registry validation
 	// (also TestCron_PanicsOnEmptyName above for the schedule string).
 	cases := []struct {

--- a/cron_test.go
+++ b/cron_test.go
@@ -1,0 +1,152 @@
+package mirrorstack
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/system"
+)
+
+func TestCron_HandlerReachableViaInternalScope(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media"})
+
+	called := false
+	m.Cron("cleanup-temp", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := doRequestWithSecret(t, m.Router(), "POST", "/crons/cleanup-temp", "secret")
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if !called {
+		t.Error("Cron handler was not invoked")
+	}
+}
+
+func TestCron_RequiresInternalSecret(t *testing.T) {
+	// Defense-in-depth: cron handlers are platform-only. If a future
+	// refactor moves /crons/* to a public scope, this test fails.
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media"})
+
+	m.Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not run without internal secret")
+	})
+
+	rec := doRequest(t, m.Router(), "POST", "/crons/cleanup")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (no secret)", rec.Code)
+	}
+}
+
+func TestCron_AppearsInManifestSchedules(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media"})
+
+	m.Cron("cleanup-temp", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+	m.Cron("daily-report", "0 9 * * *", func(w http.ResponseWriter, r *http.Request) {})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+
+	if len(got.Schedules) != 2 {
+		t.Fatalf("schedules = %d, want 2", len(got.Schedules))
+	}
+	for _, s := range got.Schedules {
+		switch s.Name {
+		case "cleanup-temp":
+			if s.Cron != "0 3 * * *" || s.Path != "/crons/cleanup-temp" {
+				t.Errorf("cleanup-temp = %+v", s)
+			}
+		case "daily-report":
+			if s.Cron != "0 9 * * *" || s.Path != "/crons/daily-report" {
+				t.Errorf("daily-report = %+v", s)
+			}
+		default:
+			t.Errorf("unexpected schedule %q", s.Name)
+		}
+	}
+}
+
+func TestCron_PanicsOnDuplicate(t *testing.T) {
+	m, _ := New(Config{ID: "media"})
+	m.Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on duplicate Cron name")
+		}
+	}()
+	m.Cron("cleanup", "0 5 * * *", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestCron_PanicsOnEmptyName(t *testing.T) {
+	m, _ := New(Config{ID: "media"})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on empty Cron name")
+		}
+	}()
+	m.Cron("", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestCron_PanicsOnEmptySchedule(t *testing.T) {
+	m, _ := New(Config{ID: "media"})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on empty Cron schedule string")
+		}
+	}()
+	m.Cron("cleanup", "", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestCron_TopLevelPanicsBeforeInit(t *testing.T) {
+	resetDefault(t)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for top-level Cron before Init")
+		}
+	}()
+	Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+// Note: registry isolation across modules is already tested by
+// TestModulesIsolated_OnEvent in event_test.go and
+// TestRequirePermission_AppearsInManifest in mirrorstack_test.go (#28).
+// Schedules use the same per-Module Registry as Subscribes, so a separate
+// cron isolation test would be redundant.
+
+func TestCron_PanicsOnPathInjection(t *testing.T) {
+	// SECURITY regression guard: a name like "../admin" used to chi-normalize
+	// the registered pattern to "/admin", letting the handler escape the
+	// /crons/ namespace AND making the manifest disagree with the actual
+	// route. validateRegistrationName now blocks this at the API boundary.
+	cases := []struct {
+		name string
+		bad  string
+	}{
+		{"dot-segment", "../admin"},
+		{"slash", "foo/bar"},
+		{"backslash", "foo\\bar"},
+		{"space", "foo bar"},
+		{"tab", "foo\tbar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := New(Config{ID: "media"})
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for cron name %q", tc.bad)
+				}
+			}()
+			m.Cron(tc.bad, "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+		})
+	}
+}

--- a/cron_test.go
+++ b/cron_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestCron_HandlerReachableViaInternalScope(t *testing.T) {
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "media"})
+	m := newTestModuleWithSecret(t, "media")
 
 	called := false
 	m.Cron("cleanup-temp", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {
@@ -30,8 +29,7 @@ func TestCron_HandlerReachableViaInternalScope(t *testing.T) {
 func TestCron_RequiresInternalSecret(t *testing.T) {
 	// Defense-in-depth: cron handlers are platform-only. If a future
 	// refactor moves /crons/* to a public scope, this test fails.
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "media"})
+	m := newTestModuleWithSecret(t, "media")
 
 	m.Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not run without internal secret")
@@ -44,8 +42,7 @@ func TestCron_RequiresInternalSecret(t *testing.T) {
 }
 
 func TestCron_AppearsInManifestSchedules(t *testing.T) {
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "media"})
+	m := newTestModuleWithSecret(t, "media")
 
 	m.Cron("cleanup-temp", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
 	m.Cron("daily-report", "0 9 * * *", func(w http.ResponseWriter, r *http.Request) {})
@@ -79,74 +76,57 @@ func TestCron_PanicsOnDuplicate(t *testing.T) {
 	m, _ := New(Config{ID: "media"})
 	m.Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic on duplicate Cron name")
-		}
-	}()
-	m.Cron("cleanup", "0 5 * * *", func(w http.ResponseWriter, r *http.Request) {})
-}
-
-func TestCron_PanicsOnEmptyName(t *testing.T) {
-	m, _ := New(Config{ID: "media"})
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic on empty Cron name")
-		}
-	}()
-	m.Cron("", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+	assertPanics(t, "expected panic on duplicate Cron name", func() {
+		m.Cron("cleanup", "0 5 * * *", func(w http.ResponseWriter, r *http.Request) {})
+	})
 }
 
 func TestCron_PanicsOnEmptySchedule(t *testing.T) {
 	m, _ := New(Config{ID: "media"})
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic on empty Cron schedule string")
-		}
-	}()
-	m.Cron("cleanup", "", func(w http.ResponseWriter, r *http.Request) {})
+	assertPanics(t, "expected panic on empty Cron schedule string", func() {
+		m.Cron("cleanup", "", func(w http.ResponseWriter, r *http.Request) {})
+	})
 }
 
 func TestCron_TopLevelPanicsBeforeInit(t *testing.T) {
 	resetDefault(t)
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for top-level Cron before Init")
-		}
-	}()
-	Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+	assertPanics(t, "expected panic for top-level Cron before Init", func() {
+		Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+	})
 }
 
-// Note: registry isolation across modules is already tested by
+// Note: per-Module registry isolation is already verified by
 // TestModulesIsolated_OnEvent in event_test.go and
 // TestRequirePermission_AppearsInManifest in mirrorstack_test.go (#28).
-// Schedules use the same per-Module Registry as Subscribes, so a separate
-// cron isolation test would be redundant.
+// Schedules use the same per-Module Registry, so a separate cron isolation
+// test would be redundant.
 
-func TestCron_PanicsOnPathInjection(t *testing.T) {
-	// SECURITY regression guard: a name like "../admin" used to chi-normalize
+func TestCron_PanicsOnInvalidName(t *testing.T) {
+	// SECURITY regression guard: a name like "../admin" would let chi normalize
 	// the registered pattern to "/admin", letting the handler escape the
 	// /crons/ namespace AND making the manifest disagree with the actual
-	// route. validateRegistrationName now blocks this at the API boundary.
+	// route. The empty case is covered separately by registry validation
+	// (also TestCron_PanicsOnEmptyName above for the schedule string).
 	cases := []struct {
 		name string
 		bad  string
 	}{
+		{"empty", ""},
 		{"dot-segment", "../admin"},
 		{"slash", "foo/bar"},
 		{"backslash", "foo\\bar"},
 		{"space", "foo bar"},
 		{"tab", "foo\tbar"},
+		{"newline", "foo\nbar"},
+		{"carriage-return", "foo\rbar"},
+		{"null-byte", "foo\x00bar"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m, _ := New(Config{ID: "media"})
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("expected panic for cron name %q", tc.bad)
-				}
-			}()
-			m.Cron(tc.bad, "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+			assertPanics(t, "expected panic for cron name "+tc.bad, func() {
+				m.Cron(tc.bad, "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {})
+			})
 		})
 	}
 }

--- a/event.go
+++ b/event.go
@@ -6,17 +6,16 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// eventPathPrefix mounts under /__mirrorstack/ to reserve a platform-owned
-// namespace. Mounting at the bare module root would let a developer-defined
-// route like m.Public(func(r){ r.Get("/events/list", h) }) collide with
-// OnEvent("list"), with chi's duplicate-pattern panic depending on
-// registration order. The /__mirrorstack/ prefix is the same convention
-// /__mirrorstack/health, /__mirrorstack/platform/* already use.
+// eventPathPrefix mounts under the reserved /__mirrorstack/ namespace so
+// developer-defined routes (registered via m.Public/Platform/Internal) cannot
+// collide with auto-generated event handlers. Same convention as
+// /__mirrorstack/health and /__mirrorstack/platform/*.
 const eventPathPrefix = "/__mirrorstack/events/"
 
 // OnEvent registers handler for events of the given name from another module.
-// Mounts the handler on this module's Internal scope at /events/{name} and
-// records the subscription in the manifest's events.subscribes map.
+// Mounts the handler on this module's Internal scope at
+// /__mirrorstack/events/{name} and records the subscription in the manifest's
+// events.subscribes map.
 //
 // The platform guarantees AT-LEAST-ONCE delivery — handlers must be
 // idempotent or implement their own deduplication. Do not rely on

--- a/event.go
+++ b/event.go
@@ -2,7 +2,6 @@ package mirrorstack
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -13,36 +12,38 @@ const eventPathPrefix = "/events/"
 // Mounts the handler on this module's Internal scope at /events/{name} and
 // records the subscription in the manifest's events.subscribes map.
 //
-// Event names follow the "module.action" convention (e.g., "oauth.user_deleted").
-// Names are validated — see validateRegistrationName for the rules.
+// The platform guarantees AT-LEAST-ONCE delivery — handlers must be
+// idempotent or implement their own deduplication. Do not rely on
+// r.RemoteAddr to identify the sender; in Lambda + API Gateway it is
+// always the AGW IP, not the original event source.
 //
-// Call from startup code (init / main), NOT from inside a request handler.
-// The registry is append-only and the auth middleware closure is captured at
-// registration time.
+// Names must not contain path separators (/, \), whitespace, dot-segments
+// (..), or null bytes. Call from startup code (init / main), not from
+// inside a request handler.
+//
+// Panics on duplicate registration with the same name.
 func (m *Module) OnEvent(name string, handler http.HandlerFunc) {
-	validateRegistrationName("OnEvent", name)
-	if m.registry.HasSubscribe(name) {
+	path := eventPathPrefix + name
+	if !m.registry.AddSubscribe(name, path) {
 		panic("mirrorstack: OnEvent(" + name + ") registered twice")
 	}
-	path := eventPathPrefix + name
 	m.Internal(func(r chi.Router) {
 		r.Post(path, handler)
 	})
-	m.registry.AddSubscribe(name, path)
 }
 
-// Emit declares that this module emits an event of the given name. The
+// Emits declares that this module emits an event of the given name. The
 // declaration appears in the manifest's events.emits list so the platform
-// knows the event belongs to this module's vocabulary and other modules can
-// subscribe to it. Runtime emission is a separate API (TBD).
+// knows the event belongs to this module's vocabulary and other modules
+// can subscribe to it. Runtime emission is a separate API (TBD); this
+// method is purely a declaration.
 //
-// Call from startup code. Panics on empty name or duplicate declaration.
-func (m *Module) Emit(name string) {
-	validateRegistrationName("Emit", name)
-	if m.registry.HasEmit(name) {
-		panic("mirrorstack: Emit(" + name + ") registered twice")
+// Panics on an invalid name (see OnEvent for the rules) or duplicate
+// declaration. Call from startup code.
+func (m *Module) Emits(name string) {
+	if !m.registry.AddEmit(name) {
+		panic("mirrorstack: Emits(" + name + ") registered twice")
 	}
-	m.registry.AddEmit(name)
 }
 
 // OnEvent registers an event handler on the default Module created by Init().
@@ -51,35 +52,7 @@ func OnEvent(name string, handler http.HandlerFunc) {
 	mustDefault("OnEvent").OnEvent(name, handler)
 }
 
-// Emit declares an emitted event on the default Module. Panics before Init.
-func Emit(name string) {
-	mustDefault("Emit").Emit(name)
-}
-
-// validateRegistrationName rejects names that are empty or that would
-// produce an unsafe URL path when appended to /events/ or /crons/. Specifically:
-// path separators (/, \), dot-segments (..), and whitespace are blocked.
-//
-// SECURITY: without this check, OnEvent("../admin", h) would let chi
-// normalize the registered pattern to "/admin", silently escaping the
-// /events/ namespace. The manifest payload would still carry the un-cleaned
-// path "/events/../admin" — making the SDK and platform's view of the
-// route disagree, and the platform-fired events would land in the wrong
-// handler. The same applies to Cron and Emit (Emit doesn't mount a route
-// but the name still appears in the manifest payload as a developer-facing
-// identifier).
-//
-// The check is intentionally a deny-list, not a strict allow-list, so that
-// reasonable conventions like "media-uploaded" or "Module.Action" remain
-// valid. If stricter validation becomes necessary, tighten this in one place.
-func validateRegistrationName(kind, name string) {
-	if name == "" {
-		panic("mirrorstack: " + kind + "() name cannot be empty")
-	}
-	if strings.ContainsAny(name, "/\\ \t\n\r") {
-		panic("mirrorstack: " + kind + "(" + name + ") contains a path separator or whitespace")
-	}
-	if strings.Contains(name, "..") {
-		panic("mirrorstack: " + kind + "(" + name + ") contains '..'")
-	}
+// Emits declares an emitted event on the default Module. Panics before Init.
+func Emits(name string) {
+	mustDefault("Emits").Emits(name)
 }

--- a/event.go
+++ b/event.go
@@ -6,7 +6,13 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-const eventPathPrefix = "/events/"
+// eventPathPrefix mounts under /__mirrorstack/ to reserve a platform-owned
+// namespace. Mounting at the bare module root would let a developer-defined
+// route like m.Public(func(r){ r.Get("/events/list", h) }) collide with
+// OnEvent("list"), with chi's duplicate-pattern panic depending on
+// registration order. The /__mirrorstack/ prefix is the same convention
+// /__mirrorstack/health, /__mirrorstack/platform/* already use.
+const eventPathPrefix = "/__mirrorstack/events/"
 
 // OnEvent registers handler for events of the given name from another module.
 // Mounts the handler on this module's Internal scope at /events/{name} and

--- a/event.go
+++ b/event.go
@@ -1,0 +1,85 @@
+package mirrorstack
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const eventPathPrefix = "/events/"
+
+// OnEvent registers handler for events of the given name from another module.
+// Mounts the handler on this module's Internal scope at /events/{name} and
+// records the subscription in the manifest's events.subscribes map.
+//
+// Event names follow the "module.action" convention (e.g., "oauth.user_deleted").
+// Names are validated — see validateRegistrationName for the rules.
+//
+// Call from startup code (init / main), NOT from inside a request handler.
+// The registry is append-only and the auth middleware closure is captured at
+// registration time.
+func (m *Module) OnEvent(name string, handler http.HandlerFunc) {
+	validateRegistrationName("OnEvent", name)
+	if m.registry.HasSubscribe(name) {
+		panic("mirrorstack: OnEvent(" + name + ") registered twice")
+	}
+	path := eventPathPrefix + name
+	m.Internal(func(r chi.Router) {
+		r.Post(path, handler)
+	})
+	m.registry.AddSubscribe(name, path)
+}
+
+// Emit declares that this module emits an event of the given name. The
+// declaration appears in the manifest's events.emits list so the platform
+// knows the event belongs to this module's vocabulary and other modules can
+// subscribe to it. Runtime emission is a separate API (TBD).
+//
+// Call from startup code. Panics on empty name or duplicate declaration.
+func (m *Module) Emit(name string) {
+	validateRegistrationName("Emit", name)
+	if m.registry.HasEmit(name) {
+		panic("mirrorstack: Emit(" + name + ") registered twice")
+	}
+	m.registry.AddEmit(name)
+}
+
+// OnEvent registers an event handler on the default Module created by Init().
+// Panics before Init — matches Platform/Public/Internal.
+func OnEvent(name string, handler http.HandlerFunc) {
+	mustDefault("OnEvent").OnEvent(name, handler)
+}
+
+// Emit declares an emitted event on the default Module. Panics before Init.
+func Emit(name string) {
+	mustDefault("Emit").Emit(name)
+}
+
+// validateRegistrationName rejects names that are empty or that would
+// produce an unsafe URL path when appended to /events/ or /crons/. Specifically:
+// path separators (/, \), dot-segments (..), and whitespace are blocked.
+//
+// SECURITY: without this check, OnEvent("../admin", h) would let chi
+// normalize the registered pattern to "/admin", silently escaping the
+// /events/ namespace. The manifest payload would still carry the un-cleaned
+// path "/events/../admin" — making the SDK and platform's view of the
+// route disagree, and the platform-fired events would land in the wrong
+// handler. The same applies to Cron and Emit (Emit doesn't mount a route
+// but the name still appears in the manifest payload as a developer-facing
+// identifier).
+//
+// The check is intentionally a deny-list, not a strict allow-list, so that
+// reasonable conventions like "media-uploaded" or "Module.Action" remain
+// valid. If stricter validation becomes necessary, tighten this in one place.
+func validateRegistrationName(kind, name string) {
+	if name == "" {
+		panic("mirrorstack: " + kind + "() name cannot be empty")
+	}
+	if strings.ContainsAny(name, "/\\ \t\n\r") {
+		panic("mirrorstack: " + kind + "(" + name + ") contains a path separator or whitespace")
+	}
+	if strings.Contains(name, "..") {
+		panic("mirrorstack: " + kind + "(" + name + ") contains '..'")
+	}
+}

--- a/event_test.go
+++ b/event_test.go
@@ -17,7 +17,7 @@ func TestOnEvent_HandlerReachableViaInternalScope(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	rec := doRequestWithSecret(t, m.Router(), "POST", "/events/oauth.user_deleted", "secret")
+	rec := doRequestWithSecret(t, m.Router(), "POST", "/__mirrorstack/events/oauth.user_deleted", "secret")
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -37,7 +37,7 @@ func TestOnEvent_RequiresInternalSecret(t *testing.T) {
 		t.Error("handler should not run without internal secret")
 	})
 
-	rec := doRequest(t, m.Router(), "POST", "/events/user.created")
+	rec := doRequest(t, m.Router(), "POST", "/__mirrorstack/events/user.created")
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 (no secret)", rec.Code)
 	}
@@ -55,10 +55,10 @@ func TestOnEvent_AppearsInManifestSubscribes(t *testing.T) {
 		t.Fatalf("decode manifest: %v", err)
 	}
 
-	if got.Events.Subscribes["oauth.user_deleted"] != "/events/oauth.user_deleted" {
-		t.Errorf("subscribes[oauth.user_deleted] = %q, want /events/oauth.user_deleted", got.Events.Subscribes["oauth.user_deleted"])
+	if got.Events.Subscribes["oauth.user_deleted"] != "/__mirrorstack/events/oauth.user_deleted" {
+		t.Errorf("subscribes[oauth.user_deleted] = %q, want /__mirrorstack/events/oauth.user_deleted", got.Events.Subscribes["oauth.user_deleted"])
 	}
-	if got.Events.Subscribes["billing.payment_succeeded"] != "/events/billing.payment_succeeded" {
+	if got.Events.Subscribes["billing.payment_succeeded"] != "/__mirrorstack/events/billing.payment_succeeded" {
 		t.Errorf("subscribes[billing.payment_succeeded] = %q", got.Events.Subscribes["billing.payment_succeeded"])
 	}
 }
@@ -122,7 +122,7 @@ func TestEvent_TopLevelPanicsBeforeInit(t *testing.T) {
 func TestOnEvent_PanicsOnInvalidName(t *testing.T) {
 	// SECURITY regression guard: a name like "../admin" would let chi normalize
 	// the registered pattern to "/admin", letting the handler escape the
-	// /events/ namespace AND making the manifest disagree with the actual
+	// /__mirrorstack/events/ namespace AND making the manifest disagree with the actual
 	// route. validateRegistrationName (in internal/registry) blocks this at
 	// the API boundary.
 	cases := []struct {

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,204 @@
+package mirrorstack
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/system"
+)
+
+func TestOnEvent_HandlerReachableViaInternalScope(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media"})
+
+	called := false
+	m.OnEvent("oauth.user_deleted", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := doRequestWithSecret(t, m.Router(), "POST", "/events/oauth.user_deleted", "secret")
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if !called {
+		t.Error("OnEvent handler was not invoked")
+	}
+}
+
+func TestOnEvent_RequiresInternalSecret(t *testing.T) {
+	// Defense-in-depth: events are mounted on the Internal scope, so the
+	// InternalAuth gate must reject unauthenticated callers. If a future
+	// refactor accidentally moves OnEvent to a public-scope mount, this
+	// test fails immediately.
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media"})
+
+	m.OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not run without internal secret")
+	})
+
+	rec := doRequest(t, m.Router(), "POST", "/events/user.created")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (no secret)", rec.Code)
+	}
+}
+
+func TestOnEvent_AppearsInManifestSubscribes(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media"})
+
+	m.OnEvent("oauth.user_deleted", func(w http.ResponseWriter, r *http.Request) {})
+	m.OnEvent("billing.payment_succeeded", func(w http.ResponseWriter, r *http.Request) {})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+
+	if got.Events.Subscribes["oauth.user_deleted"] != "/events/oauth.user_deleted" {
+		t.Errorf("subscribes[oauth.user_deleted] = %q, want /events/oauth.user_deleted", got.Events.Subscribes["oauth.user_deleted"])
+	}
+	if got.Events.Subscribes["billing.payment_succeeded"] != "/events/billing.payment_succeeded" {
+		t.Errorf("subscribes[billing.payment_succeeded] = %q", got.Events.Subscribes["billing.payment_succeeded"])
+	}
+}
+
+func TestOnEvent_PanicsOnDuplicate(t *testing.T) {
+	m, _ := New(Config{ID: "media"})
+	m.OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on duplicate OnEvent")
+		}
+	}()
+	m.OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestEmit_AppearsInManifestEmits(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "media"})
+
+	m.Emit("created")
+	m.Emit("deleted")
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+
+	if len(got.Events.Emits) != 2 {
+		t.Fatalf("emits = %v, want 2", got.Events.Emits)
+	}
+	want := map[string]bool{"created": true, "deleted": true}
+	for _, e := range got.Events.Emits {
+		if !want[e] {
+			t.Errorf("unexpected emit %q", e)
+		}
+	}
+}
+
+func TestEmit_PanicsOnDuplicate(t *testing.T) {
+	m, _ := New(Config{ID: "media"})
+	m.Emit("created")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on duplicate Emit")
+		}
+	}()
+	m.Emit("created")
+}
+
+func TestEvent_TopLevelPanicsBeforeInit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func()
+	}{
+		{"OnEvent", func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) }},
+		{"Emit", func() { Emit("created") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetDefault(t)
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for top-level %s before Init", tc.name)
+				}
+			}()
+			tc.fn()
+		})
+	}
+}
+
+func TestOnEvent_PanicsOnPathInjection(t *testing.T) {
+	// SECURITY regression guard: a name like "../admin" used to chi-normalize
+	// the registered pattern to "/admin", letting the handler escape the
+	// /events/ namespace AND making the manifest disagree with the actual
+	// route. validateRegistrationName now blocks this at the API boundary.
+	cases := []struct {
+		name string
+		bad  string
+	}{
+		{"empty", ""},
+		{"dot-segment", "../admin"},
+		{"slash", "foo/bar"},
+		{"backslash", "foo\\bar"},
+		{"space", "foo bar"},
+		{"newline", "foo\nbar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := New(Config{ID: "media"})
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for event name %q", tc.bad)
+				}
+			}()
+			m.OnEvent(tc.bad, func(w http.ResponseWriter, r *http.Request) {})
+		})
+	}
+}
+
+func TestEmit_PanicsOnPathInjection(t *testing.T) {
+	// Emit doesn't mount a route, but its name is still developer-facing in
+	// the manifest payload — same validation rules apply for consistency
+	// and to catch typos at startup.
+	m, _ := New(Config{ID: "media"})
+	for _, bad := range []string{"", "../admin", "foo/bar", "foo bar"} {
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for emit name %q", bad)
+				}
+			}()
+			m.Emit(bad)
+		}()
+	}
+}
+
+func TestModulesIsolated_OnEvent(t *testing.T) {
+	// Two modules in the same process must not see each other's event
+	// subscriptions in the manifest. This mirrors the test isolation
+	// guarantee from #28 (per-Module registry, no package globals).
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m1, _ := New(Config{ID: "media"})
+	m2, _ := New(Config{ID: "billing"})
+
+	m1.OnEvent("oauth.user_deleted", func(w http.ResponseWriter, r *http.Request) {})
+	m2.OnEvent("media.uploaded", func(w http.ResponseWriter, r *http.Request) {})
+
+	rec := doRequestWithSecret(t, m1.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+
+	if _, ok := got.Events.Subscribes["media.uploaded"]; ok {
+		t.Error("m1 manifest leaked m2's event subscription")
+	}
+	if _, ok := got.Events.Subscribes["oauth.user_deleted"]; !ok {
+		t.Error("m1 manifest missing its own subscription")
+	}
+}

--- a/event_test.go
+++ b/event_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestOnEvent_HandlerReachableViaInternalScope(t *testing.T) {
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "media"})
+	m := newTestModuleWithSecret(t, "media")
 
 	called := false
 	m.OnEvent("oauth.user_deleted", func(w http.ResponseWriter, r *http.Request) {
@@ -32,8 +31,7 @@ func TestOnEvent_RequiresInternalSecret(t *testing.T) {
 	// InternalAuth gate must reject unauthenticated callers. If a future
 	// refactor accidentally moves OnEvent to a public-scope mount, this
 	// test fails immediately.
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "media"})
+	m := newTestModuleWithSecret(t, "media")
 
 	m.OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not run without internal secret")
@@ -46,8 +44,7 @@ func TestOnEvent_RequiresInternalSecret(t *testing.T) {
 }
 
 func TestOnEvent_AppearsInManifestSubscribes(t *testing.T) {
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "media"})
+	m := newTestModuleWithSecret(t, "media")
 
 	m.OnEvent("oauth.user_deleted", func(w http.ResponseWriter, r *http.Request) {})
 	m.OnEvent("billing.payment_succeeded", func(w http.ResponseWriter, r *http.Request) {})
@@ -70,20 +67,16 @@ func TestOnEvent_PanicsOnDuplicate(t *testing.T) {
 	m, _ := New(Config{ID: "media"})
 	m.OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {})
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic on duplicate OnEvent")
-		}
-	}()
-	m.OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {})
+	assertPanics(t, "expected panic on duplicate OnEvent", func() {
+		m.OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {})
+	})
 }
 
-func TestEmit_AppearsInManifestEmits(t *testing.T) {
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "media"})
+func TestEmits_AppearsInManifestEmits(t *testing.T) {
+	m := newTestModuleWithSecret(t, "media")
 
-	m.Emit("created")
-	m.Emit("deleted")
+	m.Emits("created")
+	m.Emits("deleted")
 
 	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
 	var got system.ManifestPayload
@@ -102,16 +95,13 @@ func TestEmit_AppearsInManifestEmits(t *testing.T) {
 	}
 }
 
-func TestEmit_PanicsOnDuplicate(t *testing.T) {
+func TestEmits_PanicsOnDuplicate(t *testing.T) {
 	m, _ := New(Config{ID: "media"})
-	m.Emit("created")
+	m.Emits("created")
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic on duplicate Emit")
-		}
-	}()
-	m.Emit("created")
+	assertPanics(t, "expected panic on duplicate Emits", func() {
+		m.Emits("created")
+	})
 }
 
 func TestEvent_TopLevelPanicsBeforeInit(t *testing.T) {
@@ -120,25 +110,21 @@ func TestEvent_TopLevelPanicsBeforeInit(t *testing.T) {
 		fn   func()
 	}{
 		{"OnEvent", func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) }},
-		{"Emit", func() { Emit("created") }},
+		{"Emits", func() { Emits("created") }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resetDefault(t)
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("expected panic for top-level %s before Init", tc.name)
-				}
-			}()
-			tc.fn()
+			assertPanics(t, "expected panic for top-level "+tc.name+" before Init", tc.fn)
 		})
 	}
 }
 
-func TestOnEvent_PanicsOnPathInjection(t *testing.T) {
-	// SECURITY regression guard: a name like "../admin" used to chi-normalize
+func TestOnEvent_PanicsOnInvalidName(t *testing.T) {
+	// SECURITY regression guard: a name like "../admin" would let chi normalize
 	// the registered pattern to "/admin", letting the handler escape the
 	// /events/ namespace AND making the manifest disagree with the actual
-	// route. validateRegistrationName now blocks this at the API boundary.
+	// route. validateRegistrationName (in internal/registry) blocks this at
+	// the API boundary.
 	cases := []struct {
 		name string
 		bad  string
@@ -148,44 +134,52 @@ func TestOnEvent_PanicsOnPathInjection(t *testing.T) {
 		{"slash", "foo/bar"},
 		{"backslash", "foo\\bar"},
 		{"space", "foo bar"},
+		{"tab", "foo\tbar"},
 		{"newline", "foo\nbar"},
+		{"carriage-return", "foo\rbar"},
+		{"null-byte", "foo\x00bar"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m, _ := New(Config{ID: "media"})
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("expected panic for event name %q", tc.bad)
-				}
-			}()
-			m.OnEvent(tc.bad, func(w http.ResponseWriter, r *http.Request) {})
+			assertPanics(t, "expected panic for event name "+tc.bad, func() {
+				m.OnEvent(tc.bad, func(w http.ResponseWriter, r *http.Request) {})
+			})
 		})
 	}
 }
 
-func TestEmit_PanicsOnPathInjection(t *testing.T) {
-	// Emit doesn't mount a route, but its name is still developer-facing in
+func TestEmits_PanicsOnInvalidName(t *testing.T) {
+	// Emits doesn't mount a route, but its name is still developer-facing in
 	// the manifest payload — same validation rules apply for consistency
-	// and to catch typos at startup.
-	m, _ := New(Config{ID: "media"})
-	for _, bad := range []string{"", "../admin", "foo/bar", "foo bar"} {
-		func() {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("expected panic for emit name %q", bad)
-				}
-			}()
-			m.Emit(bad)
-		}()
+	// and to catch typos at startup. Subset of the OnEvent matrix.
+	cases := []struct {
+		name string
+		bad  string
+	}{
+		{"empty", ""},
+		{"dot-segment", "../admin"},
+		{"slash", "foo/bar"},
+		{"backslash", "foo\\bar"},
+		{"whitespace", "foo bar"},
+		{"newline", "foo\nbar"},
+		{"null-byte", "foo\x00bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := New(Config{ID: "media"})
+			assertPanics(t, "expected panic for emits name "+tc.bad, func() {
+				m.Emits(tc.bad)
+			})
+		})
 	}
 }
 
 func TestModulesIsolated_OnEvent(t *testing.T) {
 	// Two modules in the same process must not see each other's event
-	// subscriptions in the manifest. This mirrors the test isolation
-	// guarantee from #28 (per-Module registry, no package globals).
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m1, _ := New(Config{ID: "media"})
+	// subscriptions in the manifest. Mirrors the test isolation guarantee
+	// from #28 (per-Module registry, no package globals).
+	m1 := newTestModuleWithSecret(t, "media")
 	m2, _ := New(Config{ID: "billing"})
 
 	m1.OnEvent("oauth.user_deleted", func(w http.ResponseWriter, r *http.Request) {})

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -4,9 +4,9 @@
 //
 // Routes are recorded by Module.Platform/Public/Internal as the developer
 // registers handlers. Permissions are recorded by Module.RequirePermission.
-// Events and schedules are placeholders for issue #9 (ms.OnEvent / ms.Emit /
-// ms.Cron) — the registry exposes empty defaults so the manifest payload
-// shape is stable.
+// Events and schedules are recorded by Module.OnEvent / Module.Emits /
+// Module.Cron (issue #9). The registry exposes empty defaults so the
+// manifest payload shape is stable even when nothing is registered.
 package registry
 
 import (
@@ -47,7 +47,7 @@ type Route struct {
 
 // Schedule is a cron job declaration. Path is the URL the platform's
 // scheduler invokes (POSTs to) when the cron fires; the SDK auto-derives
-// it as /crons/{name} on the module's Internal scope.
+// it as /__mirrorstack/crons/{name} on the module's Internal scope.
 type Schedule struct {
 	Name string `json:"name"`
 	Cron string `json:"cron"`

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -45,9 +45,13 @@ type Route struct {
 	Path   string `json:"path"`
 }
 
+// Schedule is a cron job declaration. Path is the URL the platform's
+// scheduler invokes (POSTs to) when the cron fires; the SDK auto-derives
+// it as /crons/{name} on the module's Internal scope.
 type Schedule struct {
 	Name string `json:"name"`
 	Cron string `json:"cron"`
+	Path string `json:"path"`
 }
 
 // Permission is a declared module permission. Exposed in the manifest so the
@@ -153,7 +157,7 @@ func (r *Registry) Subscribes() map[string]string {
 
 // AddSchedule registers a cron job. First-wins by name: a second
 // AddSchedule with the same name is dropped.
-func (r *Registry) AddSchedule(name, cron string) {
+func (r *Registry) AddSchedule(name, cron, path string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.schedules {
@@ -161,7 +165,39 @@ func (r *Registry) AddSchedule(name, cron string) {
 			return
 		}
 	}
-	r.schedules = append(r.schedules, Schedule{Name: name, Cron: cron})
+	r.schedules = append(r.schedules, Schedule{Name: name, Cron: cron, Path: path})
+}
+
+// HasSubscribe reports whether an event subscription is already registered
+// under the given name. Used by Module.OnEvent to fail loudly on duplicate
+// registrations rather than letting the silent first-wins behavior hide a
+// programmer mistake.
+func (r *Registry) HasSubscribe(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, exists := r.subscribes[name]
+	return exists
+}
+
+// HasEmit reports whether an emit declaration is already registered under
+// the given name. See HasSubscribe for the rationale.
+func (r *Registry) HasEmit(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Contains(r.emits, name)
+}
+
+// HasSchedule reports whether a cron job is already registered under the
+// given name. See HasSubscribe for the rationale.
+func (r *Registry) HasSchedule(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, s := range r.schedules {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Schedules returns a non-nil copy of all scheduled jobs.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -190,11 +190,14 @@ func (r *Registry) Schedules() []Schedule {
 // AddPermission records a declared permission. First-wins by name: a second
 // AddPermission for the same name is dropped (matches AddRoute / AddEmit /
 // AddSchedule semantics). The roles slice is cloned so caller mutations
-// after the call cannot leak into the stored copy.
+// after the call cannot leak into the stored copy. Panics on an invalid
+// name (see validateRegistrationName) — permissions don't end up in URL
+// paths, so the path-separator check is purely cosmetic for permissions,
+// but the consistency with AddSubscribe/AddEmit/AddSchedule prevents
+// downstream consumers (DB columns, log parsers) from receiving malformed
+// strings via the manifest.
 func (r *Registry) AddPermission(name string, roles []string) {
-	if name == "" {
-		panic("mirrorstack/registry: AddPermission called with empty name")
-	}
+	validateRegistrationName("RequirePermission", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.permissions {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -113,14 +113,17 @@ func (r *Registry) Routes() map[Scope][]Route {
 }
 
 // AddEmit declares that the module emits an event of the given name.
-// First-wins: duplicate names are dropped.
-func (r *Registry) AddEmit(name string) {
+// Returns true if added, false if a declaration for that name already exists
+// (first-wins). Panics on an invalid name (see validateRegistrationName).
+func (r *Registry) AddEmit(name string) bool {
+	validateRegistrationName("Emits", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if slices.Contains(r.emits, name) {
-		return
+		return false
 	}
 	r.emits = append(r.emits, name)
+	return true
 }
 
 // Emits returns a non-nil copy of all declared emit events.
@@ -134,15 +137,18 @@ func (r *Registry) Emits() []string {
 }
 
 // AddSubscribe declares that the module subscribes to an event from another
-// module. The handler is mounted at path on the Internal scope. First-wins:
-// a second AddSubscribe for the same event name is dropped.
-func (r *Registry) AddSubscribe(name, path string) {
+// module. The handler is mounted at path on the Internal scope. Returns true
+// if added, false if a subscription for that event name already exists
+// (first-wins). Panics on an invalid name (see validateRegistrationName).
+func (r *Registry) AddSubscribe(name, path string) bool {
+	validateRegistrationName("OnEvent", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.subscribes[name]; exists {
-		return
+		return false
 	}
 	r.subscribes[name] = path
+	return true
 }
 
 // Subscribes returns a non-nil copy of all event subscriptions.
@@ -155,49 +161,20 @@ func (r *Registry) Subscribes() map[string]string {
 	return maps.Clone(r.subscribes)
 }
 
-// AddSchedule registers a cron job. First-wins by name: a second
-// AddSchedule with the same name is dropped.
-func (r *Registry) AddSchedule(name, cron, path string) {
+// AddSchedule registers a cron job. Returns true if added, false if a job
+// with the same name already exists (first-wins). Panics on an invalid name
+// (see validateRegistrationName).
+func (r *Registry) AddSchedule(name, cron, path string) bool {
+	validateRegistrationName("Cron", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.schedules {
 		if existing.Name == name {
-			return
+			return false
 		}
 	}
 	r.schedules = append(r.schedules, Schedule{Name: name, Cron: cron, Path: path})
-}
-
-// HasSubscribe reports whether an event subscription is already registered
-// under the given name. Used by Module.OnEvent to fail loudly on duplicate
-// registrations rather than letting the silent first-wins behavior hide a
-// programmer mistake.
-func (r *Registry) HasSubscribe(name string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	_, exists := r.subscribes[name]
-	return exists
-}
-
-// HasEmit reports whether an emit declaration is already registered under
-// the given name. See HasSubscribe for the rationale.
-func (r *Registry) HasEmit(name string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return slices.Contains(r.emits, name)
-}
-
-// HasSchedule reports whether a cron job is already registered under the
-// given name. See HasSubscribe for the rationale.
-func (r *Registry) HasSchedule(name string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	for _, s := range r.schedules {
-		if s.Name == name {
-			return true
-		}
-	}
-	return false
+	return true
 }
 
 // Schedules returns a non-nil copy of all scheduled jobs.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -288,7 +288,7 @@ func TestValidateRegistrationName_AcceptsValidNames(t *testing.T) {
 		"oauth.user_deleted",
 		"billing.payment_succeeded",
 		"media-uploaded",
-		"Module.Action",
+		"v1.user.created", // versioned event names should still pass
 	}
 	for _, name := range good {
 		t.Run(name, func(t *testing.T) {
@@ -390,14 +390,34 @@ func TestPermissions_RolesAreCloned(t *testing.T) {
 	}
 }
 
-func TestAddPermission_PanicsOnEmptyName(t *testing.T) {
+func TestAddPermission_PanicsOnInvalidName(t *testing.T) {
 	t.Parallel()
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for empty permission name")
-		}
-	}()
-	r := New()
-	r.AddPermission("", []string{"admin"})
+	// Permissions don't end up in URL paths, but they DO appear in the
+	// manifest payload which platform-side consumers may use as identifiers
+	// for grant UI, RBAC tables, log fields, etc. Sharing the registry's
+	// validateRegistrationName guard with AddSubscribe/AddEmit/AddSchedule
+	// prevents inconsistent behavior across the four registration sites
+	// and keeps malformed strings (null bytes, dot-segments) out of the
+	// manifest regardless of which Add* the developer called.
+	cases := []struct {
+		name string
+		bad  string
+	}{
+		{"empty", ""},
+		{"dot-segment", "../admin"},
+		{"slash", "foo/bar"},
+		{"null-byte", "foo\x00bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Errorf("expected panic for AddPermission(%q)", tc.bad)
+				}
+			}()
+			r.AddPermission(tc.bad, []string{"admin"})
+		})
+	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -212,40 +212,94 @@ func TestSchedules_EmptyReturnsNonNil(t *testing.T) {
 	}
 }
 
-func TestHasSubscribe_HasEmit_HasSchedule(t *testing.T) {
+func TestAddX_ReturnBoolForFirstWins(t *testing.T) {
 	t.Parallel()
 
-	// Has* helpers exist so the user-facing event/cron API can panic on
-	// duplicate registrations cheaply, without paying for a deep clone of
-	// the whole map/slice.
+	// Add* methods return true on first registration, false on duplicate.
+	// This is the contract Module.OnEvent / Cron / Emits rely on to panic
+	// on duplicates without a separate Has*-then-Add two-step.
 	r := New()
-	if r.HasSubscribe("user.created") {
-		t.Error("empty registry should not report HasSubscribe")
+	if !r.AddSubscribe("user.created", "/events/user.created") {
+		t.Error("first AddSubscribe should return true")
 	}
-	if r.HasEmit("media.uploaded") {
-		t.Error("empty registry should not report HasEmit")
-	}
-	if r.HasSchedule("nightly") {
-		t.Error("empty registry should not report HasSchedule")
+	if r.AddSubscribe("user.created", "/events/user.created") {
+		t.Error("duplicate AddSubscribe should return false")
 	}
 
-	r.AddSubscribe("user.created", "/events/user.created")
-	r.AddEmit("media.uploaded")
-	r.AddSchedule("nightly", "0 3 * * *", "/crons/nightly")
-
-	if !r.HasSubscribe("user.created") {
-		t.Error("HasSubscribe should return true after AddSubscribe")
+	if !r.AddEmit("media.uploaded") {
+		t.Error("first AddEmit should return true")
 	}
-	if !r.HasEmit("media.uploaded") {
-		t.Error("HasEmit should return true after AddEmit")
-	}
-	if !r.HasSchedule("nightly") {
-		t.Error("HasSchedule should return true after AddSchedule")
+	if r.AddEmit("media.uploaded") {
+		t.Error("duplicate AddEmit should return false")
 	}
 
-	// Spot-check non-matches stay false (no false positives via prefix etc.)
-	if r.HasSubscribe("user") {
-		t.Error("HasSubscribe should not match prefixes")
+	if !r.AddSchedule("nightly", "0 3 * * *", "/crons/nightly") {
+		t.Error("first AddSchedule should return true")
+	}
+	if r.AddSchedule("nightly", "0 5 * * *", "/crons/nightly-other") {
+		t.Error("duplicate AddSchedule should return false")
+	}
+}
+
+func TestValidateRegistrationName_Rejects(t *testing.T) {
+	t.Parallel()
+
+	// SECURITY regression guard for the registry-level validation. The
+	// rules apply uniformly to AddSubscribe / AddSchedule / AddEmit because
+	// the validator is called from each Add*. Without this guard, names
+	// like "../admin" would let chi normalize the registered pattern to
+	// "/admin", silently escaping the /events/ or /crons/ namespace.
+	cases := []struct {
+		name string
+		bad  string
+	}{
+		{"empty", ""},
+		{"dot-segment", "../admin"},
+		{"slash", "foo/bar"},
+		{"backslash", "foo\\bar"},
+		{"space", "foo bar"},
+		{"tab", "foo\tbar"},
+		{"newline", "foo\nbar"},
+		{"carriage-return", "foo\rbar"},
+		{"null-byte", "foo\x00bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Errorf("expected panic for AddSubscribe(%q)", tc.bad)
+				}
+			}()
+			r.AddSubscribe(tc.bad, "/events/x")
+		})
+	}
+}
+
+func TestValidateRegistrationName_AcceptsValidNames(t *testing.T) {
+	t.Parallel()
+
+	// Reasonable names must NOT panic — the validator is a deny-list, not
+	// an allow-list. If someone tightens it later this test catches the
+	// over-rejection.
+	good := []string{
+		"created",
+		"user.created",
+		"oauth.user_deleted",
+		"billing.payment_succeeded",
+		"media-uploaded",
+		"Module.Action",
+	}
+	for _, name := range good {
+		t.Run(name, func(t *testing.T) {
+			r := New()
+			defer func() {
+				if rec := recover(); rec != nil {
+					t.Errorf("name %q unexpectedly rejected: %v", name, rec)
+				}
+			}()
+			r.AddSubscribe(name, "/events/"+name)
+		})
 	}
 }
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -349,8 +349,8 @@ func TestPermissions_FirstWinsBlocksPrivilegeEscalation(t *testing.T) {
 	// First-wins must block this — a buggy or malicious second call cannot
 	// replace the original tight ruleset with a wider one.
 	r := New()
-	r.AddPermission("media.delete", []string{"admin"})                            // strict first
-	r.AddPermission("media.delete", []string{"admin", "member", "viewer"})        // looser second — must be dropped
+	r.AddPermission("media.delete", []string{"admin"})                     // strict first
+	r.AddPermission("media.delete", []string{"admin", "member", "viewer"}) // looser second — must be dropped
 
 	got := r.Permissions()
 	if len(got) != 1 {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -175,15 +175,15 @@ func TestSchedules_Recorded(t *testing.T) {
 	t.Parallel()
 
 	r := New()
-	r.AddSchedule("cleanup-temp", "0 3 * * *")
-	r.AddSchedule("daily-report", "0 9 * * *")
+	r.AddSchedule("cleanup-temp", "0 3 * * *", "/crons/cleanup-temp")
+	r.AddSchedule("daily-report", "0 9 * * *", "/crons/daily-report")
 
 	got := r.Schedules()
 	if len(got) != 2 {
 		t.Fatalf("schedules = %v, want 2", got)
 	}
-	if got[0].Name != "cleanup-temp" || got[0].Cron != "0 3 * * *" {
-		t.Errorf("schedules[0] = %+v, want {cleanup-temp, 0 3 * * *}", got[0])
+	if got[0].Name != "cleanup-temp" || got[0].Cron != "0 3 * * *" || got[0].Path != "/crons/cleanup-temp" {
+		t.Errorf("schedules[0] = %+v, want {cleanup-temp, 0 3 * * *, /crons/cleanup-temp}", got[0])
 	}
 }
 
@@ -193,8 +193,8 @@ func TestSchedules_DropsDuplicateNames(t *testing.T) {
 	// Two schedules with the same name (even with different crons) is a
 	// configuration mistake — first-wins matches AddRoute / AddEmit.
 	r := New()
-	r.AddSchedule("cleanup", "0 3 * * *")
-	r.AddSchedule("cleanup", "0 5 * * *")
+	r.AddSchedule("cleanup", "0 3 * * *", "/crons/cleanup")
+	r.AddSchedule("cleanup", "0 5 * * *", "/crons/cleanup-other")
 
 	got := r.Schedules()
 	if len(got) != 1 {
@@ -209,6 +209,43 @@ func TestSchedules_EmptyReturnsNonNil(t *testing.T) {
 	t.Parallel()
 	if got := New().Schedules(); got == nil {
 		t.Error("empty Schedules() returned nil, want []Schedule{}")
+	}
+}
+
+func TestHasSubscribe_HasEmit_HasSchedule(t *testing.T) {
+	t.Parallel()
+
+	// Has* helpers exist so the user-facing event/cron API can panic on
+	// duplicate registrations cheaply, without paying for a deep clone of
+	// the whole map/slice.
+	r := New()
+	if r.HasSubscribe("user.created") {
+		t.Error("empty registry should not report HasSubscribe")
+	}
+	if r.HasEmit("media.uploaded") {
+		t.Error("empty registry should not report HasEmit")
+	}
+	if r.HasSchedule("nightly") {
+		t.Error("empty registry should not report HasSchedule")
+	}
+
+	r.AddSubscribe("user.created", "/events/user.created")
+	r.AddEmit("media.uploaded")
+	r.AddSchedule("nightly", "0 3 * * *", "/crons/nightly")
+
+	if !r.HasSubscribe("user.created") {
+		t.Error("HasSubscribe should return true after AddSubscribe")
+	}
+	if !r.HasEmit("media.uploaded") {
+		t.Error("HasEmit should return true after AddEmit")
+	}
+	if !r.HasSchedule("nightly") {
+		t.Error("HasSchedule should return true after AddSchedule")
+	}
+
+	// Spot-check non-matches stay false (no false positives via prefix etc.)
+	if r.HasSubscribe("user") {
+		t.Error("HasSubscribe should not match prefixes")
 	}
 }
 

--- a/internal/registry/validate.go
+++ b/internal/registry/validate.go
@@ -1,0 +1,35 @@
+package registry
+
+import "strings"
+
+// validateRegistrationName rejects names that are empty, contain a path
+// separator (/, \), contain a dot-segment (..), contain whitespace, or
+// contain a null byte. The name is concatenated into a URL path by the
+// SDK's event/cron handlers, so any character that chi might normalize
+// or that an HTTP client cannot transmit safely is forbidden.
+//
+// SECURITY: this is the registry-level invariant. Bypassing the
+// user-facing Module.OnEvent / Cron / Emits API and calling AddSubscribe
+// / AddSchedule / AddEmit directly still triggers this guard, so the
+// SDK's manifest cannot contain a name that would mismatch the chi route
+// table or would serialize to malformed JSON for downstream consumers.
+//
+// Null byte (\x00) is blocked because it produces valid JSON but breaks
+// many downstream consumers (shell, log parsers, PostgreSQL text columns).
+// Unicode whitespace beyond ASCII is not blocked — chi's pattern matcher
+// is byte-oriented and a Unicode-whitespace name would simply produce a
+// dead handler, not a security issue.
+//
+// kind is the user-facing API name (e.g., "OnEvent", "Cron", "Emits") used
+// in the panic message so callers see which call failed validation.
+func validateRegistrationName(kind, name string) {
+	if name == "" {
+		panic("mirrorstack/registry: " + kind + " name cannot be empty")
+	}
+	if strings.ContainsAny(name, "/\\ \t\n\r\x00") {
+		panic("mirrorstack/registry: " + kind + "(" + name + ") contains a path separator, whitespace, or null byte")
+	}
+	if strings.Contains(name, "..") {
+		panic("mirrorstack/registry: " + kind + "(" + name + ") contains '..'")
+	}
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -227,7 +227,9 @@ func (m *Module) Public(fn func(r chi.Router)) {
 }
 
 // Internal registers routes with internal auth scope (platform-to-module only).
-// Validates X-MS-Internal-Secret via constant-time comparison.
+// Validates X-MS-Internal-Secret via constant-time comparison. The middleware
+// is cached on the Module at New() so OnEvent / Cron registrations reuse a
+// single closure instead of constructing one per call.
 func (m *Module) Internal(fn func(r chi.Router)) {
 	m.scopedRoutes(registry.ScopeInternal, m.internalAuth, fn)
 }

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -50,18 +50,19 @@ type Config struct {
 
 // Module is the core SDK instance.
 type Module struct {
-	config    Config
-	router    *chi.Mux
-	logger    *log.Logger
-	registry  *registry.Registry
-	poolCache *db.PoolCache // production: per-app DB pools
-	devDBOnce sync.Once     // dev mode: lazy DB init
-	devDB     *db.DB
-	devDBErr  error
-	cacheCache   *cache.ClientCache // production: per-app Redis clients
-	devCacheOnce sync.Once          // dev mode: lazy cache init
-	devCache     *cache.Client
-	devCacheErr  error
+	config       Config
+	router       *chi.Mux
+	logger       *log.Logger
+	registry     *registry.Registry
+	internalAuth func(http.Handler) http.Handler // cached at New() — InternalAuth() reads MS_INTERNAL_SECRET once at construction; recomputing per registration would re-read the env var and re-allocate the closure for every OnEvent/Cron call
+	poolCache    *db.PoolCache                   // production: per-app DB pools
+	devDBOnce    sync.Once                       // dev mode: lazy DB init
+	devDB        *db.DB
+	devDBErr     error
+	cacheCache     *cache.ClientCache // production: per-app Redis clients
+	devCacheOnce   sync.Once          // dev mode: lazy cache init
+	devCache       *cache.Client
+	devCacheErr    error
 	devStorageOnce sync.Once // dev mode: lazy storage init
 	devStorage     *storage.Client
 	devStorageErr  error
@@ -73,12 +74,13 @@ func New(cfg Config) (*Module, error) {
 		return nil, errors.New("mirrorstack: Config.ID is required")
 	}
 	m := &Module{
-		config:     cfg,
-		router:     chi.NewRouter(),
-		logger:     log.New(os.Stderr, "mirrorstack: ", log.LstdFlags),
-		registry:   registry.New(),
-		poolCache:  db.NewPoolCache(),
-		cacheCache: cache.NewClientCache(),
+		config:       cfg,
+		router:       chi.NewRouter(),
+		logger:       log.New(os.Stderr, "mirrorstack: ", log.LstdFlags),
+		registry:     registry.New(),
+		internalAuth: auth.InternalAuth(),
+		poolCache:    db.NewPoolCache(),
+		cacheCache:   cache.NewClientCache(),
 	}
 	m.mountSystemRoutes()
 	return m, nil
@@ -227,7 +229,7 @@ func (m *Module) Public(fn func(r chi.Router)) {
 // Internal registers routes with internal auth scope (platform-to-module only).
 // Validates X-MS-Internal-Secret via constant-time comparison.
 func (m *Module) Internal(fn func(r chi.Router)) {
-	m.scopedRoutes(registry.ScopeInternal, auth.InternalAuth(), fn)
+	m.scopedRoutes(registry.ScopeInternal, m.internalAuth, fn)
 }
 
 // scopedRoutes records every route fn registers under the given scope, then
@@ -348,7 +350,7 @@ func (m *Module) mountSystemRoutes() {
 		r.Get("/health", system.Health) // intentionally public — no auth
 		r.Route("/platform", func(r chi.Router) {
 			r.Use(httputil.MaxBytes(64 * 1024)) // 64 KB — lifecycle bodies are tiny
-			r.Use(auth.InternalAuth())
+			r.Use(m.internalAuth)
 			r.Get("/manifest", system.ManifestHandler(
 				m.config.ID, m.config.Name, m.config.Icon,
 				m.config.SQL, m.config.Versions, m.registry,

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -49,16 +49,21 @@ type Config struct {
 }
 
 // Module is the core SDK instance.
+//
+// internalAuth is captured at New() time so OnEvent/Cron registrations can
+// reuse a single middleware closure. auth.InternalAuth() reads
+// MS_INTERNAL_SECRET once at construction; constructing it per registration
+// would re-read the env var and re-allocate the closure on every call.
 type Module struct {
-	config       Config
-	router       *chi.Mux
-	logger       *log.Logger
-	registry     *registry.Registry
-	internalAuth func(http.Handler) http.Handler // cached at New() — InternalAuth() reads MS_INTERNAL_SECRET once at construction; recomputing per registration would re-read the env var and re-allocate the closure for every OnEvent/Cron call
-	poolCache    *db.PoolCache                   // production: per-app DB pools
-	devDBOnce    sync.Once                       // dev mode: lazy DB init
-	devDB        *db.DB
-	devDBErr     error
+	config         Config
+	router         *chi.Mux
+	logger         *log.Logger
+	registry       *registry.Registry
+	internalAuth   func(http.Handler) http.Handler
+	poolCache      *db.PoolCache // production: per-app DB pools
+	devDBOnce      sync.Once     // dev mode: lazy DB init
+	devDB          *db.DB
+	devDBErr       error
 	cacheCache     *cache.ClientCache // production: per-app Redis clients
 	devCacheOnce   sync.Once          // dev mode: lazy cache init
 	devCache       *cache.Client

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -484,6 +484,9 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"Public":            func() { Public(func(r chi.Router) {}) },
 		"Internal":          func() { Internal(func(r chi.Router) {}) },
 		"RequirePermission": func() { RequirePermission("media.view", "admin") },
+		"OnEvent":           func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) },
+		"Emit":              func() { Emit("created") },
+		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
 	}
 	for name, fn := range fns {
 		t.Run(name, func(t *testing.T) {

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -24,6 +24,13 @@ func resetDefault(t *testing.T) {
 // "secret" — the canonical setup for tests that exercise internal-scope
 // routes (manifest, lifecycle, events, crons). Use the lowercase id for
 // stable manifest assertions.
+//
+// IMPORTANT: t.Setenv MUST run before New(), which is why this helper
+// bundles them. Module.New() captures auth.InternalAuth() at construction;
+// the cached middleware closure reads MS_INTERNAL_SECRET once and never
+// re-reads. A test that calls New() then sets the env afterward will
+// silently produce a module with the wrong secret and fail with
+// confusing 401/503 responses.
 func newTestModuleWithSecret(t *testing.T, id string) *Module {
 	t.Helper()
 	t.Setenv("MS_INTERNAL_SECRET", "secret")

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -20,6 +20,34 @@ func resetDefault(t *testing.T) {
 	defaultModule = nil
 }
 
+// newTestModuleWithSecret creates a Module with MS_INTERNAL_SECRET set to
+// "secret" — the canonical setup for tests that exercise internal-scope
+// routes (manifest, lifecycle, events, crons). Use the lowercase id for
+// stable manifest assertions.
+func newTestModuleWithSecret(t *testing.T, id string) *Module {
+	t.Helper()
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, err := New(Config{ID: id})
+	if err != nil {
+		t.Fatalf("New(%q): %v", id, err)
+	}
+	return m
+}
+
+// assertPanics runs fn and fails the test if fn does not panic. msg is the
+// error message used when no panic occurred. Mirrors the recover-pattern
+// previously duplicated across event_test.go, cron_test.go,
+// permission_test.go, and registry_test.go.
+func assertPanics(t *testing.T, msg string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error(msg)
+		}
+	}()
+	fn()
+}
+
 func doRequest(t *testing.T, h http.Handler, method, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(method, path, nil)
@@ -502,7 +530,7 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"Internal":          func() { Internal(func(r chi.Router) {}) },
 		"RequirePermission": func() { RequirePermission("media.view", "admin") },
 		"OnEvent":           func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) },
-		"Emit":              func() { Emit("created") },
+		"Emits":             func() { Emits("created") },
 		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
 	}
 	for name, fn := range fns {

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -86,7 +86,7 @@ func TestManifest_EventsAndSchedules(t *testing.T) {
 	reg := registry.New()
 	reg.AddEmit("created")
 	reg.AddSubscribe("oauth.user_deleted", "/internal/events/on-user-deleted")
-	reg.AddSchedule("cleanup-temp", "0 3 * * *")
+	reg.AddSchedule("cleanup-temp", "0 3 * * *", "/crons/cleanup-temp")
 
 	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, nil, reg))
 
@@ -96,8 +96,8 @@ func TestManifest_EventsAndSchedules(t *testing.T) {
 	if got.Events.Subscribes["oauth.user_deleted"] != "/internal/events/on-user-deleted" {
 		t.Errorf("events.subscribes mismatch: %v", got.Events.Subscribes)
 	}
-	if len(got.Schedules) != 1 || got.Schedules[0].Name != "cleanup-temp" {
-		t.Errorf("schedules = %v, want [{cleanup-temp ...}]", got.Schedules)
+	if len(got.Schedules) != 1 || got.Schedules[0].Name != "cleanup-temp" || got.Schedules[0].Path != "/crons/cleanup-temp" {
+		t.Errorf("schedules = %v, want [{cleanup-temp 0 3 * * * /crons/cleanup-temp}]", got.Schedules)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the per-Module event subscription, emit declaration, and cron registration APIs the issue calls for. Handlers auto-mount on the Internal scope (gated by `InternalAuth` from #36) at deterministic paths the platform's event bus and scheduler can derive without guessing.

## API surface

All panic on duplicate or invalid name. Call from startup code, not request handlers.

```go
// Subscribe to an event from another module — handler mounted at
// /events/{name}, recorded in manifest.events.subscribes.
mod.OnEvent("oauth.user_deleted", func(w http.ResponseWriter, r *http.Request) { ... })

// Declare an emitted event — appears in manifest.events.emits.
mod.Emit("created")

// Register a cron job — handler mounted at /crons/{name}, recorded
// in manifest.schedules with cron string + path.
mod.Cron("cleanup-temp", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) { ... })
```

Top-level wrappers (`ms.OnEvent`, `ms.Emit`, `ms.Cron`) dispatch through `mustDefault`, panic before `Init()` — matches the existing `Platform`/`Public`/`Internal`/`RequirePermission` pattern.

## Registry changes

- `Schedule` struct gains a `Path` field so the platform's scheduler knows the URL to invoke. `AddSchedule` signature broadens from `(name, cron)` to `(name, cron, path)`. All callers updated.
- New `HasSubscribe` / `HasEmit` / `HasSchedule` helpers — lock-free read-locked existence checks so the user-facing API can panic on duplicates without deep-cloning the whole map/slice.

## Security

`validateRegistrationName` rejects empty names, path separators (`/`, `\`), dot-segments (`..`), and whitespace. Without this check, `OnEvent(\"../admin\", h)` would let chi normalize the registered pattern to `/admin`, silently escaping the `/events/` namespace AND making the manifest payload disagree with the actual mounted route.

This was the **MEDIUM finding** from the security/efficiency `/simplify` review:

> The platform-vs-chi disagreement is the real bug: events fired at \`/events/../admin\` by the platform hit a 404, while a separate \`Platform()\` route at \`/admin\` actually receives them.

`TestOnEvent_PanicsOnPathInjection`, `TestEmit_PanicsOnPathInjection`, and `TestCron_PanicsOnPathInjection` are the regression guards (covering 6 attack patterns: empty, `../`, `/`, `\`, space, newline).

## Test coverage

- Handler reachability via internal scope (200 with secret, 401 without)
- Manifest serialization (`subscribes` / `emits` / `schedules`)
- Duplicate registration panic
- Empty / path-injection name panic (security regression)
- Top-level wrapper panic-before-Init (added to `TestScopesPanic_BeforeInit`)
- Two-module isolation guarantee (m1's manifest does not see m2's events)
- Empty schedule string panic (cron-specific)
- New `Has*` helpers (`TestHasSubscribe_HasEmit_HasSchedule`)

## Reviews applied (`/simplify`)

3 review agents (reuse / quality / security+efficiency). Findings addressed:

| Severity | Finding | Action |
|---|---|---|
| **MED** | S1: Path injection via event/cron name | **Fixed** — `validateRegistrationName` + 6-case regression test |
| **MED** | Empty name validation gap on `OnEvent`/`Emit` | **Fixed** — same helper handles all three |
| Medium | Reuse #4: `/events/` and `/crons/` hardcoded literals | **Fixed** — `eventPathPrefix` / `cronPathPrefix` constants |
| Quality | Panic message verb consistency (\"declared\" vs \"registered\") | **Fixed** — all use \"registered twice\" |
| Quality | `TestModulesIsolated_Cron` redundant with `TestModulesIsolated_OnEvent` | **Fixed** — dropped, replaced with cross-reference comment |
| Quality | WHAT-narration in doc comments | **Fixed** — trimmed `OnEvent` chi-dot paragraph and `Emit` TBD paragraph |

## Out-of-scope follow-ups

Will file separate issues:

- **Event/cron name enumeration via 401 vs 404** — related to #44 but more impactful because event names follow predictable conventions (`module.action`). An unauthenticated attacker can map a deployed module's full subscription surface without ever guessing the secret.
- **Manifest contract doc update** — `docs/module-protocol.md` needs the `schedules[].path` field added to its example. Parent repo, separate PR.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race ./...` all packages green
- [x] Path injection: `TestOnEvent_PanicsOnPathInjection`, `TestEmit_PanicsOnPathInjection`, `TestCron_PanicsOnPathInjection`
- [x] Two-module isolation: `TestModulesIsolated_OnEvent`
- [x] Manifest serialization: `TestOnEvent_AppearsInManifestSubscribes`, `TestEmit_AppearsInManifestEmits`, `TestCron_AppearsInManifestSchedules`
- [x] Internal-secret gating: `TestOnEvent_RequiresInternalSecret`, `TestCron_RequiresInternalSecret`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)