### PR TITLE
feat(auth): MaxBytesReader on Internal scope (closes #52)

### DIFF
--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -403,8 +403,17 @@ func (m *Module) Internal(fn func(r chi.Router)) {
 // route tree, which indicates a misconfigured module that should not start.
 // Panic instead of silently leaving the registry and router in inconsistent
 // states (some routes recorded but not re-registered, or vice versa).
+// internalRouteBodyCap is the default body size limit for Internal-scope
+// routes (events, crons, tasks, and developer-registered internal handlers).
+// Defense-in-depth — Lambda's API Gateway has a 6 MB cap, but dev mode is
+// unbounded without this.
+const internalRouteBodyCap = 1 << 20 // 1 MB
+
 func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Handler) http.Handler, fn func(r chi.Router)) {
 	sub := chi.NewRouter()
+	if scope == registry.ScopeInternal {
+		sub.Use(httputil.MaxBytes(internalRouteBodyCap))
+	}
 	if scopeMiddleware != nil {
 		sub.Use(scopeMiddleware)
 	}

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -634,6 +634,32 @@ func TestPlatformRoutes_MaxBytesLimit(t *testing.T) {
 	}
 }
 
+func TestInternalRoutes_MaxBytesLimit(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+
+	// Handler must read the body for MaxBytesReader to trigger.
+	m.OnEvent("big-event", func(w http.ResponseWriter, r *http.Request) {
+		var v json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Build a body > 1 MB to exceed the internal route cap
+	padding := strings.Repeat("a", 1<<20+1)
+	bigJSON := `{"data":"` + padding + `"}`
+	req := httptest.NewRequest("POST", "/__mirrorstack/events/big-event", strings.NewReader(bigJSON))
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413 for oversized internal route body, got %d", rec.Code)
+	}
+}
+
 func TestScopesPanic_BeforeInit(t *testing.T) {
 	fns := map[string]func(){
 		"Platform":          func() { Platform(func(r chi.Router) {}) },


### PR DESCRIPTION
1 MB body cap on all Internal-scope routes (events, crons, tasks). 2 files, +35 lines.