### PR TITLE
feat(task): RunTask + InjectResources + HMAC signing (PR 2/4 of #34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      elasticmq:
+        image: softwaremill/elasticmq-native
+        ports:
+          - 9324:9324
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,10 @@ services:
     ports:
       - "6379:6379"
 
+  elasticmq:
+    image: softwaremill/elasticmq-native
+    ports:
+      - "9324:9324"
+
 volumes:
   pgdata:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/redis/go-redis/v9 v9.18.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0 h1:foqo/ocQ7WqKwy3FojGtZQJo0FR4v
 github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25 h1:8Bv3TQ1Cob6HLlpUbAnWxeHhAkYScJO9RIHh2WPXaxw=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25/go.mod h1:eDstEbM0OEnBUnNQxIA7j74Jy61cCU1S4EMlCtdMwzs=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15/go.mod h1:WSvS1NLr7JaPunCXqpJnWk1Bjo7IxzZXrZi1QQCkuqM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6fuOwWlWpD2StNLTceKpys=

--- a/internal/runtime/inject.go
+++ b/internal/runtime/inject.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/cache"
+	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/storage"
+)
+
+// InjectParams holds the trusted values to inject into a request context.
+// Used by both the Lambda handler and the task worker — any change here
+// applies to both paths automatically.
+type InjectParams struct {
+	Resources *Resources
+	UserID    string
+	AppID     string
+	AppRole   string
+	AppSchema string
+}
+
+// validRoles is the set of platform roles the SDK recognizes. Messages
+// carrying an unknown role are rejected before credential injection.
+var validRoles = map[string]bool{
+	auth.RoleAdmin:  true,
+	auth.RoleMember: true,
+	auth.RoleViewer: true,
+	"":              true, // empty is valid (internal/system calls with no user)
+}
+
+// InjectResources populates ctx with DB/Cache/Storage credentials, app schema,
+// and auth identity from the given params. This is the authoritative gate for
+// AppSchema validation — callers do not need to validate separately.
+//
+// Returns an error if AppSchema is non-empty and does not match the expected
+// pattern, or if AppRole is not a recognized platform role.
+func InjectResources(ctx context.Context, p InjectParams) (context.Context, error) {
+	if p.AppSchema != "" && !schemaPattern.MatchString(p.AppSchema) {
+		return ctx, fmt.Errorf("mirrorstack: invalid app schema format %q", p.AppSchema)
+	}
+	if !validRoles[p.AppRole] {
+		return ctx, fmt.Errorf("mirrorstack: unknown app role %q", p.AppRole)
+	}
+
+	if p.Resources != nil {
+		if p.Resources.DB != nil {
+			ctx = db.WithCredential(ctx, *p.Resources.DB)
+		}
+		if p.Resources.Cache != nil {
+			ctx = cache.WithCredential(ctx, *p.Resources.Cache)
+		}
+		if p.Resources.Storage != nil {
+			ctx = storage.WithCredential(ctx, *p.Resources.Storage)
+		}
+	}
+	if p.AppSchema != "" {
+		ctx = db.WithSchema(ctx, p.AppSchema)
+	}
+	if p.UserID != "" || p.AppID != "" || p.AppRole != "" {
+		ctx = auth.Set(ctx, auth.Identity{
+			UserID:  p.UserID,
+			AppID:   p.AppID,
+			AppRole: p.AppRole,
+		})
+	}
+	return ctx, nil
+}

--- a/internal/runtime/inject_test.go
+++ b/internal/runtime/inject_test.go
@@ -1,0 +1,91 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/cache"
+	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/storage"
+)
+
+func TestInjectResources_FullInjection(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := InjectResources(context.Background(), InjectParams{
+		Resources: &Resources{
+			DB:      &db.Credential{Host: "h", Port: 5432, Database: "d", Username: "u", Token: "t"},
+			Cache:   &cache.Credential{Endpoint: "localhost:6379", Username: "cu"},
+			Storage: &storage.Credential{Bucket: "b", Region: "r"},
+		},
+		UserID:    "user-1",
+		AppID:     "app-1",
+		AppRole:   "admin",
+		AppSchema: "app_abc123",
+	})
+	if err != nil {
+		t.Fatalf("InjectResources: %v", err)
+	}
+
+	if cred := db.CredentialFrom(ctx); cred == nil || cred.Username != "u" {
+		t.Errorf("DB credential not injected correctly")
+	}
+	if cred := cache.CredentialFrom(ctx); cred == nil || cred.Username != "cu" {
+		t.Errorf("Cache credential not injected correctly")
+	}
+	if cred := storage.CredentialFrom(ctx); cred == nil || cred.Bucket != "b" {
+		t.Errorf("Storage credential not injected correctly")
+	}
+	if schema := db.SchemaFrom(ctx); schema != "app_abc123" {
+		t.Errorf("schema = %q, want app_abc123", schema)
+	}
+	if a := auth.Get(ctx); a == nil || a.UserID != "user-1" || a.AppRole != "admin" {
+		t.Errorf("auth identity not injected correctly: %+v", a)
+	}
+}
+
+func TestInjectResources_EmptyParams(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := InjectResources(context.Background(), InjectParams{})
+	if err != nil {
+		t.Fatalf("InjectResources with empty params: %v", err)
+	}
+	if db.CredentialFrom(ctx) != nil {
+		t.Error("expected nil DB credential for empty params")
+	}
+}
+
+func TestInjectResources_InvalidSchema(t *testing.T) {
+	t.Parallel()
+
+	_, err := InjectResources(context.Background(), InjectParams{
+		AppSchema: `app"; DROP TABLE users;--`,
+	})
+	if err == nil {
+		t.Error("expected error for invalid schema")
+	}
+}
+
+func TestInjectResources_InvalidRole(t *testing.T) {
+	t.Parallel()
+
+	_, err := InjectResources(context.Background(), InjectParams{
+		AppRole: "superadmin",
+	})
+	if err == nil {
+		t.Error("expected error for unknown role")
+	}
+}
+
+func TestInjectResources_EmptyRoleAllowed(t *testing.T) {
+	t.Parallel()
+
+	_, err := InjectResources(context.Background(), InjectParams{
+		AppRole: "",
+	})
+	if err != nil {
+		t.Errorf("empty role should be allowed: %v", err)
+	}
+}

--- a/internal/runtime/lambda.go
+++ b/internal/runtime/lambda.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
@@ -64,11 +63,6 @@ func NewLambdaHandler(handler http.Handler) func(context.Context, json.RawMessag
 			return jsonError(400, "invalid request payload"), nil
 		}
 
-		// Validate schema format if present
-		if req.AppSchema != "" && !schemaPattern.MatchString(req.AppSchema) {
-			return jsonError(400, "invalid app schema format"), nil
-		}
-
 		// Ensure path is relative to prevent host injection
 		path := req.Path
 		if !strings.HasPrefix(path, "/") {
@@ -93,28 +87,18 @@ func NewLambdaHandler(handler http.Handler) func(context.Context, json.RawMessag
 			httpReq.Header.Set(k, v)
 		}
 
-		// Inject trusted values from typed payload fields into context
-		reqCtx := httpReq.Context()
-		if req.Resources != nil {
-			if req.Resources.DB != nil {
-				reqCtx = db.WithCredential(reqCtx, *req.Resources.DB)
-			}
-			if req.Resources.Cache != nil {
-				reqCtx = cache.WithCredential(reqCtx, *req.Resources.Cache)
-			}
-			if req.Resources.Storage != nil {
-				reqCtx = storage.WithCredential(reqCtx, *req.Resources.Storage)
-			}
-		}
-		if req.AppSchema != "" {
-			reqCtx = db.WithSchema(reqCtx, req.AppSchema)
-		}
-		if req.UserID != "" || req.AppID != "" || req.AppRole != "" {
-			reqCtx = auth.Set(reqCtx, auth.Identity{
-				UserID:  req.UserID,
-				AppID:   req.AppID,
-				AppRole: req.AppRole,
-			})
+		// Inject trusted values from typed payload fields into context.
+		// InjectResources is the shared injection function used by both
+		// Lambda and task worker paths — see inject.go.
+		reqCtx, err := InjectResources(httpReq.Context(), InjectParams{
+			Resources: req.Resources,
+			UserID:    req.UserID,
+			AppID:     req.AppID,
+			AppRole:   req.AppRole,
+			AppSchema: req.AppSchema,
+		})
+		if err != nil {
+			return jsonError(400, err.Error()), nil
 		}
 		httpReq = httpReq.WithContext(reqCtx)
 

--- a/internal/runtime/task_message.go
+++ b/internal/runtime/task_message.go
@@ -1,0 +1,87 @@
+package runtime
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// TaskMessage is the SQS message envelope for background tasks dispatched
+// via Module.RunTask. It mirrors the LambdaRequest shape for credential
+// transport but uses a different delivery channel (SQS instead of Lambda
+// Invoke). The Signature field provides HMAC integrity verification so the
+// task worker can reject forged messages.
+type TaskMessage struct {
+	TaskID    string          `json:"taskId"`
+	Name      string          `json:"name"`
+	Payload   json.RawMessage `json:"payload"`
+	Resources *Resources      `json:"resources,omitempty"`
+	UserID    string          `json:"userId,omitempty"`
+	AppID     string          `json:"appId,omitempty"`
+	AppRole   string          `json:"appRole,omitempty"`
+	AppSchema string          `json:"appSchema,omitempty"`
+	Signature string          `json:"sig,omitempty"`
+}
+
+// Sign computes an HMAC-SHA256 over the message content (excluding the sig
+// field itself) and sets the Signature field. The key should come from
+// MS_TASK_SIGNING_KEY. A nil or empty key is a no-op — dev mode skips signing.
+func (m *TaskMessage) Sign(key []byte) {
+	if len(key) == 0 {
+		return
+	}
+	m.Signature = ""
+	m.Signature = computeHMAC(key, m.signingPayload())
+}
+
+// Verify checks the HMAC signature. Returns an error if the key is non-empty
+// and the signature is missing or invalid. A nil/empty key always passes —
+// dev mode skips verification.
+func (m *TaskMessage) Verify(key []byte) error {
+	if len(key) == 0 {
+		return nil
+	}
+	if m.Signature == "" {
+		return fmt.Errorf("mirrorstack: task message missing signature")
+	}
+	expected := computeHMAC(key, m.signingPayload())
+	if !hmac.Equal([]byte(m.Signature), []byte(expected)) {
+		return fmt.Errorf("mirrorstack: task message signature mismatch")
+	}
+	return nil
+}
+
+// signingPayload returns a deterministic JSON representation of the message
+// fields that are covered by the signature (everything except sig itself).
+func (m *TaskMessage) signingPayload() []byte {
+	// Use a shadow struct to exclude Signature from marshaling.
+	type shadow struct {
+		TaskID    string          `json:"taskId"`
+		Name      string          `json:"name"`
+		Payload   json.RawMessage `json:"payload"`
+		Resources *Resources      `json:"resources,omitempty"`
+		UserID    string          `json:"userId,omitempty"`
+		AppID     string          `json:"appId,omitempty"`
+		AppRole   string          `json:"appRole,omitempty"`
+		AppSchema string          `json:"appSchema,omitempty"`
+	}
+	b, _ := json.Marshal(shadow{
+		TaskID:    m.TaskID,
+		Name:      m.Name,
+		Payload:   m.Payload,
+		Resources: m.Resources,
+		UserID:    m.UserID,
+		AppID:     m.AppID,
+		AppRole:   m.AppRole,
+		AppSchema: m.AppSchema,
+	})
+	return b
+}
+
+func computeHMAC(key, data []byte) string {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/runtime/task_message_test.go
+++ b/internal/runtime/task_message_test.go
@@ -1,0 +1,107 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTaskMessage_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	msg := TaskMessage{
+		TaskID:    "tid-123",
+		Name:      "transcode",
+		Payload:   json.RawMessage(`{"videoId":"v1"}`),
+		UserID:    "u1",
+		AppID:     "a1",
+		AppRole:   "admin",
+		AppSchema: "app_abc",
+	}
+
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got TaskMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.TaskID != "tid-123" || got.Name != "transcode" || got.AppSchema != "app_abc" {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+	if string(got.Payload) != `{"videoId":"v1"}` {
+		t.Errorf("payload = %s, want {\"videoId\":\"v1\"}", string(got.Payload))
+	}
+}
+
+func TestTaskMessage_SignVerify(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("test-signing-key")
+	msg := TaskMessage{
+		TaskID:  "tid-1",
+		Name:    "work",
+		Payload: json.RawMessage(`{}`),
+	}
+
+	msg.Sign(key)
+	if msg.Signature == "" {
+		t.Fatal("Sign should set Signature")
+	}
+
+	if err := msg.Verify(key); err != nil {
+		t.Errorf("Verify should pass: %v", err)
+	}
+}
+
+func TestTaskMessage_VerifyRejectsTampered(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("test-signing-key")
+	msg := TaskMessage{
+		TaskID:  "tid-1",
+		Name:    "work",
+		Payload: json.RawMessage(`{}`),
+	}
+	msg.Sign(key)
+
+	msg.Name = "tampered" // modify after signing
+	if err := msg.Verify(key); err == nil {
+		t.Error("Verify should reject tampered message")
+	}
+}
+
+func TestTaskMessage_VerifyRejectsWrongKey(t *testing.T) {
+	t.Parallel()
+
+	msg := TaskMessage{TaskID: "tid-1", Name: "work", Payload: json.RawMessage(`{}`)}
+	msg.Sign([]byte("key-a"))
+
+	if err := msg.Verify([]byte("key-b")); err == nil {
+		t.Error("Verify should reject wrong key")
+	}
+}
+
+func TestTaskMessage_SignVerify_EmptyKeySkips(t *testing.T) {
+	t.Parallel()
+
+	msg := TaskMessage{TaskID: "tid-1", Name: "work"}
+	msg.Sign(nil) // no-op
+	if msg.Signature != "" {
+		t.Error("Sign with nil key should not set signature")
+	}
+	if err := msg.Verify(nil); err != nil {
+		t.Errorf("Verify with nil key should pass: %v", err)
+	}
+}
+
+func TestTaskMessage_VerifyRejectsMissingSig(t *testing.T) {
+	t.Parallel()
+
+	msg := TaskMessage{TaskID: "tid-1", Name: "work"}
+	if err := msg.Verify([]byte("key")); err == nil {
+		t.Error("Verify should reject missing signature when key is set")
+	}
+}

--- a/internal/sqs/client.go
+++ b/internal/sqs/client.go
@@ -1,0 +1,109 @@
+// Package sqs provides a thin wrapper around the AWS SQS SDK for sending
+// and receiving task messages. The wrapper exists to centralize queue URL
+// handling and to provide a seam for unit-testing without LocalStack.
+package sqs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+)
+
+// Message is a received SQS message with the fields the worker loop needs.
+type Message struct {
+	Body          string
+	ReceiptHandle string
+	MessageID     string
+	ReceiveCount  int
+}
+
+// Client wraps an SQS client with a fixed queue URL.
+type Client struct {
+	sqs      *sqs.Client
+	queueURL string
+}
+
+// New creates a Client for the given queue URL. Uses the default AWS config
+// (IAM role from the environment — Lambda execution role or ECS task role).
+func New(ctx context.Context, queueURL string) (*Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("mirrorstack/sqs: load aws config: %w", err)
+	}
+	return &Client{
+		sqs:      sqs.NewFromConfig(cfg),
+		queueURL: queueURL,
+	}, nil
+}
+
+// Send publishes a message body to the queue. Returns the SQS message ID.
+func (c *Client) Send(ctx context.Context, body string) (string, error) {
+	out, err := c.sqs.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:    &c.queueURL,
+		MessageBody: &body,
+	})
+	if err != nil {
+		return "", fmt.Errorf("mirrorstack/sqs: send: %w", err)
+	}
+	return aws.ToString(out.MessageId), nil
+}
+
+// Receive long-polls for up to 1 message with a 20-second wait. Returns
+// an empty slice (not an error) when no messages are available.
+func (c *Client) Receive(ctx context.Context) ([]Message, error) {
+	out, err := c.sqs.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            &c.queueURL,
+		MaxNumberOfMessages: 1,
+		WaitTimeSeconds:     20,
+		AttributeNames:      []types.QueueAttributeName{types.QueueAttributeNameAll},
+		MessageSystemAttributeNames: []types.MessageSystemAttributeName{
+			types.MessageSystemAttributeNameApproximateReceiveCount,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mirrorstack/sqs: receive: %w", err)
+	}
+	msgs := make([]Message, 0, len(out.Messages))
+	for _, m := range out.Messages {
+		rc := 0
+		if v, ok := m.Attributes[string(types.MessageSystemAttributeNameApproximateReceiveCount)]; ok {
+			fmt.Sscanf(v, "%d", &rc)
+		}
+		msgs = append(msgs, Message{
+			Body:          aws.ToString(m.Body),
+			ReceiptHandle: aws.ToString(m.ReceiptHandle),
+			MessageID:     aws.ToString(m.MessageId),
+			ReceiveCount:  rc,
+		})
+	}
+	return msgs, nil
+}
+
+// Delete removes a message from the queue (ack).
+func (c *Client) Delete(ctx context.Context, receiptHandle string) error {
+	_, err := c.sqs.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+		QueueUrl:      &c.queueURL,
+		ReceiptHandle: &receiptHandle,
+	})
+	if err != nil {
+		return fmt.Errorf("mirrorstack/sqs: delete: %w", err)
+	}
+	return nil
+}
+
+// ChangeVisibility extends or shortens the visibility timeout of a message.
+func (c *Client) ChangeVisibility(ctx context.Context, receiptHandle string, timeoutSeconds int32) error {
+	_, err := c.sqs.ChangeMessageVisibility(ctx, &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          &c.queueURL,
+		ReceiptHandle:     &receiptHandle,
+		VisibilityTimeout: timeoutSeconds,
+	})
+	if err != nil {
+		return fmt.Errorf("mirrorstack/sqs: change visibility: %w", err)
+	}
+	return nil
+}

--- a/internal/sqs/client_integration_test.go
+++ b/internal/sqs/client_integration_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	sqssdk "github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+// sqsEndpoint returns the SQS-compatible endpoint, defaulting to ElasticMQ on localhost:9324.
+func sqsEndpoint() string {
+	if ep := os.Getenv("SQS_ENDPOINT"); ep != "" {
+		return ep
+	}
+	return "http://localhost:9324"
+}
+
+// skipIfNoSQS skips the test if ElasticMQ is not reachable.
+func skipIfNoSQS(t *testing.T) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", "localhost:9324", 2*time.Second)
+	if err != nil {
+		t.Skip("ElasticMQ not available, skipping SQS integration test")
+	}
+	conn.Close()
+}
+
+// testAWSConfig returns an AWS config pointing at ElasticMQ with fake credentials.
+func testAWSConfig(ctx context.Context) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithBaseEndpoint(sqsEndpoint()),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+}
+
+// createTestQueue creates an SQS queue in ElasticMQ and returns its URL.
+func createTestQueue(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	cfg, err := testAWSConfig(ctx)
+	if err != nil {
+		t.Fatalf("load aws config: %v", err)
+	}
+
+	client := sqssdk.NewFromConfig(cfg)
+	queueName := "test-queue-" + t.Name()
+	out, err := client.CreateQueue(ctx, &sqssdk.CreateQueueInput{
+		QueueName: &queueName,
+	})
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+	t.Cleanup(func() {
+		client.DeleteQueue(context.Background(), &sqssdk.DeleteQueueInput{
+			QueueUrl: out.QueueUrl,
+		})
+	})
+	return aws.ToString(out.QueueUrl)
+}
+
+func TestIntegration_SendReceiveDelete(t *testing.T) {
+	skipIfNoSQS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Set fake credentials BEFORE any AWS SDK calls
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ENDPOINT_URL", sqsEndpoint())
+
+	queueURL := createTestQueue(t, ctx)
+
+	c, err := New(ctx, queueURL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Send
+	body := `{"taskId":"t1","name":"work","payload":{}}`
+	msgID, err := c.Send(ctx, body)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if msgID == "" {
+		t.Error("Send should return a non-empty message ID")
+	}
+
+	// Receive
+	msgs, err := c.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatal("Receive returned 0 messages, expected 1")
+	}
+
+	msg := msgs[0]
+	if msg.Body != body {
+		t.Errorf("body = %q, want %q", msg.Body, body)
+	}
+	if msg.MessageID == "" {
+		t.Error("MessageID should be set")
+	}
+
+	// Verify JSON roundtrip
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(msg.Body), &parsed); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+
+	// Delete (ack)
+	if err := c.Delete(ctx, msg.ReceiptHandle); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Verify queue is empty after delete
+	msgs2, err := c.Receive(ctx)
+	if err != nil {
+		t.Fatalf("second Receive: %v", err)
+	}
+	if len(msgs2) != 0 {
+		t.Errorf("queue should be empty after delete, got %d messages", len(msgs2))
+	}
+}
+
+func TestIntegration_ChangeVisibility(t *testing.T) {
+	skipIfNoSQS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ENDPOINT_URL", sqsEndpoint())
+
+	queueURL := createTestQueue(t, ctx)
+
+	c, err := New(ctx, queueURL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = c.Send(ctx, `{"name":"test"}`)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	msgs, err := c.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatal("expected 1 message")
+	}
+
+	if err := c.ChangeVisibility(ctx, msgs[0].ReceiptHandle, 60); err != nil {
+		t.Fatalf("ChangeVisibility: %v", err)
+	}
+
+	c.Delete(ctx, msgs[0].ReceiptHandle)
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
+	msqs "github.com/mirrorstack-ai/app-module-sdk/internal/sqs"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 	"github.com/mirrorstack-ai/app-module-sdk/system"
 )
@@ -82,6 +83,8 @@ type Module struct {
 	devStorage     *storage.Client
 	devStorageErr  error
 	taskHandlers   map[string]taskEntry // registered task handlers (startup-only writes)
+	sqsClient      *msqs.Client         // nil in dev mode (MS_TASK_QUEUE_URL unset)
+	signingKey     []byte               // HMAC key for TaskMessage signing (MS_TASK_SIGNING_KEY)
 }
 
 // moduleIDPattern matches valid module IDs: lowercase letter, then lowercase alphanumerics/underscores, max 31 chars.
@@ -105,7 +108,20 @@ func New(cfg Config) (*Module, error) {
 		poolCache:    db.NewPoolCache(),
 		cacheCache:   cache.NewClientCache(),
 		taskHandlers: make(map[string]taskEntry),
+		signingKey:   []byte(os.Getenv("MS_TASK_SIGNING_KEY")),
 	}
+
+	// Eagerly initialize SQS client when queue URL is configured.
+	// LoadDefaultConfig may hit IMDS on first cold start in Lambda; acceptable
+	// since this runs once at process init, not per request.
+	if queueURL := os.Getenv("MS_TASK_QUEUE_URL"); queueURL != "" {
+		sqsClient, err := msqs.New(context.Background(), queueURL)
+		if err != nil {
+			return nil, fmt.Errorf("mirrorstack: init sqs client: %w", err)
+		}
+		m.sqsClient = sqsClient
+	}
+
 	m.mountSystemRoutes()
 	return m, nil
 }

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -644,6 +644,7 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"Emits":             func() { Emits("created") },
 		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
 		"OnTask":            func() { OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil }) },
+		"RunTask":           func() { _, _ = RunTask(context.Background(), "work", nil) },
 		"ModuleDB":          func() { _, _, _ = ModuleDB(context.Background()) },
 		"ModuleTx":          func() { _ = ModuleTx(context.Background(), func(q db.Querier) error { return nil }) },
 	}

--- a/task.go
+++ b/task.go
@@ -2,14 +2,21 @@ package mirrorstack
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/cache"
+	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
+	"github.com/mirrorstack-ai/app-module-sdk/storage"
 )
 
 // TaskHandler is the handler function for background tasks dispatched via SQS.
@@ -124,8 +131,108 @@ func (m *Module) taskHTTPHandler(name string) http.HandlerFunc {
 	}
 }
 
+// maxTaskPayloadSize is the SQS message body limit. RunTask validates payload
+// size before sending so the error is clear, not a cryptic SQS SDK error.
+const maxTaskPayloadSize = 256 * 1024 // 256 KB
+
+// RunTask dispatches a background task to the module's SQS queue. Returns
+// the generated TaskID (UUID). In dev mode (MS_TASK_QUEUE_URL unset),
+// dispatches in-process to the registered OnTask handler.
+//
+// ctx must carry the same credentials as a Lambda handler — RunTask copies
+// them into the TaskMessage so the task worker has the same DB/Cache/Storage
+// access as the caller.
+//
+// WARNING: If called inside ms.Tx(), the SQS send is NOT transactional with
+// the database write. The task may execute before, after, or even if the
+// transaction rolls back. Use the transactional outbox pattern (future)
+// for atomic dispatch.
+//
+//	taskID, err := mod.RunTask(r.Context(), "transcode-video", payload)
+func (m *Module) RunTask(ctx context.Context, name string, payload json.RawMessage) (string, error) {
+	if _, ok := m.taskHandlers[name]; !ok {
+		return "", fmt.Errorf("mirrorstack: RunTask(%q): unknown task (not registered via OnTask)", name)
+	}
+
+	if len(payload) > maxTaskPayloadSize {
+		return "", fmt.Errorf("mirrorstack: RunTask(%q): payload size %d exceeds SQS limit of %d bytes", name, len(payload), maxTaskPayloadSize)
+	}
+
+	msg := m.buildTaskMessage(ctx, name, payload)
+
+	// Dev mode: dispatch in-process when no queue is configured.
+	if m.sqsClient == nil {
+		entry := m.taskHandlers[name]
+		return msg.TaskID, entry.handler(ctx, payload)
+	}
+
+	// Sign the message for integrity verification by the task worker.
+	msg.Sign(m.signingKey)
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return "", fmt.Errorf("mirrorstack: RunTask(%q): marshal: %w", name, err)
+	}
+
+	if _, err := m.sqsClient.Send(ctx, string(body)); err != nil {
+		return "", fmt.Errorf("mirrorstack: RunTask(%q): %w", name, err)
+	}
+	return msg.TaskID, nil
+}
+
+// buildTaskMessage constructs a TaskMessage from the current request context,
+// copying credentials so the task worker has identical DB/Cache/Storage access.
+func (m *Module) buildTaskMessage(ctx context.Context, name string, payload json.RawMessage) *runtime.TaskMessage {
+	msg := &runtime.TaskMessage{
+		TaskID:  generateTaskID(),
+		Name:    name,
+		Payload: payload,
+	}
+
+	// Copy credentials from context — these were injected by the Lambda handler.
+	var res runtime.Resources
+	if cred := db.CredentialFrom(ctx); cred != nil {
+		res.DB = cred
+	}
+	if cred := cache.CredentialFrom(ctx); cred != nil {
+		res.Cache = cred
+	}
+	if cred := storage.CredentialFrom(ctx); cred != nil {
+		res.Storage = cred
+	}
+	if res.DB != nil || res.Cache != nil || res.Storage != nil {
+		msg.Resources = &res
+	}
+
+	if a := auth.Get(ctx); a != nil {
+		msg.UserID = a.UserID
+		msg.AppID = a.AppID
+		msg.AppRole = a.AppRole
+	}
+
+	msg.AppSchema = db.SchemaFrom(ctx)
+
+	return msg
+}
+
+// generateTaskID returns a new UUID v4 string for task deduplication.
+func generateTaskID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("mirrorstack: crypto/rand.Read failed: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 2
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
 // OnTask registers a task handler on the default Module created by Init().
 // Panics before Init — matches Platform/Public/Internal.
 func OnTask(name string, handler TaskHandler, opts ...TaskOption) {
 	mustDefault("OnTask").OnTask(name, handler, opts...)
+}
+
+// RunTask dispatches a task on the default Module. Panics before Init.
+func RunTask(ctx context.Context, name string, payload json.RawMessage) (string, error) {
+	return mustDefault("RunTask").RunTask(ctx, name, payload)
 }

--- a/task_test.go
+++ b/task_test.go
@@ -159,3 +159,59 @@ func TestOnTask_WithTimeout(t *testing.T) {
 		t.Errorf("timeout = %v, want 5s", entry.timeout)
 	}
 }
+
+// --- RunTask (dev-mode in-process dispatch) ---
+
+func TestRunTask_DevMode_Dispatches(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+
+	var received json.RawMessage
+	m.OnTask("echo", func(ctx context.Context, payload json.RawMessage) error {
+		received = payload
+		return nil
+	})
+
+	payload := json.RawMessage(`{"key":"value"}`)
+	taskID, err := m.RunTask(context.Background(), "echo", payload)
+	if err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+	if taskID == "" {
+		t.Error("RunTask should return a non-empty taskID")
+	}
+	if string(received) != `{"key":"value"}` {
+		t.Errorf("received = %s, want {\"key\":\"value\"}", string(received))
+	}
+}
+
+func TestRunTask_UnknownTask(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+
+	_, err := m.RunTask(context.Background(), "nonexistent", nil)
+	if err == nil {
+		t.Error("RunTask should error on unknown task")
+	}
+}
+
+func TestRunTask_PayloadTooLarge(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil })
+
+	big := make(json.RawMessage, 300*1024) // > 256KB
+	_, err := m.RunTask(context.Background(), "work", big)
+	if err == nil {
+		t.Error("RunTask should reject payload > 256KB")
+	}
+}
+
+func TestRunTask_DevMode_PropagatesError(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.OnTask("fail", func(ctx context.Context, p json.RawMessage) error {
+		return context.DeadlineExceeded
+	})
+
+	_, err := m.RunTask(context.Background(), "fail", json.RawMessage(`{}`))
+	if err == nil {
+		t.Error("RunTask should propagate handler error in dev mode")
+	}
+}


### PR DESCRIPTION
## Summary

PR 2 of 4 for issue #34 (ECS task worker mode). Adds the dispatch side — Lambda handlers can now send tasks to SQS.

- **InjectResources refactor**: Extract credential→context injection from `NewLambdaHandler` (lambda.go:98-119) into shared `InjectResources(ctx, InjectParams)`. Owns `AppSchema` regex validation and `AppRole` validation as the authoritative gate. All existing `lambda_test.go` tests pass unchanged.
- **TaskMessage**: SQS message envelope mirroring LambdaRequest shape. HMAC `Sign`/`Verify` via `MS_TASK_SIGNING_KEY` for message integrity.
- **SQS client**: Thin wrapper (`internal/sqs`) with `Send`, `Receive`, `Delete`, `ChangeVisibility`.
- **Module.RunTask**: Dispatches to SQS in production (signs message), in-process in dev mode. Generates UUID `TaskID`. Validates payload < 256KB.
- **Module struct**: `sqsClient` eagerly initialized in `New()` when `MS_TASK_QUEUE_URL` is set. `signingKey` from `MS_TASK_SIGNING_KEY`.

## Test plan

- [x] `TestInjectResources_FullInjection` — all credential types + schema + auth injected
- [x] `TestInjectResources_InvalidSchema` — SQL injection pattern rejected
- [x] `TestInjectResources_InvalidRole` — unknown role rejected
- [x] `TestTaskMessage_SignVerify` — HMAC roundtrip
- [x] `TestTaskMessage_VerifyRejectsTampered` — tampered message rejected
- [x] `TestTaskMessage_VerifyRejectsWrongKey` — wrong key rejected
- [x] `TestTaskMessage_SignVerify_EmptyKeySkips` — dev mode (no key) passes
- [x] `TestRunTask_DevMode_Dispatches` — in-process dispatch works
- [x] `TestRunTask_UnknownTask` — error on unregistered task
- [x] `TestRunTask_PayloadTooLarge` — rejects > 256KB
- [x] All existing `TestNewLambdaHandler_*` tests pass unchanged
- [x] `go test -race ./...` all green

Depends on PR #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)