### PR TITLE
feat(core): auto-apply migrations in ms.Start() when MS_LOCAL_DB_URL set

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -17,7 +17,11 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/internal/lambdaenv"
 )
 
-const defaultDevURL = "postgres://postgres:postgres@localhost:5433/module?sslmode=disable"
+// Matches the mirrorstack-cli's bundled `templates/dev/docker-compose.yml.tmpl`
+// (mirrorstack/mirrorstack on :5433). The CLI exports MS_LOCAL_DB_URL which
+// takes precedence, but if a developer runs `go run .` outside `mirrorstack
+// dev` and forgot to set anything, this connects to the compose Postgres.
+const defaultDevURL = "postgres://mirrorstack:mirrorstack@localhost:5433/mirrorstack?sslmode=disable"
 
 // Querier is the interface for database operations.
 // Compatible with pgxpool.Conn and sqlc's DBTX interface.
@@ -32,14 +36,22 @@ type DB struct {
 	pool *pgxpool.Pool
 }
 
-// Open creates a DB from DATABASE_URL env var, falling back to local dev default.
+// Open creates a DB for local development. Precedence:
+//
+//	MS_LOCAL_DB_URL    — set by `mirrorstack dev` to point at the bundled compose Postgres
+//	DATABASE_URL       — generic 12-factor name, honored for non-CLI dev flows
+//	defaultDevURL      — falls back to the compose-shape default
+//
 // Use this for dev mode only. Production uses PoolCache with injected credentials.
 // Returns an error if called inside AWS Lambda (credentials should be injected per-invocation).
 func Open(ctx context.Context) (*DB, error) {
 	if lambdaenv.IsSet() {
 		return nil, fmt.Errorf("mirrorstack/db: Open() cannot be used in Lambda — credentials are injected per-invocation")
 	}
-	url := os.Getenv("DATABASE_URL")
+	url := os.Getenv("MS_LOCAL_DB_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
 	if url == "" {
 		url = defaultDevURL
 	}

--- a/internal/core/dev_migrate.go
+++ b/internal/core/dev_migrate.go
@@ -1,0 +1,148 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
+)
+
+// devMigrateEnvVar is the local-dev signal set by `mirrorstack dev`. When
+// non-empty, the module is running under the CLI's dev lifecycle and applies
+// its embedded migrations on every start so the developer's local Postgres
+// matches the module's source tree.
+//
+// Independent of DATABASE_URL — that one is a generic fallback honored by
+// db.Open() but does NOT trigger auto-apply (it's used for non-CLI flows like
+// `go test` against a personal Postgres where the developer owns migration
+// timing).
+const devMigrateEnvVar = "MS_LOCAL_DB_URL"
+
+// devMigrateEnabled returns true when ms.Start() should auto-apply migrations
+// before serving. False in Lambda + task-worker modes (production credentials
+// arrive per-invocation) and when the dev env var is unset.
+func (m *Module) devMigrateEnabled() bool {
+	if runtime.IsLambda() || runtime.IsTaskWorker() {
+		return false
+	}
+	return os.Getenv(devMigrateEnvVar) != ""
+}
+
+// applyDevMigrations runs every embedded migration that has not yet been
+// applied to the dev Postgres. Idempotent across module restarts — the
+// tracking table __ms_local.schema_migrations records what ran, keyed by
+// (scope, version).
+//
+// Pre-creates the mod_<id> schema so module-scope migrations have a home;
+// app-scope migrations land in whatever schema the connection sees by
+// default (public in dev — there is no real per-app tenant). Production
+// install lifecycle handles both with proper schemas; this is the dev
+// shortcut.
+func (m *Module) applyDevMigrations(ctx context.Context) error {
+	pool, release, err := m.resolvePool(ctx)
+	if err != nil {
+		return fmt.Errorf("dev migrate: open pool: %w", err)
+	}
+	defer release()
+
+	if _, err := pool.Exec(ctx, fmt.Sprintf(
+		`CREATE SCHEMA IF NOT EXISTS %s`,
+		pgx.Identifier{"mod_" + m.config.ID}.Sanitize(),
+	)); err != nil {
+		return fmt.Errorf("dev migrate: create mod schema: %w", err)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		CREATE SCHEMA IF NOT EXISTS __ms_local;
+		CREATE TABLE IF NOT EXISTS __ms_local.schema_migrations (
+			scope      text NOT NULL,
+			version    text NOT NULL,
+			applied_at timestamptz NOT NULL DEFAULT now(),
+			PRIMARY KEY (scope, version)
+		)`); err != nil {
+		return fmt.Errorf("dev migrate: create tracking table: %w", err)
+	}
+
+	for _, scope := range migration.AllScopes() {
+		if err := m.applyDevScope(ctx, pool, scope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyDevScope filters the embedded sql/<scope>/ migrations down to those
+// not already recorded in the tracking table, then applies the remainder
+// via the same TxRunner the production install handler uses.
+func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, scope migration.Scope) error {
+	all, err := migration.List(m.config.SQL, scope)
+	if err != nil {
+		return fmt.Errorf("dev migrate %s: list: %w", scope, err)
+	}
+	if len(all) == 0 {
+		return nil
+	}
+
+	applied, err := loadAppliedVersions(ctx, pool, scope)
+	if err != nil {
+		return fmt.Errorf("dev migrate %s: load applied: %w", scope, err)
+	}
+
+	pending := make([]migration.Migration, 0, len(all))
+	for _, mig := range all {
+		if !applied[mig.Version] {
+			pending = append(pending, mig)
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	runTx := m.lifecycleTxRunner(scope)
+	ran, err := migration.Apply(ctx, runTx, m.config.SQL, pending)
+	// Record whatever ran before the failure (if any) so retries skip them.
+	if recErr := recordAppliedVersions(ctx, pool, scope, ran); recErr != nil && err == nil {
+		return fmt.Errorf("dev migrate %s: record applied: %w", scope, recErr)
+	}
+	if err != nil {
+		return fmt.Errorf("dev migrate %s: apply: %w", scope, err)
+	}
+	m.logger.Printf("dev: applied %d %s migration(s): %v", len(ran), scope, ran)
+	return nil
+}
+
+func loadAppliedVersions(ctx context.Context, pool *pgxpool.Pool, scope migration.Scope) (map[string]bool, error) {
+	rows, err := pool.Query(ctx,
+		`SELECT version FROM __ms_local.schema_migrations WHERE scope = $1`,
+		string(scope))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		out[v] = true
+	}
+	return out, rows.Err()
+}
+
+func recordAppliedVersions(ctx context.Context, pool *pgxpool.Pool, scope migration.Scope, versions []string) error {
+	for _, v := range versions {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO __ms_local.schema_migrations (scope, version) VALUES ($1, $2)
+			 ON CONFLICT DO NOTHING`,
+			string(scope), v); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/core/dev_migrate_test.go
+++ b/internal/core/dev_migrate_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+)
+
+func TestDevMigrateEnabled(t *testing.T) {
+	cases := []struct {
+		name       string
+		localDBURL string
+		want       bool
+	}{
+		{"unset → off", "", false},
+		{"set → on", "postgres://x@y:1/z", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetDefault(t)
+			t.Setenv(devMigrateEnvVar, tc.localDBURL)
+			m := newTestModuleWithSecret(t, "media")
+			if got := m.devMigrateEnabled(); got != tc.want {
+				t.Errorf("devMigrateEnabled() with MS_LOCAL_DB_URL=%q: got %v, want %v", tc.localDBURL, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyDevMigrations_Integration verifies the full dev-migrate path
+// against a live Postgres. Skipped when no Postgres is reachable — matches
+// the integration-test convention in db/db_integration_test.go.
+//
+// The migration here uses the same `CREATE TABLE IF NOT EXISTS` shape the
+// CLI scaffold ships, so a re-run after a successful first run is a true
+// idempotency check (tracking table prevents Apply from running them again).
+func TestApplyDevMigrations_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	resetDefault(t)
+	t.Setenv(devMigrateEnvVar, "postgres://mirrorstack:mirrorstack@localhost:5433/mirrorstack?sslmode=disable")
+
+	sqlFS := fstest.MapFS{
+		"sql/app/0001_init.up.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE IF NOT EXISTS dev_migrate_test_items (id text PRIMARY KEY)`),
+		},
+	}
+
+	m, err := New(Config{ID: "devmigtest", Name: "Dev Migrate Test", SQL: sqlFS})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := m.applyDevMigrations(ctx); err != nil {
+		t.Skipf("skipping (no postgres on :5433): %v", err)
+	}
+
+	// Second call should be a no-op (tracking table records the prior run).
+	// If Apply runs again on an idempotent migration the test still passes;
+	// if it ran on a non-idempotent migration it would fail — the point
+	// is to assert the no-op path is taken, which we observe by reading
+	// the tracking table.
+	if err := m.applyDevMigrations(ctx); err != nil {
+		t.Fatalf("second applyDevMigrations: %v", err)
+	}
+
+	pool, release, err := m.resolvePool(ctx)
+	if err != nil {
+		t.Fatalf("resolvePool: %v", err)
+	}
+	defer release()
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM __ms_local.schema_migrations WHERE scope = 'app' AND version = '0001'`,
+	).Scan(&count); err != nil {
+		t.Fatalf("read tracking row: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 tracking row for app/0001, got %d", count)
+	}
+
+	// Cleanup so reruns are deterministic.
+	if _, err := pool.Exec(ctx, `DROP TABLE IF EXISTS dev_migrate_test_items`); err != nil {
+		t.Logf("cleanup table: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM __ms_local.schema_migrations WHERE scope = 'app' AND version = '0001'`,
+	); err != nil {
+		t.Logf("cleanup tracking: %v", err)
+	}
+}

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -286,6 +286,12 @@ func (m *Module) Start() error {
 		return m.startTaskWorker()
 	}
 
+	if m.devMigrateEnabled() {
+		if err := m.applyDevMigrations(context.Background()); err != nil {
+			return err
+		}
+	}
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"


### PR DESCRIPTION
## Summary

Closes the migration-auto-apply gap step 2 of the dev-mount roadmap was meant to address. A module run under \`mirrorstack dev\` now applies its embedded \`sql/{app,module}/*.up.sql\` against the bundled compose Postgres on startup, with a tracking table so re-runs are no-ops.

Three pieces:

- **\`db.Open()\` env-var precedence**: \`MS_LOCAL_DB_URL\` → \`DATABASE_URL\` → \`defaultDevURL\`. Default URL realigned to the CLI's compose creds (\`mirrorstack/mirrorstack@:5433/mirrorstack\`) so a developer running \`go run .\` outside the CLI still hits the right Postgres if they brought it up via the CLI compose.

- **\`internal/core/dev_migrate.go\`**: \`applyDevMigrations()\` creates the \`mod_<id>\` schema, ensures \`__ms_local.schema_migrations(scope, version)\` exists, then for each scope queries applied versions, slices unapplied ones from the embedded sql FS, and runs them through the same \`lifecycleTxRunner\` the install handler uses.

- **\`ms.Start()\` hook**: calls \`applyDevMigrations()\` before binding the HTTP listener, gated by \`devMigrateEnabled()\` which checks the env signal and bails inside Lambda + task-worker modes.

## Why the env-var precedence

\`MS_LOCAL_DB_URL\` is the CLI-set signal *and* the connection string (single source of truth). \`DATABASE_URL\` stays honored for the \`go test\` + personal-Postgres flow where the developer owns migration timing. Only \`MS_LOCAL_DB_URL\` triggers auto-apply — \`DATABASE_URL\` does not — so a CI run with \`DATABASE_URL\` pointing at a test DB won't unexpectedly mutate it.

## Test plan

- [x] \`go test ./...\` passes (gate tests + integration test that skips without :5433)
- [ ] Manual: \`mirrorstack module init\` + \`mirrorstack dev\` boots a module, \`__ms_local.schema_migrations\` populates, \`<module-id>_items\` exists in compose Postgres
- [ ] Re-run \`mirrorstack dev\` against the same DB: no migration re-runs, no errors

## Out of scope

- A separate \`mirrorstack dev migrate\` subcommand for manual control
- Down migrations on dev (the platform install lifecycle owns that path)
- Migration consolidation in \`api-platform/scripts/init-db.sql\` (different concern — platform's own db, not modules')

🤖 Generated with [Claude Code](https://claude.com/claude-code)