### PR TITLE
feat(task): OnTask registration + manifest + dev endpoint (PR 1/4 of #34)

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -54,6 +54,14 @@ type Schedule struct {
 	Path string `json:"path"`
 }
 
+// Task is a declared background task. Exposed in the manifest so the platform
+// can provision SQS queues and ECS task definitions on deploy.
+type Task struct {
+	Name        string `json:"name"`
+	MaxDuration string `json:"maxDuration,omitempty"` // e.g. "600s", "10m" — platform sets visibility timeout
+	MaxRetries  int    `json:"maxRetries,omitempty"`  // platform configures DLQ redrive policy
+}
+
 // Permission is a declared module permission. Exposed in the manifest so the
 // platform can surface "what does this module need" on its install screen.
 type Permission struct {
@@ -61,7 +69,7 @@ type Permission struct {
 	Roles []string `json:"roles"`
 }
 
-// Registry is the per-module registry of routes/events/schedules/permissions.
+// Registry is the per-module registry of routes/events/schedules/tasks/permissions.
 // All operations are safe for concurrent use.
 type Registry struct {
 	mu          sync.RWMutex
@@ -69,6 +77,7 @@ type Registry struct {
 	emits       []string
 	subscribes  map[string]string // event name → internal path
 	schedules   []Schedule
+	tasks       []Task
 	permissions []Permission
 }
 
@@ -185,6 +194,32 @@ func (r *Registry) Schedules() []Schedule {
 		return []Schedule{}
 	}
 	return slices.Clone(r.schedules)
+}
+
+// AddTask declares a background task. Returns true if added, false if a task
+// with the same name already exists (first-wins). Panics on an invalid name
+// (see validateRegistrationName).
+func (r *Registry) AddTask(task Task) bool {
+	validateRegistrationName("OnTask", task.Name)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, existing := range r.tasks {
+		if existing.Name == task.Name {
+			return false
+		}
+	}
+	r.tasks = append(r.tasks, task)
+	return true
+}
+
+// Tasks returns a non-nil copy of all declared tasks.
+func (r *Registry) Tasks() []Task {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.tasks == nil {
+		return []Task{}
+	}
+	return slices.Clone(r.tasks)
 }
 
 // AddPermission records a declared permission. First-wins by name: a second

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -81,6 +81,7 @@ type Module struct {
 	devStorageOnce sync.Once // dev mode: lazy storage init
 	devStorage     *storage.Client
 	devStorageErr  error
+	taskHandlers   map[string]taskEntry // registered task handlers (startup-only writes)
 }
 
 // moduleIDPattern matches valid module IDs: lowercase letter, then lowercase alphanumerics/underscores, max 31 chars.
@@ -103,6 +104,7 @@ func New(cfg Config) (*Module, error) {
 		internalAuth: auth.InternalAuth(),
 		poolCache:    db.NewPoolCache(),
 		cacheCache:   cache.NewClientCache(),
+		taskHandlers: make(map[string]taskEntry),
 	}
 	m.mountSystemRoutes()
 	return m, nil

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -643,6 +643,7 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"OnEvent":           func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) },
 		"Emits":             func() { Emits("created") },
 		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
+		"OnTask":            func() { OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil }) },
 		"ModuleDB":          func() { _, _, _ = ModuleDB(context.Background()) },
 		"ModuleTx":          func() { _ = ModuleTx(context.Background(), func(q db.Querier) error { return nil }) },
 	}

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -22,6 +22,7 @@ type ManifestPayload struct {
 	Routes      map[registry.Scope][]registry.Route `json:"routes"`
 	Events      ManifestEvents                      `json:"events"`
 	Schedules   []registry.Schedule                 `json:"schedules"`
+	Tasks       []registry.Task                     `json:"tasks"`
 	Permissions []registry.Permission               `json:"permissions"`
 }
 
@@ -88,6 +89,7 @@ func ManifestHandler(id, name, icon string, sqlFS fs.FS, versions map[string]Mig
 			Routes:      reg.Routes(),
 			Events:      ManifestEvents{Emits: reg.Emits(), Subscribes: reg.Subscribes()},
 			Schedules:   reg.Schedules(),
+			Tasks:       reg.Tasks(),
 			Permissions: reg.Permissions(),
 		})
 	}

--- a/task.go
+++ b/task.go
@@ -1,0 +1,131 @@
+package mirrorstack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+)
+
+// TaskHandler is the handler function for background tasks dispatched via SQS.
+// ctx carries the same credentials as a Lambda handler (DB, Cache, Storage,
+// Auth identity). Returning nil acks the message; returning an error leaves it
+// in the queue for retry.
+type TaskHandler func(ctx context.Context, payload json.RawMessage) error
+
+// TaskOption configures task registration. See WithTimeout.
+type TaskOption func(*taskOptions)
+
+type taskOptions struct {
+	timeout    time.Duration
+	maxRetries int
+}
+
+// taskEntry stores the handler and its configured options.
+type taskEntry struct {
+	handler TaskHandler
+	timeout time.Duration
+}
+
+// WithTimeout sets the maximum duration for this task handler. The worker wraps
+// invocations in context.WithTimeout. Also exposed in the manifest so the
+// platform can set the SQS visibility timeout appropriately.
+func WithTimeout(d time.Duration) TaskOption {
+	return func(o *taskOptions) { o.timeout = d }
+}
+
+// WithMaxRetries sets the maximum number of SQS retries before routing to DLQ.
+// Exposed in the manifest so the platform can configure the redrive policy.
+func WithMaxRetries(n int) TaskOption {
+	return func(o *taskOptions) { o.maxRetries = n }
+}
+
+const taskPathPrefix = "/__mirrorstack/tasks/"
+
+// OnTask registers a background task handler. The handler appears in the
+// manifest so the platform can provision SQS queues on deploy. A dev HTTP
+// endpoint is mounted at POST /__mirrorstack/tasks/{name} on the Internal
+// scope for curl testing.
+//
+// Names must not contain path separators (/, \), whitespace, dot-segments
+// (..), or null bytes. Call from startup code (init / main), not from inside
+// a request handler.
+//
+// Panics on duplicate registration with the same name.
+//
+//	mod.OnTask("transcode-video", transcodeHandler, ms.WithTimeout(10*time.Minute))
+func (m *Module) OnTask(name string, handler TaskHandler, opts ...TaskOption) {
+	o := taskOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	task := registry.Task{Name: name}
+	if o.timeout > 0 {
+		task.MaxDuration = o.timeout.String()
+	}
+	if o.maxRetries > 0 {
+		task.MaxRetries = o.maxRetries
+	}
+
+	if !m.registry.AddTask(task) {
+		panic("mirrorstack: OnTask(" + name + ") registered twice")
+	}
+
+	m.taskHandlers[name] = taskEntry{
+		handler: handler,
+		timeout: o.timeout,
+	}
+
+	// Mount a dev/debug HTTP endpoint on the Internal scope so developers
+	// can test task handlers via curl without SQS infrastructure.
+	path := taskPathPrefix + name
+	m.Internal(func(r chi.Router) {
+		r.Post(path, m.taskHTTPHandler(name))
+	})
+}
+
+// taskHTTPHandler returns an http.HandlerFunc that dispatches to the named
+// task handler. Used for the dev HTTP endpoint only — production tasks arrive
+// via SQS, not HTTP.
+func (m *Module) taskHTTPHandler(name string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entry, ok := m.taskHandlers[name]
+		if !ok {
+			httputil.JSON(w, http.StatusNotFound, httputil.ErrorResponse{Error: "unknown task"})
+			return
+		}
+
+		var payload json.RawMessage
+		if r.Body != nil {
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				httputil.JSON(w, http.StatusBadRequest, httputil.ErrorResponse{Error: "invalid request body: " + err.Error()})
+				return
+			}
+		}
+
+		ctx := r.Context()
+		if entry.timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, entry.timeout)
+			defer cancel()
+		}
+
+		if err := entry.handler(ctx, payload); err != nil {
+			httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: err.Error()})
+			return
+		}
+		httputil.JSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
+// OnTask registers a task handler on the default Module created by Init().
+// Panics before Init — matches Platform/Public/Internal.
+func OnTask(name string, handler TaskHandler, opts ...TaskOption) {
+	mustDefault("OnTask").OnTask(name, handler, opts...)
+}

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,161 @@
+package mirrorstack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOnTask_Registration(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+
+	called := false
+	m.OnTask("transcode", func(ctx context.Context, payload json.RawMessage) error {
+		called = true
+		return nil
+	}, WithTimeout(10*time.Minute), WithMaxRetries(3))
+
+	if _, ok := m.taskHandlers["transcode"]; !ok {
+		t.Fatal("task handler not registered in taskHandlers map")
+	}
+	if called {
+		t.Error("handler should not be called at registration time")
+	}
+}
+
+func TestOnTask_DuplicatePanics(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil })
+
+	assertPanics(t, "expected panic on duplicate OnTask registration", func() {
+		m.OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil })
+	})
+}
+
+func TestOnTask_InvalidNamePanics(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+
+	bad := []string{"", "has/slash", "has space", "has..dots"}
+	for _, name := range bad {
+		t.Run(name, func(t *testing.T) {
+			assertPanics(t, "expected panic for invalid task name "+name, func() {
+				m.OnTask(name, func(ctx context.Context, p json.RawMessage) error { return nil })
+			})
+		})
+	}
+}
+
+func TestOnTask_AppearsInManifest(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.OnTask("transcode", func(ctx context.Context, p json.RawMessage) error { return nil },
+		WithTimeout(10*time.Minute), WithMaxRetries(3))
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	if rec.Code != 200 {
+		t.Fatalf("manifest status = %d, want 200", rec.Code)
+	}
+
+	var payload struct {
+		Tasks []struct {
+			Name        string `json:"name"`
+			MaxDuration string `json:"maxDuration"`
+			MaxRetries  int    `json:"maxRetries"`
+		} `json:"tasks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(payload.Tasks) != 1 {
+		t.Fatalf("tasks count = %d, want 1", len(payload.Tasks))
+	}
+	task := payload.Tasks[0]
+	if task.Name != "transcode" {
+		t.Errorf("task name = %q, want transcode", task.Name)
+	}
+	if task.MaxDuration != "10m0s" {
+		t.Errorf("task maxDuration = %q, want 10m0s", task.MaxDuration)
+	}
+	if task.MaxRetries != 3 {
+		t.Errorf("task maxRetries = %d, want 3", task.MaxRetries)
+	}
+}
+
+func TestOnTask_ManifestEmptyTasksNotNull(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	if rec.Code != 200 {
+		t.Fatalf("manifest status = %d, want 200", rec.Code)
+	}
+
+	// Verify "tasks":[] not "tasks":null
+	body := rec.Body.String()
+	if !strings.Contains(body, `"tasks":[]`) {
+		t.Errorf("manifest should contain \"tasks\":[], got: %s", body)
+	}
+}
+
+func TestOnTask_DevHTTPEndpoint(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+
+	var received json.RawMessage
+	m.OnTask("echo", func(ctx context.Context, payload json.RawMessage) error {
+		received = payload
+		return nil
+	})
+
+	body := strings.NewReader(`{"key":"value"}`)
+	req := httptest.NewRequest("POST", "/__mirrorstack/tasks/echo", body)
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200, body = %s", rec.Code, rec.Body.String())
+	}
+	if string(received) != `{"key":"value"}` {
+		t.Errorf("received payload = %s, want {\"key\":\"value\"}", string(received))
+	}
+}
+
+func TestOnTask_DevHTTPEndpoint_RequiresAuth(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil })
+
+	rec := doRequest(t, m.Router(), "POST", "/__mirrorstack/tasks/work")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 without internal secret", rec.Code)
+	}
+}
+
+func TestOnTask_DevHTTPEndpoint_HandlerError(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.OnTask("fail", func(ctx context.Context, p json.RawMessage) error {
+		return context.DeadlineExceeded
+	})
+
+	req := httptest.NewRequest("POST", "/__mirrorstack/tasks/fail", strings.NewReader(`{}`))
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 on handler error", rec.Code)
+	}
+}
+
+func TestOnTask_WithTimeout(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.OnTask("slow", func(ctx context.Context, p json.RawMessage) error { return nil },
+		WithTimeout(5*time.Second))
+
+	entry := m.taskHandlers["slow"]
+	if entry.timeout != 5*time.Second {
+		t.Errorf("timeout = %v, want 5s", entry.timeout)
+	}
+}


### PR DESCRIPTION
## Summary

PR 1 of 4 for issue #34 (ECS task worker mode). Purely declarative — no SQS runtime behavior yet.

- `TaskHandler` defined type: `func(ctx context.Context, payload json.RawMessage) error`
- `Module.OnTask(name, handler, ...TaskOption)` with `WithTimeout` and `WithMaxRetries` options
- `registry.Task` struct with `Name`, `MaxDuration`, `MaxRetries` — platform reads manifest to provision SQS queues and DLQ redrive policies
- `ManifestPayload.Tasks` field (always `[]`, never `null`)
- Dev HTTP endpoint `POST /__mirrorstack/tasks/{name}` on Internal scope for curl testing
- `OnTask` convenience wrapper + `ScopesPanic_BeforeInit` coverage

## Test plan

- [x] `TestOnTask_Registration` — handler stored in map
- [x] `TestOnTask_DuplicatePanics` — duplicate name panics
- [x] `TestOnTask_InvalidNamePanics` — path separators, spaces, dots rejected
- [x] `TestOnTask_AppearsInManifest` — name, maxDuration, maxRetries in manifest JSON
- [x] `TestOnTask_ManifestEmptyTasksNotNull` — `"tasks":[]` not `null`
- [x] `TestOnTask_DevHTTPEndpoint` — curl dispatch works, payload round-trips
- [x] `TestOnTask_DevHTTPEndpoint_RequiresAuth` — 401 without internal secret
- [x] `TestOnTask_DevHTTPEndpoint_HandlerError` — 500 on handler error
- [x] `TestOnTask_WithTimeout` — timeout stored in entry
- [x] `TestScopesPanic_BeforeInit/OnTask` — panics before Init
- [x] `go test -race ./...` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)