### PR TITLE
feat: Describe + DependsOn (auto-detect) + Resolve[T] + manifest fields (#82)

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -69,16 +69,27 @@ type Permission struct {
 	Roles []string `json:"roles"`
 }
 
+// Dependency is a declared dependency on another module. Optional=true means
+// the dependent module works standalone and uses the dependency opportunistically
+// at runtime via Resolve[T]; Optional=false means the platform must install the
+// dependency before this module.
+type Dependency struct {
+	ID       string `json:"id"`
+	Optional bool   `json:"optional,omitempty"`
+}
+
 // Registry is the per-module registry of routes/events/schedules/tasks/permissions.
 // All operations are safe for concurrent use.
 type Registry struct {
-	mu          sync.RWMutex
-	routes      map[Scope][]Route
-	emits       []string
-	subscribes  map[string]string // event name → internal path
-	schedules   []Schedule
-	tasks       []Task
-	permissions []Permission
+	mu           sync.RWMutex
+	routes       map[Scope][]Route
+	emits        []string
+	subscribes   map[string]string // event name → internal path
+	schedules    []Schedule
+	tasks        []Task
+	permissions  []Permission
+	description  string
+	dependencies []Dependency
 }
 
 func New() *Registry {
@@ -86,6 +97,57 @@ func New() *Registry {
 		routes:     make(map[Scope][]Route),
 		subscribes: make(map[string]string),
 	}
+}
+
+// SetDescription sets the module's human-readable description. Last-write-wins;
+// typically called once at module init via ms.Describe.
+func (r *Registry) SetDescription(s string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.description = s
+}
+
+// Description returns the module description, or empty string if unset.
+func (r *Registry) Description() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.description
+}
+
+// AddDependency records a dependency on another module by ID. The optional flag
+// distinguishes required (install-time) from optional (runtime Resolve) deps.
+//
+// Dedup: if the same ID is declared both ways across the codebase, required
+// wins (stricter beats looser). A subsequent required call upgrades a prior
+// optional entry; a subsequent optional call never downgrades a required one.
+// Returns true if the dependency was newly added or upgraded from optional to
+// required, false if the call was a no-op.
+func (r *Registry) AddDependency(id string, optional bool) bool {
+	ValidateName("DependsOn", id)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, existing := range r.dependencies {
+		if existing.ID == id {
+			if existing.Optional && !optional {
+				r.dependencies[i].Optional = false
+				return true
+			}
+			return false
+		}
+	}
+	r.dependencies = append(r.dependencies, Dependency{ID: id, Optional: optional})
+	return true
+}
+
+// Dependencies returns a non-nil copy of all declared dependencies in
+// registration order.
+func (r *Registry) Dependencies() []Dependency {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.dependencies == nil {
+		return []Dependency{}
+	}
+	return slices.Clone(r.dependencies)
 }
 
 // AddRoute records a route under the given scope. First-wins: duplicate

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -421,3 +421,147 @@ func TestAddPermission_PanicsOnInvalidName(t *testing.T) {
 		})
 	}
 }
+
+// ---- Description ----
+
+func TestDescription_SetAndGet(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	if got := r.Description(); got != "" {
+		t.Errorf("empty Registry Description = %q, want empty", got)
+	}
+	r.SetDescription("A demo module")
+	if got := r.Description(); got != "A demo module" {
+		t.Errorf("Description = %q, want %q", got, "A demo module")
+	}
+}
+
+func TestDescription_LastWins(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.SetDescription("first")
+	r.SetDescription("second")
+	if got := r.Description(); got != "second" {
+		t.Errorf("Description = %q, want %q (last-wins)", got, "second")
+	}
+}
+
+// ---- Dependencies ----
+
+func TestDependencies_AddRequired(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	if added := r.AddDependency("oauth-core", false); !added {
+		t.Error("AddDependency(new, required) = false, want true")
+	}
+	got := r.Dependencies()
+	if len(got) != 1 || got[0].ID != "oauth-core" || got[0].Optional {
+		t.Errorf("Dependencies = %+v, want [{ID:oauth-core, Optional:false}]", got)
+	}
+}
+
+func TestDependencies_AddOptional(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddDependency("video", true)
+	got := r.Dependencies()
+	if len(got) != 1 || got[0].ID != "video" || !got[0].Optional {
+		t.Errorf("Dependencies = %+v, want [{ID:video, Optional:true}]", got)
+	}
+}
+
+func TestDependencies_RequiredUpgradesOptional(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddDependency("oauth-core", true) // optional first
+	if upgraded := r.AddDependency("oauth-core", false); !upgraded {
+		t.Error("AddDependency(optional→required) = false, want true (upgrade)")
+	}
+	got := r.Dependencies()
+	if len(got) != 1 || got[0].Optional {
+		t.Errorf("after required override: Dependencies = %+v, want Optional=false", got)
+	}
+}
+
+func TestDependencies_OptionalDoesNotDowngradeRequired(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddDependency("oauth-core", false) // required first
+	if added := r.AddDependency("oauth-core", true); added {
+		t.Error("AddDependency(required→optional) = true, want false (no-op)")
+	}
+	got := r.Dependencies()
+	if len(got) != 1 || got[0].Optional {
+		t.Errorf("after optional override of required: Dependencies = %+v, want Optional=false", got)
+	}
+}
+
+func TestDependencies_DuplicateRequiredIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddDependency("a", false)
+	if added := r.AddDependency("a", false); added {
+		t.Error("AddDependency(same required twice) = true, want false (no-op)")
+	}
+	if got := r.Dependencies(); len(got) != 1 {
+		t.Errorf("len(Dependencies) = %d after duplicate, want 1", len(got))
+	}
+}
+
+func TestDependencies_EmptyReturnsNonNil(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	got := r.Dependencies()
+	if got == nil {
+		t.Error("Dependencies() on empty Registry returned nil, want []Dependency{}")
+	}
+	if len(got) != 0 {
+		t.Errorf("len(Dependencies()) = %d, want 0", len(got))
+	}
+}
+
+func TestDependencies_PreservesRegistrationOrder(t *testing.T) {
+	t.Parallel()
+
+	r := New()
+	r.AddDependency("third", false)
+	r.AddDependency("first", false)
+	r.AddDependency("second", true)
+	got := r.Dependencies()
+	if len(got) != 3 || got[0].ID != "third" || got[1].ID != "first" || got[2].ID != "second" {
+		t.Errorf("Dependencies = %+v, want registration order third, first, second", got)
+	}
+}
+
+func TestDependencies_ValidateNameRejectsBad(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		bad  string
+	}{
+		{"empty", ""},
+		{"dot-segment", "../oauth-core"},
+		{"slash", "foo/bar"},
+		{"null-byte", "foo\x00bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New()
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Errorf("expected panic for AddDependency(%q)", tc.bad)
+				}
+			}()
+			r.AddDependency(tc.bad, false)
+		})
+	}
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -13,7 +13,9 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	runtimepkg "runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -482,6 +484,127 @@ func (m *Module) RequirePermission(name string, roles ...string) func(http.Handl
 //	})
 func RequirePermission(name string, roles ...string) func(http.Handler) http.Handler {
 	return mustDefault("RequirePermission").RequirePermission(name, roles...)
+}
+
+// Describe sets the module's human-readable description. Used by the catalog
+// for agent discovery ("find a module that does X"). One to three sentences is
+// typical. Last call wins; typically called once at module init.
+//
+//	ms.Describe("Google OAuth provider: authorize, callback, session issue.")
+func (m *Module) Describe(s string) {
+	m.registry.SetDescription(s)
+}
+
+// DependsOn declares a dependency on another module by ID. The required vs
+// optional distinction is AUTO-DETECTED from the call site via the Go stack:
+//
+//   - Called from main.main or a package-level init() → REQUIRED (catalog
+//     installs the dependency before this module; install fails without it).
+//   - Called from anywhere else (helper functions, setup routines, handlers)
+//     → OPTIONAL (this module runs standalone; use ms.Resolve[T] to
+//     opportunistically use the dependency at runtime if installed).
+//
+// Caveat: an "extract function" refactor that moves a DependsOn call out of
+// main() into a helper silently changes the dep from required to optional.
+// Keep required deps declared literally in main() (or a package-level init()).
+// Escape hatch: wrap required deps in an init() if they must live outside
+// main, e.g. for a shared registration package.
+//
+//	func main() {
+//	    ms.Init(...)
+//	    ms.DependsOn("oauth-core")       // required — caller is main
+//	    registerVideoIntegration()
+//	    ms.Start()
+//	}
+//
+//	func registerVideoIntegration() {
+//	    ms.DependsOn("video")            // optional — caller is helper
+//	    ms.OnEvent("video.completed", handleVideoCompleted)
+//	}
+func (m *Module) DependsOn(id string) {
+	optional := !callerIsRoot()
+	m.registry.AddDependency(id, optional)
+}
+
+// Describe is the convenience wrapper that dispatches to the default Module.
+// Calling before Init() panics.
+func Describe(s string) { mustDefault("Describe").Describe(s) }
+
+// DependsOn is the convenience wrapper that dispatches to the default Module.
+// Calling before Init() panics. See Module.DependsOn for the auto-detect rule.
+func DependsOn(id string) { mustDefault("DependsOn").DependsOn(id) }
+
+// Resolve looks up a previously-registered client of type T by module ID.
+// Returns the zero value of T and false when no client is registered for id
+// (either because the dependency module isn't installed or no module has
+// exported a T-typed client).
+//
+// Pairs with DependsOn(id) declared optional: check ok before calling into T.
+//
+//	if user, ok := ms.Resolve[userclient.Client]("user"); ok {
+//	    user.UpsertByExternalIdentity(ctx, ext)
+//	} else {
+//	    // fallback: platform identity resolution
+//	}
+//
+// v1 note: cross-module client wiring is not yet designed. This stub always
+// returns (zero, false). Real resolution lands with the catalog's install
+// machinery.
+func Resolve[T any](id string) (T, bool) {
+	var zero T
+	return zero, false
+}
+
+// callerIsRoot inspects the stack and returns true when the user-code caller
+// of DependsOn is main.main or a package-level init function. SDK frames
+// (the DependsOn method itself, the package-level wrapper) are skipped.
+func callerIsRoot() bool {
+	pcs := make([]uintptr, 32)
+	// Skip: runtime.Callers (0), this function (1). Start at the caller of
+	// callerIsRoot, which is DependsOn.
+	n := runtimepkg.Callers(2, pcs)
+	if n == 0 {
+		return false
+	}
+	frames := runtimepkg.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		fn := frame.Function
+		// Skip the DependsOn plumbing frames (both receiver method and
+		// package-level wrapper end with ".DependsOn").
+		if strings.HasSuffix(fn, ".DependsOn") {
+			if !more {
+				return false
+			}
+			continue
+		}
+		return isRootCallerName(fn)
+	}
+}
+
+// isRootCallerName reports whether fn is main.main or any package init().
+// Go compiles init functions as "pkg.init", "pkg.init.0", "pkg.init.1" etc.
+func isRootCallerName(fn string) bool {
+	if fn == "main.main" {
+		return true
+	}
+	idx := strings.LastIndex(fn, ".init")
+	if idx < 0 {
+		return false
+	}
+	rest := fn[idx+len(".init"):]
+	if rest == "" {
+		return true
+	}
+	if !strings.HasPrefix(rest, ".") {
+		return false
+	}
+	for _, c := range rest[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // Start auto-detects the runtime mode and starts serving:

--- a/mirrorstack_test.go
+++ b/mirrorstack_test.go
@@ -665,6 +665,8 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"Meter":             func() { _ = Meter(context.Background()).Record("m", 1) },
 		"ModuleDB":          func() { _, _, _ = ModuleDB(context.Background()) },
 		"ModuleTx":          func() { _ = ModuleTx(context.Background(), func(q db.Querier) error { return nil }) },
+		"Describe":          func() { Describe("a module") },
+		"DependsOn":         func() { DependsOn("other") },
 	}
 	for name, fn := range fns {
 		t.Run(name, func(t *testing.T) {
@@ -701,5 +703,94 @@ func TestModule_ModuleSchema(t *testing.T) {
 				t.Errorf("moduleSchema() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// ---- Describe / DependsOn / Resolve ----
+
+func TestIsRootCallerName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		fn   string
+		want bool
+	}{
+		{"main.main", true},
+		{"main.init", true},
+		{"main.init.0", true},
+		{"main.init.12", true},
+		{"example.com/pkg.init", true},
+		{"example.com/pkg.init.5", true},
+		{"main.helperFunction", false},
+		{"pkg.SomeFunc", false},
+		{"pkg.initSomething", false}, // not an init — just starts with "init"
+		{"pkg.init.notNumber", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isRootCallerName(tc.fn); got != tc.want {
+			t.Errorf("isRootCallerName(%q) = %v, want %v", tc.fn, got, tc.want)
+		}
+	}
+}
+
+func TestDescribe_PopulatesRegistry(t *testing.T) {
+	t.Parallel()
+
+	m, _ := New(Config{ID: "demo"})
+	m.Describe("A demo module")
+	if got := m.registry.Description(); got != "A demo module" {
+		t.Errorf("Description = %q, want %q", got, "A demo module")
+	}
+}
+
+func TestDependsOn_FromHelperIsOptional(t *testing.T) {
+	t.Parallel()
+
+	m, _ := New(Config{ID: "demo"})
+	m.DependsOn("other") // called from test function — NOT main.main or init
+	deps := m.registry.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("len(Dependencies) = %d, want 1", len(deps))
+	}
+	if deps[0].ID != "other" || !deps[0].Optional {
+		t.Errorf("Dependencies[0] = %+v, want {ID:other, Optional:true}", deps[0])
+	}
+}
+
+func TestDependsOn_CallerDetectionSkipsSDKFrames(t *testing.T) {
+	t.Parallel()
+
+	// Verify both code paths (direct receiver + convenience wrapper) resolve
+	// the caller to the test function, not an SDK frame.
+	resetDefault(t)
+	if err := Init(Config{ID: "demo"}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	Describe("desc")
+	DependsOn("dep-via-wrapper")
+	defaultModule.DependsOn("dep-via-method")
+
+	deps := defaultModule.registry.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("len(Dependencies) = %d, want 2", len(deps))
+	}
+	for _, d := range deps {
+		if !d.Optional {
+			t.Errorf("dep %q: Optional = false, want true (test caller is not root)", d.ID)
+		}
+	}
+}
+
+func TestResolve_UnregisteredReturnsZeroAndFalse(t *testing.T) {
+	t.Parallel()
+
+	type fakeClient struct{ X int }
+	got, ok := Resolve[fakeClient]("not-registered")
+	if ok {
+		t.Error("Resolve for unregistered id returned ok=true, want false")
+	}
+	if got.X != 0 {
+		t.Errorf("Resolve returned non-zero value %+v, want zero", got)
 	}
 }

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -15,15 +15,17 @@ import (
 // migration versions, and the semver→migration mapping it needs to translate
 // lifecycle calls.
 type ManifestPayload struct {
-	ID          string                              `json:"id"`
-	Defaults    ManifestDefaults                    `json:"defaults"`
-	Migration   MigrationVersions                   `json:"migration"`
-	Versions    map[string]MigrationVersions        `json:"versions"`
-	Routes      map[registry.Scope][]registry.Route `json:"routes"`
-	Events      ManifestEvents                      `json:"events"`
-	Schedules   []registry.Schedule                 `json:"schedules"`
-	Tasks       []registry.Task                     `json:"tasks"`
-	Permissions []registry.Permission               `json:"permissions"`
+	ID           string                              `json:"id"`
+	Defaults     ManifestDefaults                    `json:"defaults"`
+	Description  string                              `json:"description,omitempty"`
+	Dependencies []registry.Dependency               `json:"dependencies"`
+	Migration    MigrationVersions                   `json:"migration"`
+	Versions     map[string]MigrationVersions        `json:"versions"`
+	Routes       map[registry.Scope][]registry.Route `json:"routes"`
+	Events       ManifestEvents                      `json:"events"`
+	Schedules    []registry.Schedule                 `json:"schedules"`
+	Tasks        []registry.Task                     `json:"tasks"`
+	Permissions  []registry.Permission               `json:"permissions"`
 }
 
 // MigrationVersions is the per-scope migration number set. Used both for the
@@ -82,15 +84,17 @@ func ManifestHandler(id, name, icon string, sqlFS fs.FS, versions map[string]Mig
 		}
 
 		httputil.JSON(w, http.StatusOK, ManifestPayload{
-			ID:          id,
-			Defaults:    ManifestDefaults{Name: name, Icon: icon},
-			Migration:   MigrationVersions{App: appVersion, Module: moduleVersion},
-			Versions:    versions,
-			Routes:      reg.Routes(),
-			Events:      ManifestEvents{Emits: reg.Emits(), Subscribes: reg.Subscribes()},
-			Schedules:   reg.Schedules(),
-			Tasks:       reg.Tasks(),
-			Permissions: reg.Permissions(),
+			ID:           id,
+			Defaults:     ManifestDefaults{Name: name, Icon: icon},
+			Description:  reg.Description(),
+			Dependencies: reg.Dependencies(),
+			Migration:    MigrationVersions{App: appVersion, Module: moduleVersion},
+			Versions:     versions,
+			Routes:       reg.Routes(),
+			Events:       ManifestEvents{Emits: reg.Emits(), Subscribes: reg.Subscribes()},
+			Schedules:    reg.Schedules(),
+			Tasks:        reg.Tasks(),
+			Permissions:  reg.Permissions(),
 		})
 	}
 }

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -224,3 +224,76 @@ func TestManifest_Permissions(t *testing.T) {
 		}
 	}
 }
+
+func TestManifest_DescriptionPopulated(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	reg.SetDescription("A demo module")
+
+	got := decodeManifest(t, ManifestHandler("demo", "Demo", "box", nil, nil, reg))
+	if got.Description != "A demo module" {
+		t.Errorf("description = %q, want %q", got.Description, "A demo module")
+	}
+}
+
+func TestManifest_DescriptionOmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
+	rec := httptest.NewRecorder()
+	ManifestHandler("demo", "Demo", "box", nil, nil, registry.New()).ServeHTTP(rec, req)
+
+	if strings.Contains(rec.Body.String(), `"description"`) {
+		t.Errorf("expected \"description\" key to be omitted when empty, got: %s", rec.Body.String())
+	}
+}
+
+func TestManifest_DependenciesPopulated(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	reg.AddDependency("oauth-core", false)
+	reg.AddDependency("video", true)
+
+	got := decodeManifest(t, ManifestHandler("demo", "Demo", "box", nil, nil, reg))
+	if len(got.Dependencies) != 2 {
+		t.Fatalf("len(dependencies) = %d, want 2", len(got.Dependencies))
+	}
+	if got.Dependencies[0].ID != "oauth-core" || got.Dependencies[0].Optional {
+		t.Errorf("dependencies[0] = %+v, want {oauth-core, false}", got.Dependencies[0])
+	}
+	if got.Dependencies[1].ID != "video" || !got.Dependencies[1].Optional {
+		t.Errorf("dependencies[1] = %+v, want {video, true}", got.Dependencies[1])
+	}
+}
+
+func TestManifest_EmptyDependenciesIsArrayNotNull(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
+	rec := httptest.NewRecorder()
+	ManifestHandler("demo", "Demo", "box", nil, nil, registry.New()).ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"dependencies":[]`) {
+		t.Errorf("empty dependencies should serialize as [], got: %s", body)
+	}
+}
+
+func TestManifest_OptionalOmittedInJSONWhenFalse(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	reg.AddDependency("oauth-core", false)
+
+	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
+	rec := httptest.NewRecorder()
+	ManifestHandler("demo", "Demo", "box", nil, nil, reg).ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	// Required dep should not carry "optional":false in wire shape.
+	if strings.Contains(body, `"optional":false`) {
+		t.Errorf("required dep should omit \"optional\":false, got: %s", body)
+	}
+}


### PR DESCRIPTION
Closes #82. First of three SDK PRs that together deliver #14 orchestration primitives.

## Changes

### `internal/registry/registry.go`
- New `Dependency` type `{ID string, Optional bool}`
- Accumulators on `Registry`: `description`, `dependencies`
- `SetDescription` / `Description` (last-wins)
- `AddDependency(id, optional)` with **required-wins dedup** — a subsequent required call upgrades a prior optional entry; optional never downgrades required

### `mirrorstack.go`
- `ms.Describe(s)` / `(*Module).Describe`
- `ms.DependsOn(id)` / `(*Module).DependsOn` — **auto-detects required vs optional** via `runtime.Callers`:
  - Called from `main.main` or `pkg.init[.N]` → **required**
  - Anywhere else (helpers, handlers, setup fns) → **optional**
- `ms.Resolve[T any](id) (T, bool)` — stub returning `(zero, false)` until cross-module client wiring lands
- `Describe` + `DependsOn` added to `TestScopesPanic_BeforeInit` map

### `system/manifest.go`
- `ManifestPayload` gains `Description string` (omitempty) and `Dependencies []Dependency` (always non-nil slice)
- `ManifestHandler` reads both from registry — no signature change

## Caveat documented in godoc

Extract-function refactors (pulling a block from `main()` into a helper) silently change a `DependsOn` from required to optional. Escape hatch: wrap required deps in a package-level `init()` if they must live outside `main`.

## Tests

- Registry: dep required/optional, required-wins dedup, order preservation, name validation
- Caller detection: `isRootCallerName` unit tests for `main.main`, `pkg.init`, `pkg.init.N`, various non-root patterns
- Module: `Describe` propagates to registry; `DependsOn` from test = optional (verifies stack-walk skips SDK frames correctly)
- Manifest: description populated/omitted; dependencies populated; empty dependencies = `[]` not `null`; `optional:false` omitted from wire shape

All `go test ./...` + `go vet` green. `gofmt` clean.