### PR TITLE
fix(lifecycle): wire ModuleTx for module-scope handlers

### DIFF
--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -253,6 +253,30 @@ func (m *Module) moduleSchema() string {
 	return "mod_" + m.config.ID
 }
 
+// lifecycleTxRunner returns the TxRunner that should drive migrations for
+// the given scope. Each scope runs against a different schema and uses a
+// different DB credential, so the two scopes require different runners:
+//
+//   - ScopeApp → Module.Tx (reads db.CredentialFrom, per-app role, app_<id>
+//     schema from ctx).
+//   - ScopeModule → Module.ModuleTx (reads db.ModuleCredentialFrom, per-module
+//     role, mod_<id> schema overlayed inside the transaction).
+//
+// Mixing these up is silently wrong: module migrations driven by the app
+// credential would fail at Postgres because the per-(module, app) role lacks
+// USAGE on mod_<id>, but that is infrastructure defense-in-depth — the SDK
+// must pick the correct runner itself.
+func (m *Module) lifecycleTxRunner(scope migration.Scope) migration.TxRunner {
+	switch scope {
+	case migration.ScopeModule:
+		return m.ModuleTx
+	case migration.ScopeApp:
+		return m.Tx
+	default:
+		panic("mirrorstack: lifecycleTxRunner: unhandled scope " + string(scope))
+	}
+}
+
 // Cache returns a scoped cache client. Keys are auto-prefixed with {appID}:{moduleID}:.
 //
 //	c, release, err := mod.Cache(r.Context())
@@ -461,13 +485,15 @@ func (m *Module) mountSystemRoutes() {
 			))
 			r.Route("/lifecycle", func(r chi.Router) {
 				// App and module migrations are separate tracks on disjoint
-				// directories; mount the same four endpoints under each scope
-				// so the platform can drive them independently.
+				// directories AND disjoint DB credentials; mount the same
+				// four endpoints under each scope so the platform can drive
+				// them independently.
 				for _, scope := range migration.AllScopes() {
+					runTx := m.lifecycleTxRunner(scope)
 					r.Route("/"+string(scope), func(r chi.Router) {
-						r.Post("/install", system.InstallHandler(m.config.SQL, scope, m.Tx))
-						r.Post("/upgrade", system.UpgradeHandler(m.config.SQL, scope, m.Tx))
-						r.Post("/downgrade", system.DowngradeHandler(m.config.SQL, scope, m.Tx))
+						r.Post("/install", system.InstallHandler(m.config.SQL, scope, runTx))
+						r.Post("/upgrade", system.UpgradeHandler(m.config.SQL, scope, runTx))
+						r.Post("/downgrade", system.DowngradeHandler(m.config.SQL, scope, runTx))
 						r.Post("/uninstall", system.UninstallHandler()) // no scope — no-op for both
 					})
 				}

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -115,11 +115,11 @@ func TestNew_EmptyID(t *testing.T) {
 
 func TestNew_RejectsBadID(t *testing.T) {
 	bad := []string{
-		"Media",       // uppercase
-		"media!",      // special char
-		"1media",      // starts with digit
-		"_media",      // starts with underscore
-		"../etc",      // path traversal
+		"Media",                            // uppercase
+		"media!",                           // special char
+		"1media",                           // starts with digit
+		"_media",                           // starts with underscore
+		"../etc",                           // path traversal
 		"abcdefghijklmnopqrstuvwxyz012345", // 32 chars
 	}
 	for _, id := range bad {
@@ -474,6 +474,64 @@ func TestLifecycle_UpgradeRequiresPayload(t *testing.T) {
 
 			if rec.Code != http.StatusBadRequest {
 				t.Errorf("status = %d, want 400", rec.Code)
+			}
+		})
+	}
+}
+
+// TestLifecycle_ScopeTxRunnerWiring verifies each scope's lifecycle handlers
+// read their own credential context key. An empty Token makes PoolCache
+// validate() fail before any dial, so the test stays hermetic and the error
+// body echoes the sentinel username only when the correct key was consulted.
+func TestLifecycle_ScopeTxRunnerWiring(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+
+	cases := []struct {
+		scope    migration.Scope
+		sentinel string
+		inject   func(context.Context, db.Credential) context.Context
+	}{
+		{migration.ScopeApp, "app-scope-sentinel-user", db.WithCredential},
+		{migration.ScopeModule, "mod-scope-sentinel-user", db.WithModuleCredential},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.scope), func(t *testing.T) {
+			t.Parallel()
+
+			m, err := New(Config{
+				ID: "test",
+				SQL: fstest.MapFS{
+					tc.scope.Dir() + "/0001_probe.up.sql": &fstest.MapFile{Data: []byte("SELECT 1")},
+				},
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			cred := db.Credential{
+				Host:     "h",
+				Port:     5432,
+				Database: "d",
+				Username: tc.sentinel,
+				// Token intentionally empty — PoolCache validate() fails
+				// fast, no dial attempted.
+			}
+			ctx := tc.inject(context.Background(), cred)
+
+			route := "/__mirrorstack/platform/lifecycle/" + string(tc.scope) + "/install"
+			req := httptest.NewRequest("POST", route, nil).WithContext(ctx)
+			req.Header.Set("X-MS-Internal-Secret", "secret")
+			rec := httptest.NewRecorder()
+			m.Router().ServeHTTP(rec, req)
+
+			if !strings.Contains(rec.Body.String(), tc.sentinel) {
+				t.Errorf(
+					"%s should drive migrations via the %s credential, but the "+
+						"response body does not mention sentinel user %q.\n"+
+						"Status: %d\nBody: %s",
+					route, tc.scope, tc.sentinel, rec.Code, rec.Body.String(),
+				)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `mountSystemRoutes` passed `m.Tx` (per-app credential) to both `ScopeApp` and `ScopeModule` lifecycle handlers
- Module-scope migrations need `m.ModuleTx` (per-module credential, `mod_<id>` schema)
- Extract `lifecycleTxRunner(scope)` helper to select the correct runner per scope
- Add `TestLifecycle_ScopeTxRunnerWiring` regression test (hermetic, no Postgres needed)

## Test plan

- [x] Regression test fails on buggy code (module scope returns 200 via dev pool fallback, sentinel absent)
- [x] Regression test passes on fixed code (sentinel username appears in validate error)
- [x] `go test -race ./...` all green
- [x] `go vet ./...` clean

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)