### PR TITLE
feat(lifecycle): scope-namespaced endpoints app/* and module/* (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,10 @@ Keys auto-prefixed: developer writes `"views:123"`, Redis stores `"app_abc123:mo
 - [x] `health` — health check
 - [x] `platform/manifest` — module identity + capabilities
 - [ ] `platform/meter` — custom business metrics
-- [x] `platform/lifecycle/install` — fresh install on an app
-- [x] `platform/lifecycle/upgrade` — upgrade between versions
-- [x] `platform/lifecycle/downgrade` — rollback between versions
-- [x] `platform/lifecycle/uninstall` — soft-delete removal
+- [x] `platform/lifecycle/app/install` and `platform/lifecycle/module/install` — fresh install (per-app schema or per-module shared schema)
+- [x] `platform/lifecycle/app/upgrade` and `platform/lifecycle/module/upgrade` — upgrade between versions
+- [x] `platform/lifecycle/app/downgrade` and `platform/lifecycle/module/downgrade` — rollback between versions
+- [x] `platform/lifecycle/app/uninstall` and `platform/lifecycle/module/uninstall` — soft-delete removal
 
 ### MCP integration
 

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -38,6 +38,13 @@ func (s Scope) Dir() string {
 	return "sql/" + string(s)
 }
 
+// AllScopes returns the canonical ordering of migration scopes. Callers that
+// iterate every scope (manifest reporting, lifecycle endpoint mounting, etc.)
+// should use this so a future scope addition is picked up automatically.
+func AllScopes() []Scope {
+	return []Scope{ScopeApp, ScopeModule}
+}
+
 // upFilePattern matches up-migration files named like "0000_initial.up.sql".
 // The leading numeric prefix is the version, the middle slug is the human name.
 var upFilePattern = regexp.MustCompile(`^(\d+)_(.+)\.up\.sql$`)

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
@@ -370,10 +371,17 @@ func (m *Module) mountSystemRoutes() {
 				m.config.SQL, m.config.Versions, m.registry,
 			))
 			r.Route("/lifecycle", func(r chi.Router) {
-				r.Post("/install", system.InstallHandler(m.config.SQL, m.Tx))
-				r.Post("/upgrade", system.UpgradeHandler(m.config.SQL, m.Tx))
-				r.Post("/downgrade", system.DowngradeHandler(m.config.SQL, m.Tx))
-				r.Post("/uninstall", system.UninstallHandler())
+				// App and module migrations are separate tracks on disjoint
+				// directories; mount the same four endpoints under each scope
+				// so the platform can drive them independently.
+				for _, scope := range migration.AllScopes() {
+					r.Route("/"+string(scope), func(r chi.Router) {
+						r.Post("/install", system.InstallHandler(m.config.SQL, scope, m.Tx))
+						r.Post("/upgrade", system.UpgradeHandler(m.config.SQL, scope, m.Tx))
+						r.Post("/downgrade", system.DowngradeHandler(m.config.SQL, scope, m.Tx))
+						r.Post("/uninstall", system.UninstallHandler()) // no scope — no-op for both
+					})
+				}
 			})
 		})
 	})

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/system"
 )
@@ -372,25 +373,29 @@ func TestManifest_MigrationFromConfig(t *testing.T) {
 }
 
 // --- Lifecycle endpoints ---
+//
+// Each test below covers BOTH the /lifecycle/app/* and /lifecycle/module/*
+// scope namespaces. The behavior is identical across scopes — only the
+// migration directory the handler reads from changes — so a single table
+// drives both. A regression that mounts only one scope, or that wires the
+// wrong handler under one of the namespaces, fails the loop here. Iteration
+// is keyed off migration.AllScopes() so a future scope addition is picked
+// up automatically.
 
 func TestLifecycle_RoutesRequireInternalSecret(t *testing.T) {
 	t.Setenv("MS_INTERNAL_SECRET", "secret")
 	m, _ := New(Config{ID: "test"})
 
-	// All four lifecycle routes should reject requests without the secret.
-	routes := []string{
-		"/__mirrorstack/platform/lifecycle/install",
-		"/__mirrorstack/platform/lifecycle/upgrade",
-		"/__mirrorstack/platform/lifecycle/downgrade",
-		"/__mirrorstack/platform/lifecycle/uninstall",
-	}
-	for _, route := range routes {
-		t.Run(route, func(t *testing.T) {
-			rec := doRequest(t, m.Router(), "POST", route)
-			if rec.Code != http.StatusUnauthorized {
-				t.Errorf("status = %d, want 401", rec.Code)
-			}
-		})
+	for _, scope := range migration.AllScopes() {
+		for _, action := range []string{"install", "upgrade", "downgrade", "uninstall"} {
+			route := "/__mirrorstack/platform/lifecycle/" + string(scope) + "/" + action
+			t.Run(route, func(t *testing.T) {
+				rec := doRequest(t, m.Router(), "POST", route)
+				if rec.Code != http.StatusUnauthorized {
+					t.Errorf("status = %d, want 401", rec.Code)
+				}
+			})
+		}
 	}
 }
 
@@ -398,12 +403,16 @@ func TestLifecycle_UninstallReturnsOK(t *testing.T) {
 	t.Setenv("MS_INTERNAL_SECRET", "secret")
 	m, _ := New(Config{ID: "test"})
 
-	rec := doRequestWithSecret(t, m.Router(), "POST", "/__mirrorstack/platform/lifecycle/uninstall", "secret")
-	if rec.Code != 200 {
-		t.Fatalf("status = %d, want 200", rec.Code)
-	}
-	if !strings.Contains(rec.Body.String(), `"status":"ok"`) {
-		t.Errorf("body = %s, want status:ok", rec.Body.String())
+	for _, scope := range migration.AllScopes() {
+		t.Run(string(scope), func(t *testing.T) {
+			rec := doRequestWithSecret(t, m.Router(), "POST", "/__mirrorstack/platform/lifecycle/"+string(scope)+"/uninstall", "secret")
+			if rec.Code != 200 {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if !strings.Contains(rec.Body.String(), `"status":"ok"`) {
+				t.Errorf("body = %s, want status:ok", rec.Body.String())
+			}
+		})
 	}
 }
 
@@ -412,9 +421,13 @@ func TestLifecycle_InstallEmptyFSReturnsOK(t *testing.T) {
 	// No SQL configured → install is a no-op (no migrations to apply).
 	m, _ := New(Config{ID: "test"})
 
-	rec := doRequestWithSecret(t, m.Router(), "POST", "/__mirrorstack/platform/lifecycle/install", "secret")
-	if rec.Code != 200 {
-		t.Fatalf("status = %d, want 200, body = %s", rec.Code, rec.Body.String())
+	for _, scope := range migration.AllScopes() {
+		t.Run(string(scope), func(t *testing.T) {
+			rec := doRequestWithSecret(t, m.Router(), "POST", "/__mirrorstack/platform/lifecycle/"+string(scope)+"/install", "secret")
+			if rec.Code != 200 {
+				t.Fatalf("status = %d, want 200, body = %s", rec.Code, rec.Body.String())
+			}
+		})
 	}
 }
 
@@ -422,14 +435,18 @@ func TestLifecycle_UpgradeRequiresPayload(t *testing.T) {
 	t.Setenv("MS_INTERNAL_SECRET", "secret")
 	m, _ := New(Config{ID: "test"})
 
-	// No body → 400
-	req := httptest.NewRequest("POST", "/__mirrorstack/platform/lifecycle/upgrade", nil)
-	req.Header.Set("X-MS-Internal-Secret", "secret")
-	rec := httptest.NewRecorder()
-	m.Router().ServeHTTP(rec, req)
+	for _, scope := range migration.AllScopes() {
+		t.Run(string(scope), func(t *testing.T) {
+			// No body → 400
+			req := httptest.NewRequest("POST", "/__mirrorstack/platform/lifecycle/"+string(scope)+"/upgrade", nil)
+			req.Header.Set("X-MS-Internal-Secret", "secret")
+			rec := httptest.NewRecorder()
+			m.Router().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want 400", rec.Code)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
+			}
+		})
 	}
 }
 
@@ -520,7 +537,7 @@ func TestPlatformRoutes_MaxBytesLimit(t *testing.T) {
 	// build valid JSON > 64 KB — json.Decode reads it all before failing, triggering MaxBytesReader
 	padding := strings.Repeat("a", 64*1024)
 	bigJSON := `{"from":"` + padding + `","to":"0001"}`
-	req := httptest.NewRequest("POST", "/__mirrorstack/platform/lifecycle/upgrade", strings.NewReader(bigJSON))
+	req := httptest.NewRequest("POST", "/__mirrorstack/platform/lifecycle/app/upgrade", strings.NewReader(bigJSON))
 	req.Header.Set("X-MS-Internal-Secret", "secret")
 	rec := httptest.NewRecorder()
 	m.Router().ServeHTTP(rec, req)

--- a/system/lifecycle.go
+++ b/system/lifecycle.go
@@ -46,13 +46,13 @@ type UninstallResult struct {
 //
 // The SDK does NOT track which migrations were previously applied — it is a
 // stateless executor. The platform decides when install is appropriate (a
-// fresh app) based on its own state store and only calls install once per
-// app. Calling install twice will re-run every migration and likely fail
-// with "relation already exists" — platform-side saga logic is responsible
-// for preventing that.
-func InstallHandler(sqlFS fs.FS, runTx migration.TxRunner) http.HandlerFunc {
+// fresh app, or first deploy of a module) based on its own state store and
+// calls install at most once per (scope, target). Calling install twice
+// will re-run every migration and likely fail with "relation already exists"
+// — platform-side saga logic is responsible for preventing that.
+func InstallHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		migrations, err := migration.List(sqlFS, migration.ScopeApp)
+		migrations, err := migration.List(sqlFS, scope)
 		if err != nil {
 			httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: err.Error()})
 			return
@@ -72,15 +72,15 @@ func InstallHandler(sqlFS fs.FS, runTx migration.TxRunner) http.HandlerFunc {
 // UpgradeHandler applies the migrations strictly between (req.From, req.To].
 // Both fields must be migration numbers; semver must be translated by the
 // platform before calling this endpoint (the platform reads the Versions map
-// from the manifest endpoint to do the translation).
-func UpgradeHandler(sqlFS fs.FS, runTx migration.TxRunner) http.HandlerFunc {
+// from the manifest and uses the scope-matching field of MigrationVersions).
+func UpgradeHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		req, ok := decodeVersionRequest(w, r)
 		if !ok {
 			return
 		}
 
-		migrations, err := migration.List(sqlFS, migration.ScopeApp)
+		migrations, err := migration.List(sqlFS, scope)
 		if err != nil {
 			httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: err.Error()})
 			return
@@ -106,14 +106,14 @@ func UpgradeHandler(sqlFS fs.FS, runTx migration.TxRunner) http.HandlerFunc {
 // DowngradeHandler reverts migrations between (req.To, req.From] in newest-first
 // order. Each migration must have a .down.sql or the request fails before any
 // SQL runs. Both fields must be migration numbers (see UpgradeHandler).
-func DowngradeHandler(sqlFS fs.FS, runTx migration.TxRunner) http.HandlerFunc {
+func DowngradeHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		req, ok := decodeVersionRequest(w, r)
 		if !ok {
 			return
 		}
 
-		migrations, err := migration.List(sqlFS, migration.ScopeApp)
+		migrations, err := migration.List(sqlFS, scope)
 		if err != nil {
 			httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: err.Error()})
 			return

--- a/system/lifecycle_test.go
+++ b/system/lifecycle_test.go
@@ -37,7 +37,7 @@ func noopTxRunner(t *testing.T) migration.TxRunner {
 func TestInstallHandler_EmptyFS(t *testing.T) {
 	t.Parallel()
 
-	h := InstallHandler(nil, noopTxRunner(t))
+	h := InstallHandler(nil, migration.ScopeApp, noopTxRunner(t))
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", nil))
@@ -71,7 +71,7 @@ func TestUpgradeHandler_RequiresFromTo(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			h := UpgradeHandler(nil, noopTxRunner(t))
+			h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t))
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", strings.NewReader(tc.body)))
 
@@ -100,7 +100,7 @@ func TestUpgradeHandler_RejectsSemver(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			h := UpgradeHandler(nil, noopTxRunner(t))
+			h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t))
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", strings.NewReader(tc.body)))
 
@@ -121,7 +121,7 @@ func TestUpgradeHandler_UnknownTarget(t *testing.T) {
 	// doesn't exist in the (empty) migrations list. The handler must
 	// translate the runner's error into a 400 (caller asked for something
 	// the module doesn't have).
-	h := UpgradeHandler(nil, noopTxRunner(t))
+	h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t))
 	body := strings.NewReader(`{"from": "0000", "to": "0001"}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
@@ -140,7 +140,7 @@ func TestUpgradeHandler_NoOp(t *testing.T) {
 	fsys := fstest.MapFS{
 		"sql/app/0008_a.up.sql": &fstest.MapFile{Data: []byte("")},
 	}
-	h := UpgradeHandler(fsys, noopTxRunner(t))
+	h := UpgradeHandler(fsys, migration.ScopeApp, noopTxRunner(t))
 	body := strings.NewReader(`{"from": "0008", "to": "0008"}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
@@ -162,7 +162,7 @@ func TestDowngradeHandler_RequiresFromGreaterThanTo(t *testing.T) {
 		"sql/app/0001_a.up.sql":   &fstest.MapFile{Data: []byte("")},
 		"sql/app/0001_a.down.sql": &fstest.MapFile{Data: []byte("")},
 	}
-	h := DowngradeHandler(fsys, noopTxRunner(t))
+	h := DowngradeHandler(fsys, migration.ScopeApp, noopTxRunner(t))
 
 	// from=0001, to=0001 → not a downgrade → 400
 	body := strings.NewReader(`{"from": "0001", "to": "0001"}`)
@@ -193,12 +193,35 @@ func TestUninstallHandler_AlwaysSucceeds(t *testing.T) {
 	}
 }
 
+func TestUpgradeHandler_ModuleScope(t *testing.T) {
+	t.Parallel()
+
+	// Same shape as TestUpgradeHandler_NoOp but for the module scope.
+	// Pins that the scope parameter is wired all the way through:
+	// the handler reads sql/module/ when scope=ScopeModule, NOT sql/app/.
+	// If the wiring is wrong, ScopeModule would read sql/app/0008_a.up.sql,
+	// find the version, and the test still passes — so the fixture has
+	// 0008 ONLY in sql/module/ to make a misrouted read fail with
+	// "unknown target version 0008".
+	fsys := fstest.MapFS{
+		"sql/module/0008_a.up.sql": &fstest.MapFile{Data: []byte("")},
+	}
+	h := UpgradeHandler(fsys, migration.ScopeModule, noopTxRunner(t))
+	body := strings.NewReader(`{"from": "0008", "to": "0008"}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
+
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200 (no-op upgrade on module scope)", rec.Code)
+	}
+}
+
 func TestInstallHandler_BadFS_500(t *testing.T) {
 	t.Parallel()
 
 	// fs.FS that returns an error on every Open. fs.ReadDir wraps and
 	// surfaces the error — the handler should respond 500.
-	h := InstallHandler(errFS{}, noopTxRunner(t))
+	h := InstallHandler(errFS{}, migration.ScopeApp, noopTxRunner(t))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", nil))
 


### PR DESCRIPTION
## Summary

**Stage 3 of 4 for #31** (per-module shared schema). Adds module-scoped lifecycle endpoints alongside the existing app-scoped ones, renames the existing endpoints under \`/lifecycle/app/\` for symmetry. Builds on Stage 1 (#55, migration system extension) and Stage 2 (#56, manifest exposes both versions).

## Wire-shape changes (BREAKING)

\`\`\`
Before                                       After
POST /lifecycle/install                      POST /lifecycle/app/install (renamed)
POST /lifecycle/upgrade                      POST /lifecycle/app/upgrade
POST /lifecycle/downgrade                    POST /lifecycle/app/downgrade
POST /lifecycle/uninstall                    POST /lifecycle/app/uninstall
                                             + POST /lifecycle/module/install (new)
                                             + POST /lifecycle/module/upgrade
                                             + POST /lifecycle/module/downgrade
                                             + POST /lifecycle/module/uninstall
\`\`\`

The \`{from, to}\` body shape is identical across scopes — only the migration directory the handler reads from changes (\`sql/app/\` vs \`sql/module/\`).

## Changes

### \`system/lifecycle.go\`
- \`InstallHandler\`/\`UpgradeHandler\`/\`DowngradeHandler\` take a \`migration.Scope\` parameter; the scope is passed to \`migration.List\`
- \`UninstallHandler\` unchanged (no-op for both scopes)

### \`mirrorstack.go\`
- \`mountSystemRoutes\` loops \`migration.AllScopes()\` and mounts the four endpoints under each scope's \`/lifecycle/{app,module}/\` subtree
- Drops the unnecessary \`scope := scope\` rebind (Go 1.26 has per-iteration loop scoping)

### \`internal/migration/migration.go\`
- New \`AllScopes()\` helper returns the canonical \`[ScopeApp, ScopeModule]\` iteration order. Single source of truth for any code that wants to iterate every migration scope.

## Tests

### \`system/lifecycle_test.go\`
- All handler test calls pass \`migration.ScopeApp\` explicitly
- New \`TestUpgradeHandler_ModuleScope\` pins the scope-routing contract: a module-scope handler reads \`sql/module/\`, NOT \`sql/app/\`. The fixture has \`0008\` only in \`sql/module/\` so a misrouted read fails with \"unknown target version 0008\"

### \`mirrorstack_test.go\`
- \`TestLifecycle_RoutesRequireInternalSecret\`, \`_UninstallReturnsOK\`, \`_InstallEmptyFSReturnsOK\`, \`_UpgradeRequiresPayload\` all loop \`migration.AllScopes()\` — every assertion runs against both \`/lifecycle/app/*\` and \`/lifecycle/module/*\`
- \`TestPlatformRoutes_MaxBytesLimit\` (PR #50) updated to use the new app-scoped path

### \`README.md\`
- Roadmap checkboxes updated to spell out both scopes per endpoint

## Reviews applied (\`/simplify\`)

3 review agents (reuse / quality / efficiency). Findings addressed in this PR:

- **Reuse R1 + Quality Q4**: collapsed inline scope slices into \`migration.AllScopes()\` helper
- **Reuse R3 + Quality Q5 + Efficiency**: dropped unnecessary \`scope := scope\` rebind under Go 1.26
- **Quality Q1-Q3**: trimmed WHAT-narration from handler doc comments
- **Quality Q4**: removed forward-looking \`mod_<id>\` reference from \`mountSystemRoutes\` block comment (Stage 4 work)
- **Quality Q6**: added inline \`// no scope — no-op for both\` on the \`UninstallHandler\` line so the asymmetry is obvious
- **Quality Q7**: renamed \`TestUpgradeHandler_ModuleScope_NoOp\` → \`TestUpgradeHandler_ModuleScope\` (two-segment naming)
- **Quality Q8**: typed \`lifecycleScopes\` through \`migration.AllScopes()\` with \`string(scope)\` at URL-construction sites
- **Quality Q10**: README brace expansion → spelled out

Skipped: **Quality Q9** (collapse 4 lifecycle tests into one mega-table) — reuse reviewer disagreed: per-action structure is clearer than one mega-table where each row needs its own assertion closure.

## Out of scope (next stage)

- \`Module.ModuleDB(ctx)\` public API (#58, Stage 4)

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` all packages green
- [x] New \`TestUpgradeHandler_ModuleScope\` proves scope routing
- [x] All existing lifecycle tests now run against both scopes via \`migration.AllScopes()\`

## Platform-side dependency

Platform's lifecycle caller needs to update from \`POST /lifecycle/install\` to \`POST /lifecycle/app/install\` (and start calling \`/lifecycle/module/install\` for modules with cross-app shared state). Breaking change in lockstep — file a parallel issue in the platform repo before merging.

Closes #57. Sub-issue of #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)