### PR TITLE
feat(meter): ms.Meter(ctx).Record for usage metrics (closes #13)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3x
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWURB8avufQq9gFsheUgjVD9536obIknfM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0 h1:e4NAllPs/ygQ7W4dTlAuP5N7QpCT+rTij3S8UOv2DD4=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.89.0/go.mod h1:6HBXRyFFqOw+ALkJ6YGHfrr20/YXYv6X9pcZErXRvCA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0 h1:foqo/ocQ7WqKwy3FojGtZQJo0FR4vto9qnz9VaumbCo=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=

--- a/internal/ids/uuid.go
+++ b/internal/ids/uuid.go
@@ -1,0 +1,22 @@
+// Package ids provides identifier helpers shared across SDK packages.
+// It is a leaf package with no internal imports so any SDK package can
+// use it without creating a cycle.
+package ids
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// NewUUID returns a random UUID v4 string (version 4, variant RFC 4122).
+// Panics if crypto/rand.Read fails — callers cannot recover from entropy
+// exhaustion on this path.
+func NewUUID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("mirrorstack/ids: crypto/rand.Read failed: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant RFC 4122
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}

--- a/internal/ids/uuid_test.go
+++ b/internal/ids/uuid_test.go
@@ -1,0 +1,49 @@
+package ids_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/ids"
+)
+
+var uuidV4Pattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestNewUUID_Format(t *testing.T) {
+	t.Parallel()
+	u := ids.NewUUID()
+	if !uuidV4Pattern.MatchString(u) {
+		t.Errorf("NewUUID() = %q, want UUID v4 format", u)
+	}
+}
+
+func TestNewUUID_Uniqueness(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, 1000)
+	for i := 0; i < 1000; i++ {
+		u := ids.NewUUID()
+		if _, dup := seen[u]; dup {
+			t.Fatalf("NewUUID() produced duplicate %q at iteration %d", u, i)
+		}
+		seen[u] = struct{}{}
+	}
+}
+
+func TestNewUUID_VersionAndVariantBits(t *testing.T) {
+	t.Parallel()
+	u := ids.NewUUID()
+	// UUID format: xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
+	// M = version (4), N first nibble must be 8, 9, a, or b (variant RFC 4122)
+	parts := strings.Split(u, "-")
+	if len(parts) != 5 {
+		t.Fatalf("unexpected format: %q", u)
+	}
+	if parts[2][0] != '4' {
+		t.Errorf("version nibble = %c, want 4", parts[2][0])
+	}
+	variant := parts[3][0]
+	if variant != '8' && variant != '9' && variant != 'a' && variant != 'b' {
+		t.Errorf("variant nibble = %c, want 8/9/a/b (RFC 4122)", variant)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -123,9 +123,9 @@ func (r *Registry) Routes() map[Scope][]Route {
 
 // AddEmit declares that the module emits an event of the given name.
 // Returns true if added, false if a declaration for that name already exists
-// (first-wins). Panics on an invalid name (see validateRegistrationName).
+// (first-wins). Panics on an invalid name (see ValidateName).
 func (r *Registry) AddEmit(name string) bool {
-	validateRegistrationName("Emits", name)
+	ValidateName("Emits", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if slices.Contains(r.emits, name) {
@@ -148,9 +148,9 @@ func (r *Registry) Emits() []string {
 // AddSubscribe declares that the module subscribes to an event from another
 // module. The handler is mounted at path on the Internal scope. Returns true
 // if added, false if a subscription for that event name already exists
-// (first-wins). Panics on an invalid name (see validateRegistrationName).
+// (first-wins). Panics on an invalid name (see ValidateName).
 func (r *Registry) AddSubscribe(name, path string) bool {
-	validateRegistrationName("OnEvent", name)
+	ValidateName("OnEvent", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.subscribes[name]; exists {
@@ -172,9 +172,9 @@ func (r *Registry) Subscribes() map[string]string {
 
 // AddSchedule registers a cron job. Returns true if added, false if a job
 // with the same name already exists (first-wins). Panics on an invalid name
-// (see validateRegistrationName).
+// (see ValidateName).
 func (r *Registry) AddSchedule(name, cron, path string) bool {
-	validateRegistrationName("Cron", name)
+	ValidateName("Cron", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.schedules {
@@ -198,9 +198,9 @@ func (r *Registry) Schedules() []Schedule {
 
 // AddTask declares a background task. Returns true if added, false if a task
 // with the same name already exists (first-wins). Panics on an invalid name
-// (see validateRegistrationName).
+// (see ValidateName).
 func (r *Registry) AddTask(task Task) bool {
-	validateRegistrationName("OnTask", task.Name)
+	ValidateName("OnTask", task.Name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.tasks {
@@ -226,13 +226,13 @@ func (r *Registry) Tasks() []Task {
 // AddPermission for the same name is dropped (matches AddRoute / AddEmit /
 // AddSchedule semantics). The roles slice is cloned so caller mutations
 // after the call cannot leak into the stored copy. Panics on an invalid
-// name (see validateRegistrationName) — permissions don't end up in URL
+// name (see ValidateName) — permissions don't end up in URL
 // paths, so the path-separator check is purely cosmetic for permissions,
 // but the consistency with AddSubscribe/AddEmit/AddSchedule prevents
 // downstream consumers (DB columns, log parsers) from receiving malformed
 // strings via the manifest.
 func (r *Registry) AddPermission(name string, roles []string) {
-	validateRegistrationName("RequirePermission", name)
+	ValidateName("RequirePermission", name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.permissions {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -396,7 +396,7 @@ func TestAddPermission_PanicsOnInvalidName(t *testing.T) {
 	// Permissions don't end up in URL paths, but they DO appear in the
 	// manifest payload which platform-side consumers may use as identifiers
 	// for grant UI, RBAC tables, log fields, etc. Sharing the registry's
-	// validateRegistrationName guard with AddSubscribe/AddEmit/AddSchedule
+	// ValidateName guard with AddSubscribe/AddEmit/AddSchedule
 	// prevents inconsistent behavior across the four registration sites
 	// and keeps malformed strings (null bytes, dot-segments) out of the
 	// manifest regardless of which Add* the developer called.

--- a/internal/registry/validate.go
+++ b/internal/registry/validate.go
@@ -2,7 +2,7 @@ package registry
 
 import "strings"
 
-// validateRegistrationName rejects names that are empty, contain a path
+// ValidateName rejects names that are empty, contain a path
 // separator (/, \), contain a dot-segment (..), contain whitespace, or
 // contain a null byte. The name is concatenated into a URL path by the
 // SDK's event/cron handlers, so any character that chi might normalize
@@ -20,9 +20,9 @@ import "strings"
 // is byte-oriented and a Unicode-whitespace name would simply produce a
 // dead handler, not a security issue.
 //
-// kind is the user-facing API name (e.g., "OnEvent", "Cron", "Emits") used
-// in the panic message so callers see which call failed validation.
-func validateRegistrationName(kind, name string) {
+// kind is the user-facing API name (e.g., "OnEvent", "Cron", "Emits", "Record")
+// used in the panic message so callers see which call failed validation.
+func ValidateName(kind, name string) {
 	if name == "" {
 		panic("mirrorstack/registry: " + kind + " name cannot be empty")
 	}

--- a/meter/event.go
+++ b/meter/event.go
@@ -1,0 +1,27 @@
+package meter
+
+import "time"
+
+// envelopeVersion is the current wire format version. Bump on breaking changes.
+const envelopeVersion = 1
+
+// Event is the JSON wire format sent to the platform meter Lambda.
+//
+// Fields ending in Hint are SDK-asserted values the platform uses for
+// debugging and logging but MUST NOT trust for billing attribution. The
+// authoritative values come from the AWS invoker identity (context.FunctionArn)
+// cross-checked against a platform-owned Lambda→app mapping.
+//
+// ModuleIDHint is required (no omitempty) even though it is labeled a hint —
+// the "Hint" suffix means "SDK-asserted, not authoritative," not "optional."
+// AppIDHint is omitempty because system-triggered events may have no app
+// context (e.g., cron job running without an AppID in ctx).
+type Event struct {
+	V              int       `json:"v"`
+	EventID        string    `json:"eventId"`
+	AppIDHint      string    `json:"appIdHint,omitempty"`
+	ModuleIDHint   string    `json:"moduleIdHint"`
+	Metric         string    `json:"metric"`
+	Value          float64   `json:"value"`
+	RecordedAtHint time.Time `json:"recordedAtHint"`
+}

--- a/meter/event_test.go
+++ b/meter/event_test.go
@@ -1,0 +1,51 @@
+package meter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEvent_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1712888400, 0).UTC()
+	in := Event{
+		V:              1,
+		EventID:        "b9c6a0f0-1234-4abc-8def-0123456789ab",
+		AppIDHint:      "app_abc",
+		ModuleIDHint:   "media",
+		Metric:         "transcode.minutes",
+		Value:          12.5,
+		RecordedAtHint: now,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Confirm Hint suffix is visible on the wire.
+	raw := string(b)
+	for _, key := range []string{`"appIdHint"`, `"moduleIdHint"`, `"recordedAtHint"`, `"v":1`, `"eventId"`} {
+		if !strings.Contains(raw, key) {
+			t.Errorf("wire format missing %s: %s", key, raw)
+		}
+	}
+
+	var out Event
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.EventID != in.EventID || out.ModuleIDHint != in.ModuleIDHint || out.Metric != in.Metric || out.Value != in.Value {
+		t.Errorf("roundtrip mismatch: %+v", out)
+	}
+}
+
+func TestEvent_EmptyAppIDHintOmitted(t *testing.T) {
+	t.Parallel()
+	e := Event{V: 1, EventID: "x", ModuleIDHint: "media", Metric: "m", Value: 1, RecordedAtHint: time.Now()}
+	b, _ := json.Marshal(e)
+	if strings.Contains(string(b), "appIdHint") {
+		t.Errorf("empty appIdHint should be omitted, got: %s", string(b))
+	}
+}

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -1,0 +1,139 @@
+// Package meter emits usage events for billing to a platform-owned AWS
+// Lambda function via async invoke. See the Meter interface for the API.
+//
+// Security model: IAM invoke permission scoped to the exact meter ARN is
+// the sole access control. Wire-format fields suffixed with Hint (AppIDHint,
+// ModuleIDHint, RecordedAtHint) are NOT trusted — the platform meter Lambda
+// re-derives authoritative values from the invoker's AWS identity.
+package meter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/ids"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+)
+
+// arnPattern matches a valid Lambda function ARN. Validated at Client
+// construction so a typo in MS_METER_LAMBDA_ARN fails fast at startup
+// rather than at first Record call (silent revenue loss otherwise).
+var arnPattern = regexp.MustCompile(`^arn:aws:lambda:[a-z0-9-]+:[0-9]+:function:[a-zA-Z0-9_-]+$`)
+
+// Meter records usage events for billing.
+type Meter interface {
+	// Record emits a usage event via async Lambda invoke (production) or
+	// stderr log (dev mode). Synchronous: blocks for the duration of the
+	// Lambda control-plane round-trip (~5-15ms).
+	//
+	// Call sparingly — once per meaningful action, not per row processed.
+	// Errors should be logged, not propagated — billing failures should
+	// never fail the handler.
+	//
+	// Metric names must not contain path separators (/, \), whitespace,
+	// dot-segments (..), or null bytes. Panics on invalid name.
+	Record(metric string, value float64) error
+}
+
+// lambdaInvoker is the subset of lambda.Client used by Client. Makes the
+// Lambda invoke path mockable in unit tests.
+type lambdaInvoker interface {
+	Invoke(ctx context.Context, params *lambda.InvokeInput, optFns ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
+}
+
+// Client is the module-level meter client. Created eagerly at Module.New()
+// when MS_METER_LAMBDA_ARN is set. Nil in dev mode.
+type Client struct {
+	lambdaClient lambdaInvoker
+	functionARN  string
+	logger       *log.Logger // dev-mode stderr sink when lambdaClient is nil
+}
+
+// NewFromARN creates a production meter client for the given Lambda function
+// ARN. Validates ARN format against arnPattern. Uses the module's default
+// AWS IAM role (same pattern as internal/sqs/client.go).
+func NewFromARN(ctx context.Context, arn string) (*Client, error) {
+	if !arnPattern.MatchString(arn) {
+		return nil, fmt.Errorf("mirrorstack/meter: invalid ARN format %q (expected arn:aws:lambda:<region>:<account>:function:<name>)", arn)
+	}
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("mirrorstack/meter: load aws config: %w", err)
+	}
+	return &Client{
+		lambdaClient: lambda.NewFromConfig(cfg),
+		functionARN:  arn,
+	}, nil
+}
+
+// NewDev creates a dev-mode meter client that logs Record calls to the given
+// logger (typically Module.logger writing to stderr). Returns a non-nil
+// Client; Meter.Record is a no-op beyond the log line.
+func NewDev(logger *log.Logger) *Client {
+	return &Client{logger: logger}
+}
+
+// Scope returns a Meter bound to the current request context. The AppID is
+// read from auth.Get(ctx) as a hint only — the platform does not trust it.
+func (c *Client) Scope(ctx context.Context, moduleID string) Meter {
+	appID := ""
+	if a := auth.Get(ctx); a != nil {
+		appID = a.AppID
+	}
+	return &scopedMeter{
+		ctx:      ctx,
+		client:   c,
+		moduleID: moduleID,
+		appID:    appID,
+	}
+}
+
+type scopedMeter struct {
+	ctx      context.Context
+	client   *Client
+	moduleID string
+	appID    string
+}
+
+func (s *scopedMeter) Record(metric string, value float64) error {
+	registry.ValidateName("Record", metric)
+
+	// Dev mode: log to stderr and return. The appID may be empty if the
+	// context has no auth identity (e.g., internal route, test harness).
+	if s.client.lambdaClient == nil {
+		s.client.logger.Printf("meter: appID=%q moduleID=%q metric=%q value=%g", s.appID, s.moduleID, metric, value)
+		return nil
+	}
+
+	event := Event{
+		V:              envelopeVersion,
+		EventID:        ids.NewUUID(),
+		AppIDHint:      s.appID,
+		ModuleIDHint:   s.moduleID,
+		Metric:         metric,
+		Value:          value,
+		RecordedAtHint: time.Now().UTC(),
+	}
+	body, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("mirrorstack/meter: marshal event: %w", err)
+	}
+	_, err = s.client.lambdaClient.Invoke(s.ctx, &lambda.InvokeInput{
+		FunctionName:   &s.client.functionARN,
+		InvocationType: types.InvocationTypeEvent, // async fire-and-forget
+		Payload:        body,
+	})
+	if err != nil {
+		return fmt.Errorf("mirrorstack/meter: invoke %s: %w", s.client.functionARN, err)
+	}
+	return nil
+}

--- a/meter/meter_test.go
+++ b/meter/meter_test.go
@@ -1,0 +1,177 @@
+package meter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+)
+
+type fakeLambda struct {
+	invoked int
+	lastIn  *lambda.InvokeInput
+	err     error
+}
+
+func (f *fakeLambda) Invoke(ctx context.Context, in *lambda.InvokeInput, _ ...func(*lambda.Options)) (*lambda.InvokeOutput, error) {
+	f.invoked++
+	f.lastIn = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &lambda.InvokeOutput{StatusCode: 202}, nil
+}
+
+func newTestClient(t *testing.T, fake *fakeLambda) *Client {
+	t.Helper()
+	return &Client{
+		lambdaClient: fake,
+		functionARN:  "arn:aws:lambda:us-east-1:123456789012:function:meter-test",
+	}
+}
+
+func TestNewFromARN_ValidARN(t *testing.T) {
+	t.Parallel()
+	_, err := NewFromARN(context.Background(), "arn:aws:lambda:us-east-1:123456789012:function:meter")
+	if err != nil {
+		t.Fatalf("NewFromARN with valid ARN: %v", err)
+	}
+}
+
+func TestNewFromARN_InvalidARN(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"",
+		"not-an-arn",
+		"arn:aws:s3:::bucket/key", // wrong service
+		"arn:aws:lambda::123456789012:function:meter",             // missing region
+		"arn:aws:lambda:us-east-1::function:meter",                // missing account
+		"arn:aws:lambda:us-east-1:123456789012:function:",         // missing name
+		"arn:aws:lambda:us-east-1:123456789012:function:bad name", // space in name
+	}
+	for _, arn := range cases {
+		t.Run(arn, func(t *testing.T) {
+			_, err := NewFromARN(context.Background(), arn)
+			if err == nil {
+				t.Errorf("NewFromARN(%q) should reject invalid ARN", arn)
+			}
+		})
+	}
+}
+
+func TestRecord_ProdInvokesLambda(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambda{}
+	c := newTestClient(t, fake)
+
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "app_abc", AppRole: "admin"})
+	m := c.Scope(ctx, "media")
+	if err := m.Record("transcode.minutes", 12); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if fake.invoked != 1 {
+		t.Errorf("Lambda invoked %d times, want 1", fake.invoked)
+	}
+	if *fake.lastIn.FunctionName != "arn:aws:lambda:us-east-1:123456789012:function:meter-test" {
+		t.Errorf("wrong function name")
+	}
+	if fake.lastIn.InvocationType != types.InvocationTypeEvent {
+		t.Errorf("invocation type = %v, want Event (async)", fake.lastIn.InvocationType)
+	}
+
+	var got Event
+	if err := json.Unmarshal(fake.lastIn.Payload, &got); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if got.V != 1 {
+		t.Errorf("envelope version = %d, want 1", got.V)
+	}
+	if got.EventID == "" {
+		t.Error("EventID should be set")
+	}
+	if got.Metric != "transcode.minutes" {
+		t.Errorf("metric = %q, want transcode.minutes", got.Metric)
+	}
+	if got.Value != 12 {
+		t.Errorf("value = %g, want 12", got.Value)
+	}
+	if got.AppIDHint != "app_abc" {
+		t.Errorf("appIdHint = %q, want app_abc", got.AppIDHint)
+	}
+	if got.ModuleIDHint != "media" {
+		t.Errorf("moduleIdHint = %q, want media", got.ModuleIDHint)
+	}
+	if got.RecordedAtHint.IsZero() {
+		t.Error("recordedAtHint should be set")
+	}
+}
+
+func TestRecord_PropagatesLambdaError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambda{err: errors.New("throttled")}
+	c := newTestClient(t, fake)
+
+	m := c.Scope(context.Background(), "media")
+	err := m.Record("transcode.minutes", 1)
+	if err == nil || !strings.Contains(err.Error(), "throttled") {
+		t.Errorf("expected wrapped throttled error, got %v", err)
+	}
+}
+
+func TestRecord_DevModeLogsToStderr(t *testing.T) {
+	var buf bytes.Buffer
+	c := NewDev(log.New(&buf, "", 0))
+
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "dev_app"})
+	m := c.Scope(ctx, "media")
+	if err := m.Record("transcode.minutes", 12); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `appID="dev_app"`) ||
+		!strings.Contains(out, `moduleID="media"`) ||
+		!strings.Contains(out, `metric="transcode.minutes"`) ||
+		!strings.Contains(out, `value=12`) {
+		t.Errorf("unexpected log line: %q", out)
+	}
+}
+
+func TestRecord_DevMode_EmptyAppIDWhenNoAuth(t *testing.T) {
+	var buf bytes.Buffer
+	c := NewDev(log.New(&buf, "", 0))
+
+	m := c.Scope(context.Background(), "media")
+	_ = m.Record("transcode.minutes", 1)
+
+	if !strings.Contains(buf.String(), `appID=""`) {
+		t.Errorf("expected appID=\"\" when context has no auth identity, got: %q", buf.String())
+	}
+}
+
+func TestRecord_InvalidMetricNamePanics(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambda{}
+	c := newTestClient(t, fake)
+	m := c.Scope(context.Background(), "media")
+
+	bad := []string{"", "has/slash", "has space", "has..dots", "null\x00byte"}
+	for _, metric := range bad {
+		t.Run(metric, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic on invalid metric name %q", metric)
+				}
+			}()
+			_ = m.Record(metric, 1)
+		})
+	}
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -31,6 +31,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
 	msqs "github.com/mirrorstack-ai/app-module-sdk/internal/sqs"
+	"github.com/mirrorstack-ai/app-module-sdk/meter"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 	"github.com/mirrorstack-ai/app-module-sdk/system"
 )
@@ -89,6 +90,7 @@ type Module struct {
 	taskHandlers   map[string]taskEntry // registered task handlers (startup-only writes)
 	sqsClient      *msqs.Client         // nil in dev mode (MS_TASK_QUEUE_URL unset)
 	signingKey     []byte               // HMAC key for TaskMessage signing (MS_TASK_SIGNING_KEY)
+	meterClient    *meter.Client        // prod (MS_METER_LAMBDA_ARN set) or dev-mode stderr
 }
 
 // moduleIDPattern matches valid module IDs: lowercase letter, then lowercase alphanumerics/underscores, max 31 chars.
@@ -124,6 +126,19 @@ func New(cfg Config) (*Module, error) {
 			return nil, fmt.Errorf("mirrorstack: init sqs client: %w", err)
 		}
 		m.sqsClient = sqsClient
+	}
+
+	// Meter client: production mode when MS_METER_LAMBDA_ARN is set (ARN is
+	// validated at construction so typos fail fast), dev-mode stderr sink
+	// otherwise. Never nil.
+	if meterARN := os.Getenv("MS_METER_LAMBDA_ARN"); meterARN != "" {
+		meterClient, err := meter.NewFromARN(context.Background(), meterARN)
+		if err != nil {
+			return nil, fmt.Errorf("mirrorstack: init meter client: %w", err)
+		}
+		m.meterClient = meterClient
+	} else {
+		m.meterClient = meter.NewDev(m.logger)
 	}
 
 	m.mountSystemRoutes()
@@ -347,6 +362,22 @@ func (m *Module) resolveCache(ctx context.Context) (*cache.Client, func(), error
 // already sets the prefix from cred.Prefix, so no separate ForApp scoping is needed.
 func (m *Module) Storage(ctx context.Context) (storage.Storer, error) {
 	return m.resolveStorage(ctx)
+}
+
+// Meter returns a scoped meter for recording usage events (billing metrics).
+// Unlike DB/Cache/Storage, Meter returns the interface directly — there is
+// no release closure (nothing to release) and no construction error
+// (init errors happen eagerly in New()).
+//
+// In production (MS_METER_LAMBDA_ARN set), Record dispatches to the platform
+// meter Lambda via async invoke (~5-15ms per call). In dev mode, Record
+// logs to stderr.
+//
+//	if err := ms.Meter(r.Context()).Record("transcode.minutes", 12); err != nil {
+//	    log.Printf("meter: %v", err) // don't fail the handler
+//	}
+func (m *Module) Meter(ctx context.Context) meter.Meter {
+	return m.meterClient.Scope(ctx, m.config.ID)
 }
 
 func (m *Module) resolveStorage(ctx context.Context) (*storage.Client, error) {
@@ -697,6 +728,12 @@ func Cache(ctx context.Context) (cache.Cacher, func(), error) {
 // Storage returns a scoped storage client on the default module.
 func Storage(ctx context.Context) (storage.Storer, error) {
 	return mustDefault("Storage").Storage(ctx)
+}
+
+// Meter returns a scoped meter for recording usage events on the default module.
+// Panics before Init.
+func Meter(ctx context.Context) meter.Meter {
+	return mustDefault("Meter").Meter(ctx)
 }
 
 // Platform registers platform-scoped routes on the default module.

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -662,6 +662,7 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
 		"OnTask":            func() { OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil }) },
 		"RunTask":           func() { _, _ = RunTask(context.Background(), "work", nil) },
+		"Meter":             func() { _ = Meter(context.Background()).Record("m", 1) },
 		"ModuleDB":          func() { _, _, _ = ModuleDB(context.Background()) },
 		"ModuleTx":          func() { _ = ModuleTx(context.Background(), func(q db.Querier) error { return nil }) },
 	}

--- a/task.go
+++ b/task.go
@@ -2,7 +2,6 @@ package mirrorstack
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/ids"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
@@ -184,7 +184,7 @@ func (m *Module) RunTask(ctx context.Context, name string, payload json.RawMessa
 // copying credentials so the task worker has identical DB/Cache/Storage access.
 func (m *Module) buildTaskMessage(ctx context.Context, name string, payload json.RawMessage) *runtime.TaskMessage {
 	msg := &runtime.TaskMessage{
-		TaskID:  generateTaskID(),
+		TaskID:  ids.NewUUID(),
 		Name:    name,
 		Payload: payload,
 	}
@@ -213,17 +213,6 @@ func (m *Module) buildTaskMessage(ctx context.Context, name string, payload json
 	msg.AppSchema = db.SchemaFrom(ctx)
 
 	return msg
-}
-
-// generateTaskID returns a new UUID v4 string for task deduplication.
-func generateTaskID() string {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		panic("mirrorstack: crypto/rand.Read failed: " + err.Error())
-	}
-	b[6] = (b[6] & 0x0f) | 0x40 // version 4
-	b[8] = (b[8] & 0x3f) | 0x80 // variant 2
-	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
 // OnTask registers a task handler on the default Module created by Init().


### PR DESCRIPTION
Push-only billing meter via AWS Lambda async invoke. IAM scoped to exact ARN is sole access control — no HMAC (would be theater since module holds key). Platform meter Lambda re-derives AppID from context.FunctionArn; payload Hint-fields are never trusted. 11 files, +525 lines. Also extracts UUID generator to internal/ids/.