### PR TITLE
feat(manifest): expose both app + module migration versions (#56)

### DIFF
--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -39,13 +39,20 @@ type Config struct {
 	// routes (install/upgrade/downgrade) read it to apply migrations.
 	SQL fs.FS
 
-	// Versions optionally maps semver release tags to migration numbers
-	// (e.g., {"v0.1.0": "0008", "v0.2.0": "0012"}). Exposed to the platform
-	// via the manifest endpoint so the platform can translate its internal
-	// semver-based deploy state into the migration numbers the lifecycle
-	// handlers accept. The SDK itself never reads this map at lifecycle
-	// time — /lifecycle/{upgrade,downgrade} take migration numbers only.
-	Versions map[string]string
+	// Versions optionally maps semver release tags to per-scope migration
+	// numbers, e.g.:
+	//
+	//	{
+	//	    "v0.1.0": {App: "0008", Module: "0002"},
+	//	    "v0.2.0": {App: "0012"},  // module track unchanged
+	//	}
+	//
+	// Exposed to the platform via the manifest endpoint so the platform can
+	// translate its internal semver-based deploy state into the migration
+	// numbers the lifecycle handlers accept. The SDK itself never reads this
+	// map at lifecycle time — /lifecycle/{upgrade,downgrade} take migration
+	// numbers only.
+	Versions map[string]system.MigrationVersions
 }
 
 // Module is the core SDK instance.

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -366,8 +366,8 @@ func TestManifest_MigrationFromConfig(t *testing.T) {
 		t.Fatalf("decode manifest: %v", err)
 	}
 
-	if got.Migration != "0008" {
-		t.Errorf("migration = %q, want 0008", got.Migration)
+	if got.Migration.App != "0008" {
+		t.Errorf("migration.app = %q, want 0008", got.Migration.App)
 	}
 }
 

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -12,22 +12,29 @@ import (
 
 // ManifestPayload is the JSON shape returned by GET /__mirrorstack/platform/manifest.
 // The platform reads this on deploy to discover module identity, capabilities,
-// migration version, and the semver→migration mapping it needs to translate
+// migration versions, and the semver→migration mapping it needs to translate
 // lifecycle calls.
 type ManifestPayload struct {
-	ID        string           `json:"id"`
-	Defaults  ManifestDefaults `json:"defaults"`
-	Migration string           `json:"migration"`
-	// Versions declares the mapping from human release tags (e.g., "v0.1.0")
-	// to migration numbers (e.g., "0008"). The platform reads this on deploy
-	// and uses it to translate semver release requests into the numeric
-	// migration numbers the lifecycle handlers expect. Empty map is valid:
-	// modules without formal releases just declare migration numbers directly.
-	Versions    map[string]string                   `json:"versions"`
+	ID          string                              `json:"id"`
+	Defaults    ManifestDefaults                    `json:"defaults"`
+	Migration   MigrationVersions                   `json:"migration"`
+	Versions    map[string]MigrationVersions        `json:"versions"`
 	Routes      map[registry.Scope][]registry.Route `json:"routes"`
 	Events      ManifestEvents                      `json:"events"`
 	Schedules   []registry.Schedule                 `json:"schedules"`
 	Permissions []registry.Permission               `json:"permissions"`
+}
+
+// MigrationVersions is the per-scope migration number set. Used both for the
+// current bundled version (ManifestPayload.Migration) and for each entry in
+// the semver→migration map (ManifestPayload.Versions).
+//
+// Module is omitempty so modules that don't use the cross-app shared schema
+// (the vast majority) don't see the field in the wire shape. App is always
+// present so consumers can rely on its existence.
+type MigrationVersions struct {
+	App    string `json:"app"`
+	Module string `json:"module,omitempty"`
 }
 
 // ManifestDefaults is the default display name and icon. The platform may
@@ -44,36 +51,39 @@ type ManifestEvents struct {
 }
 
 // ManifestHandler returns an http.HandlerFunc that serves the module manifest.
-// The migration version is read from sqlFS at request time so a hot-reloaded
-// build picks up new migrations without a restart. sqlFS may be nil — the
-// migration field will be empty.
+// The migration versions are read from sqlFS at request time so a hot-reloaded
+// build picks up new migrations without a restart. sqlFS may be nil — both
+// migration fields will be empty.
 //
-// versions is the module's declared semver→migration map. It is exposed
-// read-only so the platform can translate semver release tags to the migration
-// numbers the lifecycle handlers require. A nil map is normalized to an empty
-// object so the JSON output is always `"versions":{}` instead of
-// `"versions":null` — the handler owns the output contract and normalizes
-// here the same way Registry normalizes Routes/Emits/Subscribes/Schedules at
-// their getters, so every manifest field is a non-nil zero value.
-func ManifestHandler(id, name, icon string, sqlFS fs.FS, versions map[string]string, reg *registry.Registry) http.HandlerFunc {
+// versions is the module's declared semver→migration map. A nil map is
+// normalized to an empty object so the JSON output is always `"versions":{}`
+// instead of `"versions":null` — the handler owns the output contract and
+// normalizes here the same way Registry normalizes Routes/Emits/Subscribes/
+// Schedules at their getters.
+func ManifestHandler(id, name, icon string, sqlFS fs.FS, versions map[string]MigrationVersions, reg *registry.Registry) http.HandlerFunc {
 	if versions == nil {
-		versions = map[string]string{}
+		versions = map[string]MigrationVersions{}
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		version, err := migration.LatestVersion(sqlFS, migration.ScopeApp)
-		if err != nil {
-			// Don't fail the manifest — return empty migration so the platform
-			// can still discover the module. Log a sanitized message: in dev
-			// mode with os.DirFS the wrapped error would include the resolved
-			// filesystem path, which is dev-environment noise we don't want
-			// in CloudWatch. The operator can re-check Config.SQL locally.
-			log.Printf("mirrorstack: manifest migration version unavailable (check Config.SQL is set correctly)")
+		// Read each scope independently. Errors are logged with a sanitized
+		// message — in dev mode with os.DirFS the wrapped error would include
+		// the resolved filesystem path, which is dev-environment noise we
+		// don't want in CloudWatch. The operator can re-check Config.SQL
+		// locally. The manifest still serves successfully with the empty
+		// version so the platform can discover the module.
+		appVersion, appErr := migration.LatestVersion(sqlFS, migration.ScopeApp)
+		if appErr != nil {
+			log.Printf("mirrorstack: manifest app migration version unavailable (check Config.SQL is set correctly)")
+		}
+		moduleVersion, moduleErr := migration.LatestVersion(sqlFS, migration.ScopeModule)
+		if moduleErr != nil {
+			log.Printf("mirrorstack: manifest module migration version unavailable (check Config.SQL is set correctly)")
 		}
 
 		httputil.JSON(w, http.StatusOK, ManifestPayload{
 			ID:          id,
 			Defaults:    ManifestDefaults{Name: name, Icon: icon},
-			Migration:   version,
+			Migration:   MigrationVersions{App: appVersion, Module: moduleVersion},
 			Versions:    versions,
 			Routes:      reg.Routes(),
 			Events:      ManifestEvents{Emits: reg.Emits(), Subscribes: reg.Subscribes()},

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -110,25 +110,50 @@ func TestManifest_EmptyEventsAndSchedules_NotNull(t *testing.T) {
 	ManifestHandler("media", "Media", "perm_media", nil, nil, registry.New()).ServeHTTP(rec, req)
 
 	body := rec.Body.String()
-	for _, want := range []string{`"emits":[]`, `"subscribes":{}`, `"schedules":[]`, `"versions":{}`, `"permissions":[]`} {
+	// Note: "module" is omitempty on MigrationVersions and VersionEntry, so
+	// the empty manifest emits `"migration":{"app":""}` rather than
+	// `{"app":"","module":""}`. The "app" field is always present.
+	for _, want := range []string{`"emits":[]`, `"subscribes":{}`, `"schedules":[]`, `"versions":{}`, `"permissions":[]`, `"migration":{"app":""}`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("manifest body missing %q\nbody: %s", want, body)
 		}
 	}
 }
 
-func TestManifest_MigrationVersion(t *testing.T) {
+func TestManifest_MigrationVersions(t *testing.T) {
 	t.Parallel()
 
-	fsys := fstest.MapFS{
-		"sql/app/0000_initial.up.sql":   &fstest.MapFile{Data: []byte("")},
-		"sql/app/0008_add_index.up.sql": &fstest.MapFile{Data: []byte("")},
+	cases := []struct {
+		name string
+		fsys fstest.MapFS
+		want MigrationVersions
+	}{
+		{
+			name: "app only",
+			fsys: fstest.MapFS{
+				"sql/app/0000_initial.up.sql":   &fstest.MapFile{Data: []byte("")},
+				"sql/app/0008_add_index.up.sql": &fstest.MapFile{Data: []byte("")},
+			},
+			want: MigrationVersions{App: "0008", Module: ""},
+		},
+		{
+			name: "both scopes",
+			fsys: fstest.MapFS{
+				"sql/app/0000_initial.up.sql":   &fstest.MapFile{Data: []byte("")},
+				"sql/app/0008_add_index.up.sql": &fstest.MapFile{Data: []byte("")},
+				"sql/module/0000_outbox.up.sql": &fstest.MapFile{Data: []byte("")},
+				"sql/module/0003_dedup.up.sql":  &fstest.MapFile{Data: []byte("")},
+			},
+			want: MigrationVersions{App: "0008", Module: "0003"},
+		},
 	}
-
-	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", fsys, nil, registry.New()))
-
-	if got.Migration != "0008" {
-		t.Errorf("migration = %q, want 0008", got.Migration)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", tc.fsys, nil, registry.New()))
+			if got.Migration != tc.want {
+				t.Errorf("migration = %+v, want %+v", got.Migration, tc.want)
+			}
+		})
 	}
 }
 
@@ -136,8 +161,8 @@ func TestManifest_NilSQL_EmptyMigration(t *testing.T) {
 	t.Parallel()
 
 	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, nil, registry.New()))
-	if got.Migration != "" {
-		t.Errorf("migration = %q, want empty when SQL fs is nil", got.Migration)
+	if got.Migration.App != "" || got.Migration.Module != "" {
+		t.Errorf("migration = %+v, want both empty when SQL fs is nil", got.Migration)
 	}
 }
 
@@ -145,16 +170,25 @@ func TestManifest_Versions(t *testing.T) {
 	t.Parallel()
 
 	// Declared versions are surfaced verbatim — this is how the platform
-	// learns the semver→migration map it needs to translate deploy requests
-	// into the numeric migration IDs the lifecycle handlers require.
-	versions := map[string]string{"v0.1.0": "0008", "v0.2.0": "0012"}
+	// learns the semver→{app, module} map it needs to translate deploy
+	// requests into the numeric migration IDs the lifecycle handlers require.
+	// "v0.1.0" sets both tracks; "v0.2.0" only bumps the app track (the
+	// module schema is unchanged from v0.1.0). Module is omitempty so a
+	// caller that didn't set it serializes cleanly.
+	versions := map[string]MigrationVersions{
+		"v0.1.0": {App: "0008", Module: "0002"},
+		"v0.2.0": {App: "0012"},
+	}
 	got := decodeManifest(t, ManifestHandler("media", "Media", "perm_media", nil, versions, registry.New()))
 
 	if len(got.Versions) != 2 {
 		t.Fatalf("versions = %v, want 2 entries", got.Versions)
 	}
-	if got.Versions["v0.1.0"] != "0008" || got.Versions["v0.2.0"] != "0012" {
-		t.Errorf("versions map mismatch: %v", got.Versions)
+	if got.Versions["v0.1.0"].App != "0008" || got.Versions["v0.1.0"].Module != "0002" {
+		t.Errorf("v0.1.0 = %+v, want {0008 0002}", got.Versions["v0.1.0"])
+	}
+	if got.Versions["v0.2.0"].App != "0012" || got.Versions["v0.2.0"].Module != "" {
+		t.Errorf("v0.2.0 = %+v, want {0012 \"\"}", got.Versions["v0.2.0"])
 	}
 }
 


### PR DESCRIPTION
## Summary

**Stage 2 of 4 for #31** (per-module shared schema). Builds on Stage 1 (#55) which added the migration system's scope plumbing. Extends the manifest payload + \`Config.Versions\` to expose BOTH migration tracks.

## Wire-shape changes (BREAKING)

\`ManifestPayload.Migration\`:

\`\`\`json
// Before
{ "migration": "0008" }

// After
{ "migration": { "app": "0008", "module": "0003" } }
\`\`\`

\`Config.Versions\` / \`ManifestPayload.Versions\`:

\`\`\`go
// Before
map[string]string                   // {"v0.1.0": "0008"}

// After
map[string]system.MigrationVersions // {"v0.1.0": {App: "0008", Module: "0002"}}
\`\`\`

The \`module\` field is **\`omitempty\`** on \`MigrationVersions\`, so modules without cross-app shared state (the vast majority) get the same single-field shape they're used to: \`{\"app\":\"0008\"}\`.

A single \`MigrationVersions\` struct serves both \`ManifestPayload.Migration\` (current bundled version) and the per-tag entries in \`ManifestPayload.Versions\` — they're field-identical and a single type keeps the wire-shape evolution single-sourced.

## Changes

### \`system/manifest.go\`

- New \`MigrationVersions\` struct (\`App\` + \`Module\` string, \`Module\` omitempty)
- \`ManifestPayload.Migration\`: \`string\` → \`MigrationVersions\`
- \`ManifestPayload.Versions\`: \`map[string]string\` → \`map[string]MigrationVersions\`
- \`ManifestHandler\` reads \`sql/app/\` AND \`sql/module/\` via two \`LatestVersion\` calls; logs each scope's failure independently with a sanitized message
- Independent \`appErr\`/\`moduleErr\` locals (avoiding the err-shadowing footgun a future return-statement would hit)

### \`mirrorstack.go\`

- \`Config.Versions\`: \`map[string]string\` → \`map[string]system.MigrationVersions\`
- Doc example updated; doc reverted to \`/lifecycle/{upgrade,downgrade}\` (the \`/lifecycle/*/{upgrade,downgrade}\` scoped paths are Stage 3 work and don't exist yet)

### Tests

\`system/manifest_test.go\`:
- \`TestManifest_MigrationVersions\` is table-driven with two cases (app-only, both-scopes) — replaces the two single-purpose tests flagged for naming-convention violation in the \`/simplify\` pass on PR #59
- \`TestManifest_Versions\` updated for the new map value type, with coverage of the omitempty case (v0.2.0 omits \`Module\`)
- \`TestManifest_EmptyEventsAndSchedules_NotNull\` asserts \`\"migration\":{\"app\":\"\"}\` so consumers can rely on \`App\` always being present (\`Module\`'s omitempty is intentional)

\`mirrorstack_test.go\`:
- \`TestManifest_MigrationFromConfig\` single assertion update for the new struct shape

## Reviews applied (\`/simplify\`)

3 review agents (reuse / quality / efficiency). Findings addressed in this PR:

- **Reuse R1**: \`MigrationVersions\` and \`VersionEntry\` were field-for-field identical → collapsed to a single \`MigrationVersions\` type
- **Quality Q1**: \`err\` variable shadowing across two \`LatestVersion\` calls → renamed to \`appErr\`/\`moduleErr\`
- **Quality Q2**: stale forward-reference to \`/lifecycle/*/{upgrade,downgrade}\` (Stage 3 paths) → reverted to current \`/lifecycle/{upgrade,downgrade}\`
- **Quality Q3 + Reuse R5**: three-segment test names broke the file's two-segment convention → collapsed into one table-driven \`TestManifest_MigrationVersions\`
- **Quality Q4**: WHAT-narration on \`ManifestPayload.Migration\` doc → trimmed
- **Efficiency**: clean — no findings

Skipped: a \`migration.LatestVersions(fsys) MigrationVersions\` helper. Only one call site today; the scope-iteration helper doesn't pay off until Stage 3 introduces a second.

## Out of scope (next stages)

- Lifecycle endpoints applying both tracks (#57, Stage 3)
- \`Module.ModuleDB(ctx)\` public API (#58, Stage 4)

Stages must merge in order. Stage 3 is the next PR.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` all packages green
- [x] New table-driven test covers app-only AND both-scopes manifest output
- [x] omitempty wire shape pinned by \`TestManifest_EmptyEventsAndSchedules_NotNull\`
- [x] Existing assertions updated for the new struct shape

## Platform-side dependency

The platform's manifest consumer needs to update its \`migration\` field parser from \`string\` to \`{app, module}\` object before this lands. File a parallel issue in the platform repo before merging.

Closes #56. Sub-issue of #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)