### PR TITLE
feat(db): Module.ModuleDB(ctx) + ModuleCredential (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ err := ms.Tx(r.Context(), func(q db.Querier) error {
 })
 ```
 
+### Module-shared schema (`mod_<id>`)
+
+For state that crosses app boundaries — outbox tables, dedup ledgers,
+cross-app audit logs, rate limiters, module-wide config — use `ms.ModuleDB`
+and `ms.ModuleTx`:
+
+```go
+// Insert into the module's shared outbox table
+err := ms.ModuleTx(r.Context(), func(q db.Querier) error {
+    return q.Exec(ctx, "INSERT INTO outbox (event, payload) VALUES ($1, $2)", ...)
+})
+```
+
+`ModuleDB` and `ModuleTx` operate on the module's `mod_<id>` schema — independent
+of the per-app `app_<id>` schema that `DB`/`Tx` use. A handler that needs both
+calls both — they use independent credentials and don't interfere.
+
+The `mod_<id>` schema is where you put `sql/module/*.up.sql` migrations
+(see Module structure below).
+
+#### Platform role grant contract
+
+The SDK relies on the platform provisioning two distinct DB roles per
+deployed module with disjoint privileges:
+
+| Role | Schema | Granted via |
+|------|--------|-------------|
+| Per-(module, app) | `app_<appID>` only | injected as `db.Credential` for `Module.DB` / `Module.Tx` |
+| Per-module | `mod_<moduleID>` only | injected as `db.Credential` for `Module.ModuleDB` / `Module.ModuleTx` |
+
+Cross-credential contamination (e.g., a misrouted app credential reaching
+`ModuleDB`) is caught by Postgres at the SQL layer because the per-(module,
+app) role lacks `USAGE` on `mod_<id>` — defense-in-depth, no SDK enforcement
+required. Verify your platform-side role provisioning keeps the two grant
+sets disjoint.
+
 ### Security (3-layer isolation)
 
 | Layer | What | How |
@@ -275,9 +311,13 @@ app-module-sdk/
 
 ```
 app-mod-{name}/
-  sql/                         Migrations (auto-applied)
-    0000_initial.up.sql
-    0000_initial.down.sql
+  sql/
+    app/                       Per-app migrations (one app_<id> schema per tenant)
+      0000_initial.up.sql
+      0000_initial.down.sql
+    module/                    Per-module migrations (single mod_<id> shared schema)
+      0000_outbox.up.sql       e.g. outbox, dedup ledgers, audit logs
+      0000_outbox.down.sql
     queries/                   sqlc query definitions
   api/                         Go backend
     cmd/main.go

--- a/db/credential.go
+++ b/db/credential.go
@@ -8,11 +8,16 @@ import (
 type contextKey string
 
 const (
-	schemaKey     = contextKey("ms-app-schema")
-	credentialKey = contextKey("ms-db-credential")
+	schemaKey           = contextKey("ms-app-schema")
+	credentialKey       = contextKey("ms-db-credential")
+	moduleCredentialKey = contextKey("ms-db-module-credential")
 )
 
-// Credential holds per-invocation database credentials injected by the platform.
+// Credential holds per-invocation database credentials injected by the
+// platform. The same struct serves both per-app and per-module credentials,
+// distinguished by the context key they live under (credentialKey vs
+// moduleCredentialKey). Different DB usernames separate pool cache keys
+// naturally — no flag on the struct is needed.
 type Credential struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
@@ -46,13 +51,29 @@ func SchemaFrom(ctx context.Context) string {
 	return s
 }
 
-// WithCredential returns a context with the DB credential set.
+// WithCredential returns a context with the per-app DB credential set.
+// Used by the platform's Lambda invoke shim before calling the module
+// handler, so Module.DB / Module.Tx can scope queries to the app schema.
 func WithCredential(ctx context.Context, cred Credential) context.Context {
 	return context.WithValue(ctx, credentialKey, &cred)
 }
 
-// CredentialFrom reads the DB credential from the context.
+// CredentialFrom reads the per-app DB credential from the context.
 func CredentialFrom(ctx context.Context) *Credential {
 	c, _ := ctx.Value(credentialKey).(*Credential)
+	return c
+}
+
+// WithModuleCredential returns a context with the per-module DB credential
+// set. Used by the platform's Lambda invoke shim for handlers that touch
+// the module's cross-app shared schema (mod_<id>). The use cases live on
+// Module.ModuleDB; this function only handles credential injection.
+func WithModuleCredential(ctx context.Context, cred Credential) context.Context {
+	return context.WithValue(ctx, moduleCredentialKey, &cred)
+}
+
+// ModuleCredentialFrom reads the per-module DB credential from the context.
+func ModuleCredentialFrom(ctx context.Context) *Credential {
+	c, _ := ctx.Value(moduleCredentialKey).(*Credential)
 	return c
 }

--- a/db/credential_test.go
+++ b/db/credential_test.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithCredential_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cred := Credential{Host: "h", Port: 5432, Database: "d", Username: "app_user", Token: "tok"}
+	ctx := WithCredential(context.Background(), cred)
+
+	got := CredentialFrom(ctx)
+	if got == nil {
+		t.Fatal("CredentialFrom returned nil")
+	}
+	if got.Username != "app_user" {
+		t.Errorf("Username = %q, want app_user", got.Username)
+	}
+
+	// ModuleCredentialFrom on the same context must NOT see the app credential.
+	if mod := ModuleCredentialFrom(ctx); mod != nil {
+		t.Errorf("ModuleCredentialFrom returned %+v on app-only context, want nil", mod)
+	}
+}
+
+func TestWithModuleCredential_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cred := Credential{Host: "h", Port: 5432, Database: "d", Username: "mod_user", Token: "tok"}
+	ctx := WithModuleCredential(context.Background(), cred)
+
+	got := ModuleCredentialFrom(ctx)
+	if got == nil {
+		t.Fatal("ModuleCredentialFrom returned nil")
+	}
+	if got.Username != "mod_user" {
+		t.Errorf("Username = %q, want mod_user", got.Username)
+	}
+
+	// CredentialFrom on the same context must NOT see the module credential.
+	if app := CredentialFrom(ctx); app != nil {
+		t.Errorf("CredentialFrom returned %+v on module-only context, want nil", app)
+	}
+}
+
+func TestWithCredential_BothScopesCoexist(t *testing.T) {
+	t.Parallel()
+
+	// A handler that needs both app and module data gets both credentials
+	// in its context. The two context keys are independent — setting one
+	// must not overwrite the other.
+	appCred := Credential{Host: "h", Port: 5432, Database: "d", Username: "app_user", Token: "atok"}
+	modCred := Credential{Host: "h", Port: 5432, Database: "d", Username: "mod_user", Token: "mtok"}
+
+	ctx := WithCredential(context.Background(), appCred)
+	ctx = WithModuleCredential(ctx, modCred)
+
+	gotApp := CredentialFrom(ctx)
+	if gotApp == nil || gotApp.Username != "app_user" {
+		t.Errorf("CredentialFrom = %+v, want app_user", gotApp)
+	}
+	gotMod := ModuleCredentialFrom(ctx)
+	if gotMod == nil || gotMod.Username != "mod_user" {
+		t.Errorf("ModuleCredentialFrom = %+v, want mod_user", gotMod)
+	}
+}
+
+func TestModuleCredentialFrom_NoCredential(t *testing.T) {
+	t.Parallel()
+
+	if got := ModuleCredentialFrom(context.Background()); got != nil {
+		t.Errorf("ModuleCredentialFrom on bare context = %+v, want nil", got)
+	}
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -127,7 +127,10 @@ func (m *Module) DB(ctx context.Context) (db.Querier, func(), error) {
 	}, nil
 }
 
-// Tx runs fn inside a transaction with schema isolation. Commits on success, rolls back on error.
+// Tx runs fn inside a transaction with schema isolation. Commits on success,
+// rolls back on error. The app schema is read from the caller's context (set
+// by the platform's Lambda invoke shim via db.WithSchema). Compare with
+// Module.ModuleTx which explicitly overlays the mod_<id> schema.
 //
 //	err := mod.Tx(r.Context(), func(q db.Querier) error {
 //	    queries := generated.New(q)
@@ -144,17 +147,22 @@ func (m *Module) Tx(ctx context.Context, fn func(q db.Querier) error) error {
 	return db.Tx(ctx, pool, fn)
 }
 
-// resolvePool returns the right pool plus a release closure: per-app credential
-// pool (production, refcount-pinned) or dev-mode pool (no-op release).
-// Thread-safe via sync.Once for dev init.
+// resolvePool returns the per-app credential pool (production) or the dev
+// pool (dev mode). See resolvePoolFor for the shared logic.
 func (m *Module) resolvePool(ctx context.Context) (*pgxpool.Pool, func(), error) {
-	// Production: credential injected per invocation. PoolCache.Get returns
-	// a refcount-pinned pool — caller MUST run the release closure.
-	if cred := db.CredentialFrom(ctx); cred != nil {
+	return m.resolvePoolFor(ctx, db.CredentialFrom)
+}
+
+// resolvePoolFor is the shared implementation behind resolvePool and
+// resolveModulePool. Production reads a credential from the context via
+// getCred (different context key per scope) and pulls a refcount-pinned
+// pool from the cache. Dev mode falls through to the single dev pool, which
+// is shared across all scopes — schema isolation in dev happens at the
+// AcquireScoped layer via WithSchema, not at the pool level.
+func (m *Module) resolvePoolFor(ctx context.Context, getCred func(context.Context) *db.Credential) (*pgxpool.Pool, func(), error) {
+	if cred := getCred(ctx); cred != nil {
 		return m.poolCache.Get(ctx, *cred)
 	}
-
-	// Dev mode: single pool from DATABASE_URL, init once. No refcount needed.
 	m.devDBOnce.Do(func() {
 		m.devDB, m.devDBErr = db.Open(context.Background())
 	})
@@ -162,6 +170,78 @@ func (m *Module) resolvePool(ctx context.Context) (*pgxpool.Pool, func(), error)
 		return nil, nil, m.devDBErr
 	}
 	return m.devDB.Pool(), func() {}, nil
+}
+
+// ModuleDB returns a connection scoped to this module's shared schema
+// (mod_<id>). Use it for cross-app state — outbox tables, dedup ledgers,
+// cross-app audit logs, rate limiters, module-wide config — anything a
+// module needs that is owned by the module rather than by a single app.
+//
+// Production: uses the per-module credential injected by the platform via
+// db.WithModuleCredential. Independent of the per-app credential read by
+// Module.DB — a handler that needs both gets both, in the same context.
+//
+// Dev: shares the dev pool from DATABASE_URL with Module.DB; the schema is
+// the only difference. The dev Postgres must have a mod_<id> schema for
+// the queries to succeed.
+//
+// The module schema overlays any app schema set on the caller's context for
+// this single call only — the caller's ctx is not mutated, so a subsequent
+// Module.DB call sees the original app schema unchanged.
+//
+//	conn, release, err := mod.ModuleDB(r.Context())
+//	if err != nil { ... }
+//	defer release()
+//	conn.Exec(ctx, "INSERT INTO outbox(...) VALUES(...)")
+func (m *Module) ModuleDB(ctx context.Context) (db.Querier, func(), error) {
+	pool, releasePool, err := m.resolveModulePool(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	moduleCtx := db.WithSchema(ctx, m.moduleSchema())
+	querier, releaseConn, err := db.AcquireScoped(moduleCtx, pool)
+	if err != nil {
+		releasePool()
+		return nil, nil, err
+	}
+	return querier, func() {
+		releaseConn()
+		releasePool()
+	}, nil
+}
+
+// ModuleTx runs fn inside a transaction scoped to the module's shared schema
+// (mod_<id>). Commits on success, rolls back on error or panic. Use this for
+// the outbox-pattern: insert the work record AND the dedup row in the same
+// transaction so the worker only ever sees consistent state.
+//
+//	err := mod.ModuleTx(r.Context(), func(q db.Querier) error {
+//	    queries := generated.New(q)
+//	    if err := queries.InsertOutbox(ctx, ...); err != nil { return err }
+//	    return queries.MarkProcessed(ctx, ...)
+//	})
+func (m *Module) ModuleTx(ctx context.Context, fn func(q db.Querier) error) error {
+	pool, releasePool, err := m.resolveModulePool(ctx)
+	if err != nil {
+		return err
+	}
+	defer releasePool()
+	moduleCtx := db.WithSchema(ctx, m.moduleSchema())
+	return db.Tx(moduleCtx, pool, fn)
+}
+
+// resolveModulePool reads the per-module credential instead of the per-app
+// one. See resolvePoolFor for the shared logic.
+func (m *Module) resolveModulePool(ctx context.Context) (*pgxpool.Pool, func(), error) {
+	return m.resolvePoolFor(ctx, db.ModuleCredentialFrom)
+}
+
+// moduleSchema returns the Postgres schema name for this module's shared
+// state. Convention: "mod_" + the developer's Config.ID. The platform must
+// pre-create this schema and grant the per-module DB role USAGE on it
+// before any module handler runs.
+func (m *Module) moduleSchema() string {
+	return "mod_" + m.config.ID
 }
 
 // Cache returns a scoped cache client. Keys are auto-prefixed with {appID}:{moduleID}:.
@@ -427,6 +507,18 @@ func DB(ctx context.Context) (db.Querier, func(), error) {
 // Tx runs fn inside a transaction on the default module.
 func Tx(ctx context.Context, fn func(q db.Querier) error) error {
 	return mustDefault("Tx").Tx(ctx, fn)
+}
+
+// ModuleDB returns a connection scoped to the module's shared schema on the
+// default module.
+func ModuleDB(ctx context.Context) (db.Querier, func(), error) {
+	return mustDefault("ModuleDB").ModuleDB(ctx)
+}
+
+// ModuleTx runs fn inside a transaction scoped to the module's shared schema
+// on the default module.
+func ModuleTx(ctx context.Context, fn func(q db.Querier) error) error {
+	return mustDefault("ModuleTx").ModuleTx(ctx, fn)
 }
 
 // Cache returns a scoped cache client on the default module.

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -1,6 +1,7 @@
 package mirrorstack
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/system"
@@ -556,6 +558,8 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"OnEvent":           func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) },
 		"Emits":             func() { Emits("created") },
 		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
+		"ModuleDB":          func() { _, _, _ = ModuleDB(context.Background()) },
+		"ModuleTx":          func() { _ = ModuleTx(context.Background(), func(q db.Querier) error { return nil }) },
 	}
 	for name, fn := range fns {
 		t.Run(name, func(t *testing.T) {
@@ -566,6 +570,31 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 				}
 			}()
 			fn()
+		})
+	}
+}
+
+func TestModule_ModuleSchema(t *testing.T) {
+	t.Parallel()
+
+	// Pin the schema-naming convention: mod_<id>. The platform's per-module
+	// DB role provisioning depends on this exact format being predictable
+	// from Config.ID alone — a future change here would require lockstep
+	// updates to platform-side role-creation scripts.
+	cases := []struct {
+		id   string
+		want string
+	}{
+		{"media", "mod_media"},
+		{"oauth", "mod_oauth"},
+		{"billing_engine", "mod_billing_engine"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			m, _ := New(Config{ID: tc.id})
+			if got := m.moduleSchema(); got != tc.want {
+				t.Errorf("moduleSchema() = %q, want %q", got, tc.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

**Stage 4 of 4 for #31** (per-module shared schema). **Final stage.** Adds the user-facing API for accessing the module's shared schema (\`mod_<id>\`). Builds on Stages 1-3 (#55 migration split, #56 manifest payload, #57 lifecycle endpoint namespacing — all merged).

## API

\`\`\`go
// Existing — scoped to current app's schema (app_<id>)
conn, release, err := mod.DB(r.Context())
err := mod.Tx(r.Context(), func(q db.Querier) error { ... })

// New — scoped to module's shared schema (mod_<id>)
conn, release, err := mod.ModuleDB(r.Context())
err := mod.ModuleTx(r.Context(), func(q db.Querier) error { ... })
\`\`\`

A handler that needs both calls both — they use independent credentials and don't interfere. Top-level convenience wrappers \`ms.ModuleDB\` / \`ms.ModuleTx\` mirror \`ms.DB\` / \`ms.Tx\`.

## Credential model

The same \`db.Credential\` struct serves both per-app and per-module credentials, distinguished by the **context key** they live under (\`credentialKey\` vs \`moduleCredentialKey\`). Different DB usernames separate pool cache keys naturally — no flag on the struct needed.

\`\`\`go
func WithModuleCredential(ctx, cred) context.Context  // platform shim sets
func ModuleCredentialFrom(ctx) *Credential            // SDK reads
\`\`\`

## Module struct changes

\`Module.poolCache\` is shared between \`Module.DB\` and \`Module.ModuleDB\`. The cache key (\`host:port/db/user\`) naturally separates the per-(module, app) and per-module roles into distinct pool entries.

In dev mode, the single dev pool from \`DATABASE_URL\` serves both scopes; the schema differentiation happens at \`AcquireScoped\` time via \`WithSchema\` overlay (the original ctx is not mutated).

## Reviews applied (\`/simplify\`)

3 review agents (reuse / quality / efficiency+security). Findings addressed:

- **Reuse R1**: extracted \`resolvePoolFor\` helper to deduplicate \`resolvePool\` and \`resolveModulePool\` — both now thin wrappers passing the right credential getter through. Removes ~12 duplicated lines.
- **Reuse R3**: clarified \`Module.Tx\` doc that the app schema is expected upstream, mirroring \`ModuleTx\`'s explicit overlay
- **Reuse R6**: added a one-line note to \`Module.ModuleDB\` doc explaining the schema overlay is local to the call (caller's ctx not mutated)
- **Quality Q2**: trimmed the duplicated \"outbox/dedup/audit/rate-limit\" enumeration from \`db.WithModuleCredential\` — kept canonical on \`Module.ModuleDB\`
- **Quality Q5**: trimmed the \`Credential\` struct doc paragraph
- **Security #6 + #9**: added a \"Platform role grant contract\" section to the README documenting the disjoint role/grant model and the defense-in-depth at the Postgres permission layer

### Deferred (filed as #62)

- **\`Config.ID\` regex validation in \`New()\`** — both quality and security reviewers flagged the lack of validation as a footgun (a malformed ID becomes a Postgres-quoted garbage schema name; no injection but confusing runtime errors). Filed separately because the fix benefits BOTH the existing \`app_<id>\` path and the new \`mod_<id>\` path — a focused cross-cutting cleanup deserves its own PR.

## Tests

- \`db/credential_test.go\` (NEW): round-trip tests for both \`WithCredential\`/\`WithModuleCredential\`, plus the load-bearing \`TestWithCredential_BothScopesCoexist\` that proves the two context keys are independent
- \`TestModule_ModuleSchema\`: pins \`mod_<id>\` convention across three representative IDs
- \`TestScopesPanic_BeforeInit\`: \`ModuleDB\` and \`ModuleTx\` added

## README updates

- New **\"Module-shared schema (\`mod_<id>\`)\"** subsection under Database, with code example
- Module structure tree updated to show \`sql/app/\` and \`sql/module/\` side by side (Stage 1's directory split now reflected in user-facing docs)
- New **\"Platform role grant contract\"** subsection

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` all packages green
- [x] New context-key isolation tests
- [x] Schema-name convention test
- [x] Top-level wrappers added to panic-before-init coverage

## Platform-side dependency

This is the final stage of #31. After this lands, the platform side needs:

1. **Per-module DB role provisioning**: create a Postgres role per module with \`USAGE\` on \`mod_<id>\` only
2. **Per-(module, app) role grant scope**: confirm the existing per-(module, app) role does NOT have \`USAGE\` on \`mod_<id>\` (defense-in-depth)
3. **Lambda invoke shim**: inject \`db.ModuleCredential\` for handlers that declare they need module-shared state

File these as parallel issues in the platform repo before deploying any module that uses \`ModuleDB\`.

## Completes #31

| Stage | PR | Status |
|---|---|---|
| 1 — migration split | #59 | ✅ merged |
| 2 — manifest payload | #60 | ✅ merged |
| 3 — lifecycle endpoint namespacing | #61 | ✅ merged |
| 4 — \`Module.ModuleDB\` API | **THIS PR** | OPEN |

Closes #58. Completes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)