### PR TITLE
feat(sdk): InstallHandler accepts optional InstallRequest body

### DIFF
--- a/system/lifecycle.go
+++ b/system/lifecycle.go
@@ -1,12 +1,15 @@
 package system
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/fs"
 	"net/http"
 	"strconv"
 
+	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
 )
@@ -36,6 +39,20 @@ type VersionRequest struct {
 	To   string `json:"to"`
 }
 
+// InstallRequest is the optional body for the install endpoint. The
+// platform's install service populates Credential + Schema so the SDK can
+// run migrations under the per-(app, module) Postgres role provisioned at
+// install time; AppID is metadata for module-side logging/auditing.
+//
+// All fields are optional — an empty body falls back to the dev path
+// (DATABASE_URL pool, default schema), matching the pre-B2b behavior that
+// `mirrorstack dev`'s migration auto-apply relies on.
+type InstallRequest struct {
+	AppID      string         `json:"appId,omitempty"`
+	Schema     string         `json:"schema,omitempty"`
+	Credential *db.Credential `json:"credential,omitempty"`
+}
+
 // UninstallResult is the response for uninstall.
 type UninstallResult struct {
 	Status string `json:"status"`
@@ -52,12 +69,16 @@ type UninstallResult struct {
 // — platform-side saga logic is responsible for preventing that.
 func InstallHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, ok := injectInstallContext(w, r)
+		if !ok {
+			return
+		}
 		migrations, err := migration.List(sqlFS, scope)
 		if err != nil {
 			httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: err.Error()})
 			return
 		}
-		applied, err := migration.Apply(r.Context(), runTx, sqlFS, migrations)
+		applied, err := migration.Apply(ctx, runTx, sqlFS, migrations)
 		if err != nil {
 			httputil.JSON(w, http.StatusInternalServerError, LifecycleError{
 				LifecycleResult: LifecycleResult{Applied: applied},
@@ -67,6 +88,37 @@ func InstallHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner
 		}
 		httputil.JSON(w, http.StatusOK, LifecycleResult{Applied: applied})
 	}
+}
+
+// injectInstallContext reads an optional InstallRequest body and folds its
+// Credential + Schema into the request context. Empty body is allowed —
+// the dev/legacy path keeps working with no body at all, falling through
+// to the SDK's DATABASE_URL pool when nothing is in ctx.
+//
+// Returns ok=false after writing the response (400 or 413) when the body
+// is present but malformed; callers must return without touching w again.
+func injectInstallContext(w http.ResponseWriter, r *http.Request) (context.Context, bool) {
+	ctx := r.Context()
+	var req InstallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if errors.Is(err, io.EOF) {
+			return ctx, true
+		}
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			httputil.JSON(w, http.StatusRequestEntityTooLarge, httputil.ErrorResponse{Error: "request body too large"})
+		} else {
+			httputil.JSON(w, http.StatusBadRequest, httputil.ErrorResponse{Error: "invalid request body: " + err.Error()})
+		}
+		return ctx, false
+	}
+	if req.Schema != "" {
+		ctx = db.WithSchema(ctx, req.Schema)
+	}
+	if req.Credential != nil {
+		ctx = db.WithCredential(ctx, *req.Credential)
+	}
+	return ctx, true
 }
 
 // UpgradeHandler applies the migrations strictly between (req.From, req.To].

--- a/system/lifecycle_test.go
+++ b/system/lifecycle_test.go
@@ -238,3 +238,114 @@ type errFS struct{}
 func (errFS) Open(name string) (fs.File, error) {
 	return nil, fs.ErrInvalid
 }
+
+// capturingTxRunner records the context it was invoked with so tests can
+// assert what credentials/schema flowed through from the request body.
+// Pair with oneMigrationFS so Apply invokes the runner exactly once.
+func capturingTxRunner(t *testing.T, gotCtx *context.Context) migration.TxRunner {
+	return func(ctx context.Context, fn func(q db.Querier) error) error {
+		t.Helper()
+		*gotCtx = ctx
+		return nil
+	}
+}
+
+// oneMigrationFS returns an fs.FS with a single empty .up.sql so Apply
+// invokes the runner exactly once without running real SQL.
+func oneMigrationFS() fs.FS {
+	return fstest.MapFS{
+		"sql/app/0001_init.up.sql": {Data: []byte("")},
+	}
+}
+
+func TestInstallHandler_BodyInjectsCredentialAndSchema(t *testing.T) {
+	t.Parallel()
+
+	var captured context.Context
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+
+	body := strings.NewReader(`{
+		"appId":  "6c8d1234-abcd-ef01-2345-6789abcdef00",
+		"schema": "app_6c8d1234_abcd_ef01_2345_6789abcdef00",
+		"credential": {
+			"host":     "127.0.0.1",
+			"port":     5432,
+			"database": "platform_apps",
+			"username": "r_6c8d1234_oauth-core",
+			"token":    "secret-token"
+		}
+	}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", body))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("runner never invoked — Apply short-circuited unexpectedly")
+	}
+	if got := db.SchemaFrom(captured); got != "app_6c8d1234_abcd_ef01_2345_6789abcdef00" {
+		t.Errorf("SchemaFrom = %q, want app_6c8d1234_...", got)
+	}
+	cred := db.CredentialFrom(captured)
+	if cred == nil {
+		t.Fatal("CredentialFrom returned nil; expected per-module credential")
+	}
+	if cred.Username != "r_6c8d1234_oauth-core" || cred.Token != "secret-token" {
+		t.Errorf("credential = %+v, want username=r_6c8d1234_oauth-core token=secret-token", cred)
+	}
+}
+
+func TestInstallHandler_EmptyBodyFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	// Dev-mount migration auto-apply posts no body. Handler must succeed and
+	// leave ctx without injected schema or credential so resolvePoolFor
+	// falls back to the dev pool.
+	var captured context.Context
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", nil))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if db.SchemaFrom(captured) != "" {
+		t.Errorf("SchemaFrom = %q, want empty for body-less request", db.SchemaFrom(captured))
+	}
+	if db.CredentialFrom(captured) != nil {
+		t.Errorf("CredentialFrom = %+v, want nil for body-less request", db.CredentialFrom(captured))
+	}
+}
+
+func TestInstallHandler_MalformedBody_400(t *testing.T) {
+	t.Parallel()
+
+	h := InstallHandler(nil, migration.ScopeApp, noopTxRunner(t))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", strings.NewReader(`{not json`)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for malformed body", rec.Code)
+	}
+}
+
+func TestInstallHandler_PartialBodyOmitsMissingFields(t *testing.T) {
+	t.Parallel()
+
+	var captured context.Context
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	body := strings.NewReader(`{"schema": "app_only"}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", body))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := db.SchemaFrom(captured); got != "app_only" {
+		t.Errorf("SchemaFrom = %q, want app_only", got)
+	}
+	if db.CredentialFrom(captured) != nil {
+		t.Error("CredentialFrom should be nil when body omits credential")
+	}
+}


### PR DESCRIPTION
## Summary

Part 1 of Step B2b — gives the SDK side a real wire format for platform-driven installs.

The platform's install service (api-platform's B2b, coming as a follow-up PR) provisions a per-app schema (B1 ✅) and per-(app, module) Postgres role (B2a ✅), then needs to call the module's existing \`/__mirrorstack/platform/lifecycle/app/install\` so the module's migrations actually run. Today that handler takes no body, so there's nowhere to put the schema + credential.

This change:

- Adds \`InstallRequest{AppID, Schema, Credential}\` — all fields optional, JSON body.
- \`InstallHandler\` parses the body when present, folds \`Schema\` + \`Credential\` into \`r.Context()\` via the existing \`db.WithSchema\` / \`db.WithCredential\` helpers, and threads the augmented context through \`migration.Apply\` → \`runTx\` → \`resolvePool\`.
- Empty body remains valid — the dev path (\`mirrorstack dev\` migration auto-apply, plus existing tests) keeps working with no body at all.

## Why body, not header

A 5-field \`Credential\` struct + schema + future fields like \`installId\` doesn't fit one header naturally. \`UpgradeHandler\` and \`DowngradeHandler\` already take JSON bodies, so adding a body to \`InstallHandler\` is consistent with the existing convention, not a deviation. Strongly typed, visible in logs and integration tests, easy to extend.

Full trade-off in \`docs-temp/default-ui/v0-plan.md\` and the parent thread.

## Test plan

- [x] \`go test ./...\` — all packages green
- [x] \`gofmt -l\` on changed files clean
- [x] \`go vet ./...\` clean
- [x] New tests cover: body injects credential+schema, empty body falls through, partial body (schema-only), malformed body returns 400
- [ ] Reviewer to confirm: are we OK with empty body silently falling through (vs requiring an explicit \`{}\`)? The pro is backward compat for \`mirrorstack dev\`; the con is a missing-body bug is masked.

## Next

Follow-up PR in api-platform: \`HTTP client + install service wiring + integration test\`. This SDK PR is the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)