### PR TITLE
feat(sdk): RegisterUI + ModuleUI types for default UI v0

### DIFF
--- a/internal/core/ui.go
+++ b/internal/core/ui.go
@@ -1,0 +1,37 @@
+package core
+
+import "github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+
+// Public type aliases for the UI manifest. The data shapes live in the
+// registry package (alongside the storage methods); core re-exports them
+// so module authors construct ms.ModuleUI{...} without importing internal/.
+type (
+	ModuleUI    = registry.ModuleUI
+	UIComponent = registry.UIComponent
+	UIProp      = registry.UIProp
+	UIPage      = registry.UIPage
+)
+
+// RegisterUI declares the module's UI surface — agent-visible Components
+// plus DefaultPages mounted under /apps/<app-slug>/<module-slug>. See the
+// ModuleUI doc comment for the shape. Validates the input and panics on
+// programmer errors (duplicate names, invalid slug, unknown prop type).
+// Last-write-wins; a second call replaces the prior manifest.
+//
+//	ms.RegisterUI(ms.ModuleUI{
+//	    Components: []ms.UIComponent{
+//	        {Name: "SettingsForm", Export: "SettingsForm", Props: []ms.UIProp{
+//	            {Key: "appId", Type: "text", Required: true},
+//	        }},
+//	    },
+//	    DefaultPages: []ms.UIPage{
+//	        {Slug: "", Title: "OAuth Settings", Export: "SettingsPage"},
+//	    },
+//	})
+func (m *Module) RegisterUI(ui ModuleUI) {
+	m.registry.SetUI(ui)
+}
+
+// RegisterUI declares the default module's UI surface. Panics if Init
+// has not been called. See Module.RegisterUI.
+func RegisterUI(ui ModuleUI) { mustDefault("RegisterUI").RegisterUI(ui) }

--- a/internal/core/ui_test.go
+++ b/internal/core/ui_test.go
@@ -1,0 +1,323 @@
+package core
+
+import (
+	"slices"
+	"testing"
+)
+
+// ---- RegisterUI: storage ----
+
+func TestRegisterUI_PopulatesRegistry(t *testing.T) {
+	t.Parallel()
+
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		Components: []UIComponent{
+			{Name: "SettingsForm", Export: "SettingsForm", Props: []UIProp{
+				{Key: "appId", Type: "text", Required: true},
+			}},
+		},
+		DefaultPages: []UIPage{
+			{Slug: "", Title: "OAuth Settings", Export: "SettingsPage"},
+		},
+	})
+
+	got := m.registry.UI()
+	if got == nil {
+		t.Fatal("UI() returned nil after RegisterUI")
+	}
+	if len(got.Components) != 1 || got.Components[0].Name != "SettingsForm" {
+		t.Errorf("Components = %+v", got.Components)
+	}
+	if len(got.DefaultPages) != 1 || got.DefaultPages[0].Title != "OAuth Settings" {
+		t.Errorf("DefaultPages = %+v", got.DefaultPages)
+	}
+}
+
+func TestRegisterUI_NotCalled_UIReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	m, _ := New(Config{ID: "demo"})
+	if got := m.registry.UI(); got != nil {
+		t.Errorf("UI() = %+v before RegisterUI, want nil", got)
+	}
+}
+
+func TestRegisterUI_LastWriteWins(t *testing.T) {
+	t.Parallel()
+
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{{Slug: "", Title: "First", Export: "First"}},
+	})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{{Slug: "", Title: "Second", Export: "Second"}},
+	})
+
+	got := m.registry.UI()
+	if len(got.DefaultPages) != 1 || got.DefaultPages[0].Title != "Second" {
+		t.Errorf("after second RegisterUI, DefaultPages = %+v, want only [{Second}]", got.DefaultPages)
+	}
+}
+
+func TestRegisterUI_StoresDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	// Mutating the input after RegisterUI must not corrupt the registry.
+	m, _ := New(Config{ID: "demo"})
+	pages := []UIPage{{Slug: "", Title: "Original", Export: "P"}}
+	m.RegisterUI(ModuleUI{DefaultPages: pages})
+
+	pages[0].Title = "Mutated"
+
+	got := m.registry.UI()
+	if got.DefaultPages[0].Title != "Original" {
+		t.Errorf("registry mutated through input slice: Title = %q", got.DefaultPages[0].Title)
+	}
+}
+
+func TestRegisterUI_UIReturnsDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	// Mutating the returned manifest must not corrupt the registry.
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{{Slug: "", Title: "Original", Export: "P"}},
+	})
+
+	first := m.registry.UI()
+	first.DefaultPages[0].Title = "Mutated"
+
+	second := m.registry.UI()
+	if second.DefaultPages[0].Title != "Original" {
+		t.Errorf("registry mutated through UI() return: Title = %q", second.DefaultPages[0].Title)
+	}
+}
+
+// ---- RegisterUI: page slug validation ----
+
+func TestRegisterUI_EmptySlugIsIndex(t *testing.T) {
+	t.Parallel()
+
+	// Empty slug is the index page — not subject to the regex.
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{{Slug: "", Title: "Index", Export: "P"}},
+	})
+}
+
+func TestRegisterUI_ValidSlugVariations(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"a", "1", "settings", "audit-log", "v2-api", "abc123", "1-2-3",
+		"thirty-two-chars-exactly-1234567"}
+	for _, s := range valid {
+		t.Run("ok/"+s, func(t *testing.T) {
+			m, _ := New(Config{ID: "demo"})
+			m.RegisterUI(ModuleUI{
+				DefaultPages: []UIPage{{Slug: s, Title: "T", Export: "P"}},
+			})
+		})
+	}
+}
+
+func TestRegisterUI_InvalidSlugPanics(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"uppercase":           "Settings",
+		"underscore":          "settings_page",
+		"trailing-hyphen":     "settings-",
+		"leading-hyphen":      "-settings",
+		"space":               "settings page",
+		"too-long":            "thirty-three-chars-just-over-limit",
+		"reserved-underscore": "_internal",
+		"reserved-ms":         "__ms",
+		"reserved-ms-sub":     "__ms-something",
+	}
+	for name, slug := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected panic for slug %q", slug)
+				}
+			}()
+			m, _ := New(Config{ID: "demo"})
+			m.RegisterUI(ModuleUI{
+				DefaultPages: []UIPage{{Slug: slug, Title: "T", Export: "P"}},
+			})
+		})
+	}
+}
+
+func TestRegisterUI_DuplicatePageSlugPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on duplicate page slug")
+		}
+	}()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{
+			{Slug: "audit", Title: "A", Export: "A"},
+			{Slug: "audit", Title: "B", Export: "B"},
+		},
+	})
+}
+
+// ---- RegisterUI: component validation ----
+
+func TestRegisterUI_DuplicateComponentNamePanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on duplicate Component name")
+		}
+	}()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		Components: []UIComponent{
+			{Name: "X", Export: "X"},
+			{Name: "X", Export: "Y"},
+		},
+	})
+}
+
+func TestRegisterUI_EmptyComponentFieldsPanic(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]UIComponent{
+		"empty-name":   {Name: "", Export: "X"},
+		"empty-export": {Name: "X", Export: ""},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected panic for %s", name)
+				}
+			}()
+			m, _ := New(Config{ID: "demo"})
+			m.RegisterUI(ModuleUI{Components: []UIComponent{c}})
+		})
+	}
+}
+
+func TestRegisterUI_EmptyPageFieldsPanic(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]UIPage{
+		"empty-title":  {Slug: "", Title: "", Export: "P"},
+		"empty-export": {Slug: "", Title: "T", Export: ""},
+	}
+	for name, p := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected panic for %s", name)
+				}
+			}()
+			m, _ := New(Config{ID: "demo"})
+			m.RegisterUI(ModuleUI{DefaultPages: []UIPage{p}})
+		})
+	}
+}
+
+// ---- RegisterUI: prop validation ----
+
+func TestRegisterUI_ValidPropTypes(t *testing.T) {
+	t.Parallel()
+
+	allowed := []string{"text", "secret", "textarea", "bool", "number", "text-list"}
+	props := make([]UIProp, len(allowed))
+	for i, ty := range allowed {
+		props[i] = UIProp{Key: "p" + ty, Type: ty}
+	}
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		Components: []UIComponent{{Name: "C", Export: "C", Props: props}},
+	})
+	got := m.registry.UI().Components[0].Props
+	if len(got) != len(allowed) {
+		t.Errorf("len(props) = %d, want %d", len(got), len(allowed))
+	}
+}
+
+func TestRegisterUI_InvalidPropTypePanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for unknown prop type")
+		}
+	}()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		Components: []UIComponent{
+			{Name: "C", Export: "C", Props: []UIProp{{Key: "k", Type: "color"}}},
+		},
+	})
+}
+
+func TestRegisterUI_DuplicatePropKeyPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for duplicate prop key")
+		}
+	}()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		Components: []UIComponent{
+			{Name: "C", Export: "C", Props: []UIProp{
+				{Key: "appId", Type: "text"},
+				{Key: "appId", Type: "text"},
+			}},
+		},
+	})
+}
+
+func TestRegisterUI_EmptyPropKeyPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for empty prop key")
+		}
+	}()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		Components: []UIComponent{
+			{Name: "C", Export: "C", Props: []UIProp{{Key: "", Type: "text"}}},
+		},
+	})
+}
+
+// ---- RegisterUI: end-to-end multi-page ----
+
+func TestRegisterUI_MultiPage(t *testing.T) {
+	t.Parallel()
+
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{
+			{Slug: "", Icon: "settings", Title: "Settings", Export: "SettingsPage"},
+			{Slug: "connections", Icon: "link", Title: "Connections", Export: "ConnectionsPage"},
+			{Slug: "audit", Icon: "history", Title: "Audit log", Export: "AuditPage"},
+		},
+	})
+
+	got := m.registry.UI().DefaultPages
+	wantSlugs := []string{"", "connections", "audit"}
+	gotSlugs := make([]string, len(got))
+	for i, p := range got {
+		gotSlugs[i] = p.Slug
+	}
+	if !slices.Equal(gotSlugs, wantSlugs) {
+		t.Errorf("slugs = %+v, want %+v", gotSlugs, wantSlugs)
+	}
+}

--- a/internal/core/ui_test.go
+++ b/internal/core/ui_test.go
@@ -63,7 +63,6 @@ func TestRegisterUI_LastWriteWins(t *testing.T) {
 func TestRegisterUI_StoresDeepCopy(t *testing.T) {
 	t.Parallel()
 
-	// Mutating the input after RegisterUI must not corrupt the registry.
 	m, _ := New(Config{ID: "demo"})
 	pages := []UIPage{{Slug: "", Title: "Original", Export: "P"}}
 	m.RegisterUI(ModuleUI{DefaultPages: pages})
@@ -79,7 +78,6 @@ func TestRegisterUI_StoresDeepCopy(t *testing.T) {
 func TestRegisterUI_UIReturnsDeepCopy(t *testing.T) {
 	t.Parallel()
 
-	// Mutating the returned manifest must not corrupt the registry.
 	m, _ := New(Config{ID: "demo"})
 	m.RegisterUI(ModuleUI{
 		DefaultPages: []UIPage{{Slug: "", Title: "Original", Export: "P"}},

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -135,6 +135,7 @@ type Registry struct {
 	dependencies []Dependency
 	mcpTools     []MCPToolDecl
 	mcpResources []MCPResourceDecl
+	ui           *ModuleUI
 }
 
 func New() *Registry {

--- a/internal/registry/ui.go
+++ b/internal/registry/ui.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 )
 
+// validPropTypes locks the v0 prop type vocabulary. Adding a new type means
+// updating the renderer in web-applications + the agent's schema awareness;
+// rejecting unknown types here surfaces that as a programmer error at
+// module init instead of as a silent render failure later. The slice is
+// also used to compose the panic message so the "allowed" list stays in
+// lockstep with the actual check.
+var validPropTypes = []string{"text", "secret", "textarea", "bool", "number", "text-list"}
+
 // ModuleUI is the module's declared UI surface. Two parts:
 //
 //   - Components: the module's agent-visible React vocabulary. Each entry
@@ -55,19 +63,6 @@ type UIPage struct {
 	Title       string `json:"title"`
 	Description string `json:"description,omitempty"`
 	Export      string `json:"export"`
-}
-
-// validPropTypes locks the v0 prop type vocabulary. Adding a new type means
-// updating the renderer in web-applications + the agent's schema awareness;
-// rejecting unknown types here surfaces that as a programmer error at
-// module init instead of as a silent render failure later.
-var validPropTypes = map[string]struct{}{
-	"text":      {},
-	"secret":    {},
-	"textarea":  {},
-	"bool":      {},
-	"number":    {},
-	"text-list": {},
 }
 
 // pageSlugRe is the slug rule from the v0 plan: lowercase letters, digits,
@@ -148,8 +143,8 @@ func validateProps(componentName string, props []UIProp) {
 			panic(fmt.Sprintf("mirrorstack: RegisterUI: %s has duplicate Prop key %q", componentName, p.Key))
 		}
 		seen[p.Key] = struct{}{}
-		if _, ok := validPropTypes[p.Type]; !ok {
-			panic(fmt.Sprintf("mirrorstack: RegisterUI: %s.Props[%d] (%q) invalid type %q (allowed: text, secret, textarea, bool, number, text-list)", componentName, i, p.Key, p.Type))
+		if !slices.Contains(validPropTypes, p.Type) {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: %s.Props[%d] (%q) invalid type %q (allowed: %s)", componentName, i, p.Key, p.Type, strings.Join(validPropTypes, ", ")))
 		}
 	}
 }

--- a/internal/registry/ui.go
+++ b/internal/registry/ui.go
@@ -1,0 +1,184 @@
+package registry
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// ModuleUI is the module's declared UI surface. Two parts:
+//
+//   - Components: the module's agent-visible React vocabulary. Each entry
+//     names a React export the module's bundle ships, plus a prop schema
+//     so the agent envelope layer (dynamic-ui v1) can compose them.
+//   - DefaultPages: the module's own React pages, mounted by the platform
+//     under /apps/<app-slug>/<module-slug>/<page-slug>. Each page is a
+//     full React export — the module has total layout freedom.
+//
+// A module without a UI surface omits the ms.RegisterUI call entirely;
+// Registry.UI() returns nil and the manifest omits the field.
+type ModuleUI struct {
+	Components   []UIComponent `json:"components"`
+	DefaultPages []UIPage      `json:"defaultPages"`
+}
+
+// UIComponent declares one agent-visible React component shipped by the
+// module's web bundle. Name is how the component is referenced from agent
+// envelopes (namespaced "<module-slug>/<Name>" at the platform layer);
+// Export is the corresponding named export in web/index.tsx. Props is the
+// schema the agent uses to know what to pass in.
+type UIComponent struct {
+	Name   string   `json:"name"`
+	Export string   `json:"export"`
+	Props  []UIProp `json:"props,omitempty"`
+}
+
+// UIProp is one prop declared on a UIComponent. Type is one of the v0 set:
+// "text", "secret", "textarea", "bool", "number", "text-list". Required
+// defaults to false; Default carries the literal default value (any JSON);
+// Hint is freeform help text shown to the agent / in dev tooling.
+type UIProp struct {
+	Key      string `json:"key"`
+	Type     string `json:"type"`
+	Required bool   `json:"required,omitempty"`
+	Default  any    `json:"default,omitempty"`
+	Hint     string `json:"hint,omitempty"`
+}
+
+// UIPage is one entry in DefaultPages — the module's own React page mounted
+// at /apps/<app-slug>/<module-slug>/<Slug>. Empty Slug is the index page.
+// Export names the bundle's React export to mount.
+type UIPage struct {
+	Slug        string `json:"slug"`
+	Icon        string `json:"icon,omitempty"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Export      string `json:"export"`
+}
+
+// validPropTypes locks the v0 prop type vocabulary. Adding a new type means
+// updating the renderer in web-applications + the agent's schema awareness;
+// rejecting unknown types here surfaces that as a programmer error at
+// module init instead of as a silent render failure later.
+var validPropTypes = map[string]struct{}{
+	"text":      {},
+	"secret":    {},
+	"textarea":  {},
+	"bool":      {},
+	"number":    {},
+	"text-list": {},
+}
+
+// pageSlugRe is the slug rule from the v0 plan: lowercase letters, digits,
+// and hyphens, 1–32 chars, must start and end with a letter or digit (no
+// leading/trailing hyphens). Empty slug (the index page) is checked
+// separately and skips this pattern.
+var pageSlugRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$`)
+
+// reservedSlugPrefixes are platform-reserved namespaces under the module
+// route. The platform may mount its own surfaces under these prefixes in
+// the future (e.g. /__ms/* for platform-rendered fallbacks); reserving
+// them at the SDK avoids a future collision.
+var reservedSlugPrefixes = []string{"_", "__ms"}
+
+// SetUI stores the module's declared UI manifest. Validates the input and
+// panics on programmer errors (duplicate names, invalid slug, unknown prop
+// type). Last-write-wins; a second call replaces the first. The stored
+// value is a deep copy so callers can mutate their input afterwards
+// without aliasing into the registry.
+func (r *Registry) SetUI(ui ModuleUI) {
+	validateUI(ui)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ui = cloneUI(ui)
+}
+
+// UI returns a deep copy of the stored manifest, or nil if SetUI was never
+// called. Nil rather than an empty zero-value so the manifest endpoint can
+// distinguish "no UI" (omit the field) from "UI with empty lists".
+func (r *Registry) UI() *ModuleUI {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.ui == nil {
+		return nil
+	}
+	return cloneUI(*r.ui)
+}
+
+func validateUI(ui ModuleUI) {
+	seenComp := make(map[string]struct{}, len(ui.Components))
+	for i, c := range ui.Components {
+		if c.Name == "" {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: Components[%d].Name is empty", i))
+		}
+		if c.Export == "" {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: Components[%d] (%q) Export is empty", i, c.Name))
+		}
+		if _, dup := seenComp[c.Name]; dup {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: duplicate Component name %q", c.Name))
+		}
+		seenComp[c.Name] = struct{}{}
+		validateProps(c.Name, c.Props)
+	}
+
+	seenSlug := make(map[string]struct{}, len(ui.DefaultPages))
+	for i, p := range ui.DefaultPages {
+		if p.Title == "" {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: DefaultPages[%d] Title is empty", i))
+		}
+		if p.Export == "" {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: DefaultPages[%d] (%q) Export is empty", i, p.Title))
+		}
+		validatePageSlug(p.Slug, i)
+		if _, dup := seenSlug[p.Slug]; dup {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: duplicate DefaultPages slug %q", p.Slug))
+		}
+		seenSlug[p.Slug] = struct{}{}
+	}
+}
+
+func validateProps(componentName string, props []UIProp) {
+	seen := make(map[string]struct{}, len(props))
+	for i, p := range props {
+		if p.Key == "" {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: %s.Props[%d].Key is empty", componentName, i))
+		}
+		if _, dup := seen[p.Key]; dup {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: %s has duplicate Prop key %q", componentName, p.Key))
+		}
+		seen[p.Key] = struct{}{}
+		if _, ok := validPropTypes[p.Type]; !ok {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: %s.Props[%d] (%q) invalid type %q (allowed: text, secret, textarea, bool, number, text-list)", componentName, i, p.Key, p.Type))
+		}
+	}
+}
+
+func validatePageSlug(slug string, index int) {
+	if slug == "" {
+		return
+	}
+	for _, prefix := range reservedSlugPrefixes {
+		if slug == prefix || strings.HasPrefix(slug, prefix+"/") || strings.HasPrefix(slug, prefix+"-") {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: DefaultPages[%d] slug %q uses reserved prefix %q", index, slug, prefix))
+		}
+	}
+	if !pageSlugRe.MatchString(slug) {
+		panic(fmt.Sprintf("mirrorstack: RegisterUI: DefaultPages[%d] slug %q is invalid (lowercase letters, digits, hyphens; 1-32 chars; must start with a letter or digit)", index, slug))
+	}
+}
+
+func cloneUI(ui ModuleUI) *ModuleUI {
+	out := &ModuleUI{
+		Components:   make([]UIComponent, len(ui.Components)),
+		DefaultPages: slices.Clone(ui.DefaultPages),
+	}
+	for i, c := range ui.Components {
+		out.Components[i] = UIComponent{
+			Name:   c.Name,
+			Export: c.Export,
+			Props:  slices.Clone(c.Props),
+		}
+	}
+	return out
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -126,6 +126,28 @@ func OptionalDependOn(spec string, configure ...func(*Need)) OnEventOption {
 // always returns (zero, false).
 func Resolve[T any](id string) (T, bool) { return core.Resolve[T](id) }
 
+// --- UI surface ---
+
+// ModuleUI is the module's declared UI surface. Pass to ms.RegisterUI.
+type ModuleUI = core.ModuleUI
+
+// UIComponent declares one agent-visible React component shipped by the
+// module's web bundle. See ms.ModuleUI for the full shape.
+type UIComponent = core.UIComponent
+
+// UIProp is one prop declared on a UIComponent. Type is one of "text",
+// "secret", "textarea", "bool", "number", "text-list".
+type UIProp = core.UIProp
+
+// UIPage is one entry in DefaultPages — a module-shipped React page
+// mounted by the platform under /apps/<app-slug>/<module-slug>/<Slug>.
+type UIPage = core.UIPage
+
+// RegisterUI declares the module's UI surface (agent-visible Components
+// plus DefaultPages). Panics on programmer errors (duplicate names,
+// invalid slug, unknown prop type). Last-write-wins.
+func RegisterUI(ui ModuleUI) { core.RegisterUI(ui) }
+
 // --- Agent surface (MCP) ---
 
 // MCPTool registers an agent-callable tool on the default module with JSON

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -31,6 +31,9 @@ type ManifestPayload struct {
 	Tasks        []registry.Task                     `json:"tasks"`
 	Permissions  []registry.Permission               `json:"permissions"`
 	MCP          ManifestMCP                         `json:"mcp"`
+	// UI is the module's declared UI surface (RegisterUI). Nil/absent when
+	// the module ships no UI — callers must nil-check before reading.
+	UI *registry.ModuleUI `json:"ui,omitempty"`
 }
 
 // ManifestMCP declares the MCP tool and resource surface of the module. The
@@ -121,6 +124,7 @@ func ManifestHandler(id, slug, name, icon string, sqlFS fs.FS, versions map[stri
 			Tasks:        reg.Tasks(),
 			Permissions:  reg.Permissions(),
 			MCP:          buildManifestMCP(reg),
+			UI:           reg.UI(),
 		})
 	}
 }

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -315,3 +315,43 @@ func TestManifest_OptionalOmittedInJSONWhenFalse(t *testing.T) {
 		t.Errorf("required dep should omit \"optional\":false, got: %s", body)
 	}
 }
+
+func TestManifest_UIPopulatedWhenRegistered(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	reg.SetUI(registry.ModuleUI{
+		Components: []registry.UIComponent{
+			{Name: "SettingsForm", Export: "SettingsForm", Props: []registry.UIProp{
+				{Key: "appId", Type: "text", Required: true},
+			}},
+		},
+		DefaultPages: []registry.UIPage{
+			{Slug: "", Title: "Settings", Export: "SettingsPage"},
+			{Slug: "audit", Title: "Audit", Export: "AuditPage"},
+		},
+	})
+
+	got := decodeManifest(t, ManifestHandler("demo", "", "Demo", "box", nil, nil, reg))
+	if got.UI == nil {
+		t.Fatal("manifest.ui is nil; expected populated UI")
+	}
+	if len(got.UI.Components) != 1 || got.UI.Components[0].Name != "SettingsForm" {
+		t.Errorf("manifest.ui.components = %+v", got.UI.Components)
+	}
+	if len(got.UI.DefaultPages) != 2 {
+		t.Errorf("manifest.ui.defaultPages len = %d, want 2", len(got.UI.DefaultPages))
+	}
+}
+
+func TestManifest_UIOmittedWhenNotRegistered(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
+	rec := httptest.NewRecorder()
+	ManifestHandler("demo", "", "Demo", "box", nil, nil, registry.New()).ServeHTTP(rec, req)
+
+	if strings.Contains(rec.Body.String(), `"ui"`) {
+		t.Errorf("expected \"ui\" key omitted when no RegisterUI was called, got: %s", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

First step of the default-UI v0 plan (`docs-temp/default-ui/v0-plan.md`). Adds the SDK surface modules use to declare their UI:

- `ms.RegisterUI(ModuleUI{Components, DefaultPages})` called inside `ms.Init` body
- `Components` — agent-visible React vocabulary the dynamic-ui v1 envelope layer composes with
- `DefaultPages` — module-shipped React pages mounted by the platform under `/apps/<app-slug>/<module-slug>/<page-slug>`
- Manifest endpoint surfaces a new optional `ui` field; modules without `RegisterUI` omit it entirely

Validation at registration panics with descriptive errors on programmer mistakes: duplicate Component names, duplicate page slugs, invalid slug chars, unknown prop types, reserved slug prefixes (`_`, `__ms`), empty required fields.

Pure-additive change — no existing callers break.

## What's next

- **U2** — api-platform persists the manifest's `ui` field on `module_versions` during lifecycle install (needs B2b first)
- **U3** — api-platform proxy + bundle routes
- **U4a/b** — `mirrorstack` CLI dev/publish for the React bundle
- **U5** — web-applications renderer at `/apps/[appSlug]/[moduleSlug]/[[...pageSlug]]`
- **U6** — wire `oauth-core` end-to-end

## Test plan

- [x] `go test ./...` — all packages green
- [x] `gofmt -l` on changed files clean
- [x] `go vet ./...` clean
- [ ] Reviewer to verify the public type aliases compose into `ms.ModuleUI{...}` as expected from module code

🤖 Generated with [Claude Code](https://claude.com/claude-code)