### PR TITLE
feat(auth): log rejected internal auth requests (closes #43)

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -59,6 +59,7 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if expected == "" {
+				log.Printf("mirrorstack: internal auth rejected (no secret configured) from %s %s", r.RemoteAddr, r.URL.Path)
 				if inLambda {
 					// SECURITY: generic body. The detailed reason is in the
 					// construction-time log line above; the 503 status itself
@@ -76,6 +77,8 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 
 			secret := r.Header.Get("X-MS-Internal-Secret")
 			if !constantTimeEqual(secret, expected) {
+				// SECURITY: never log the header value; only whether it was present
+				log.Printf("mirrorstack: internal auth rejected (secret mismatch, header_present=%v) from %s %s", secret != "", r.RemoteAddr, r.URL.Path)
 				httputil.JSON(w, http.StatusUnauthorized, httputil.ErrorResponse{Error: "internal authentication required"})
 				return
 			}
@@ -87,4 +90,3 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 func constantTimeEqual(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
-

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -1,8 +1,11 @@
 package auth
 
 import (
+	"bytes"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -168,3 +171,67 @@ func TestInternalAuth_WrongSecret_InLambda_Still401(t *testing.T) {
 	}
 }
 
+func TestInternalAuth_LogsOnNoSecret(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/platform/lifecycle/tick", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	got := buf.String()
+	if !strings.Contains(got, "no secret configured") {
+		t.Errorf("expected log to mention 'no secret configured', got: %q", got)
+	}
+	if !strings.Contains(got, "/platform/lifecycle/tick") {
+		t.Errorf("expected log to mention request path, got: %q", got)
+	}
+}
+
+func TestInternalAuth_LogsOnSecretMismatch(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("MS_INTERNAL_SECRET", "real-secret")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/platform/lifecycle/tick", nil)
+	req.Header.Set("X-MS-Internal-Secret", "wrong")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	got := buf.String()
+	if !strings.Contains(got, "secret mismatch") {
+		t.Errorf("expected log to mention 'secret mismatch', got: %q", got)
+	}
+	if !strings.Contains(got, "header_present=true") {
+		t.Errorf("expected header_present=true in log, got: %q", got)
+	}
+	// SECURITY: actual secret must never appear in log
+	if strings.Contains(got, "real-secret") || strings.Contains(got, "wrong") {
+		t.Errorf("log leaks secret value: %q", got)
+	}
+}
+
+func TestInternalAuth_LogsHeaderAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("MS_INTERNAL_SECRET", "real-secret")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/platform/lifecycle/tick", nil) // no header
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	got := buf.String()
+	if !strings.Contains(got, "header_present=false") {
+		t.Errorf("expected header_present=false in log, got: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Per-request log lines on rejected internal auth requests. Fixes the nil bug from contributor PR #64.

- **no secret configured**: `mirrorstack: internal auth rejected (no secret configured) from <addr> <path>`
- **secret mismatch**: `mirrorstack: internal auth rejected (secret mismatch, header_present=<bool>) from <addr> <path>`

Secret value never logged. Tests use `log.SetOutput(os.Stderr)` in cleanup (not `nil`).

## Test plan

- [x] `TestInternalAuth_LogsOnNoSecret` — log mentions "no secret configured" + path
- [x] `TestInternalAuth_LogsOnSecretMismatch` — log mentions "secret mismatch" + header_present=true
- [x] `TestInternalAuth_LogsHeaderAbsent` — header_present=false when header missing
- [x] Security: log never contains "real-secret" or "wrong"
- [x] `go test -race ./...` all green

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)