### PR TITLE
perf(routing): single-route fast-path for OnEvent/Cron/OnTask (closes #51)

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -3,7 +3,7 @@ package mirrorstack
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 )
 
 // cronPathPrefix mounts under the reserved /__mirrorstack/ namespace.
@@ -35,9 +35,7 @@ func (m *Module) Cron(name, schedule string, handler http.HandlerFunc) {
 	if !m.registry.AddSchedule(name, schedule, path) {
 		panic("mirrorstack: Cron(" + name + ") registered twice")
 	}
-	m.Internal(func(r chi.Router) {
-		r.Post(path, handler)
-	})
+	m.scopedSingleRoute(registry.ScopeInternal, m.internalAuth, "POST", path, handler)
 }
 
 // Cron registers a cron job on the default Module created by Init(). Panics

--- a/event.go
+++ b/event.go
@@ -3,7 +3,7 @@ package mirrorstack
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 )
 
 // eventPathPrefix mounts under the reserved /__mirrorstack/ namespace so
@@ -32,9 +32,7 @@ func (m *Module) OnEvent(name string, handler http.HandlerFunc) {
 	if !m.registry.AddSubscribe(name, path) {
 		panic("mirrorstack: OnEvent(" + name + ") registered twice")
 	}
-	m.Internal(func(r chi.Router) {
-		r.Post(path, handler)
-	})
+	m.scopedSingleRoute(registry.ScopeInternal, m.internalAuth, "POST", path, handler)
 }
 
 // Emits declares that this module emits an event of the given name. The

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -409,6 +409,23 @@ func (m *Module) Internal(fn func(r chi.Router)) {
 // unbounded without this.
 const internalRouteBodyCap = 1 << 20 // 1 MB
 
+// scopedSingleRoute records and mounts one route on the given scope without
+// allocating an intermediate chi sub-router. Used by OnEvent, Cron, and OnTask
+// which always register exactly one POST handler at a known path. Avoids the
+// chi.NewRouter + chi.Walk overhead that scopedRoutes pays for multi-route
+// registration callbacks.
+func (m *Module) scopedSingleRoute(scope registry.Scope, scopeMiddleware func(http.Handler) http.Handler, method, path string, handler http.Handler) {
+	m.registry.AddRoute(scope, method, path)
+	mw := make([]func(http.Handler) http.Handler, 0, 2)
+	if scope == registry.ScopeInternal {
+		mw = append(mw, httputil.MaxBytes(internalRouteBodyCap))
+	}
+	if scopeMiddleware != nil {
+		mw = append(mw, scopeMiddleware)
+	}
+	m.router.With(mw...).Method(method, path, handler)
+}
+
 func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Handler) http.Handler, fn func(r chi.Router)) {
 	sub := chi.NewRouter()
 	if scope == registry.ScopeInternal {

--- a/task.go
+++ b/task.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
@@ -92,9 +90,7 @@ func (m *Module) OnTask(name string, handler TaskHandler, opts ...TaskOption) {
 	// Mount a dev/debug HTTP endpoint on the Internal scope so developers
 	// can test task handlers via curl without SQS infrastructure.
 	path := taskPathPrefix + name
-	m.Internal(func(r chi.Router) {
-		r.Post(path, m.taskHTTPHandler(name))
-	})
+	m.scopedSingleRoute(registry.ScopeInternal, m.internalAuth, "POST", path, m.taskHTTPHandler(name))
 }
 
 // taskHTTPHandler returns an http.HandlerFunc that dispatches to the named


### PR DESCRIPTION
Eliminates chi.NewRouter + chi.Walk per event/cron/task registration. 4 files, net -13/+22 lines.