### PR TITLE
refactor(sdk): drop host/port/database from InstallRequest body

### DIFF
--- a/db/credential.go
+++ b/db/credential.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type contextKey string
@@ -98,4 +101,31 @@ func WithModuleCredential(ctx context.Context, cred Credential) context.Context 
 func ModuleCredentialFrom(ctx context.Context) *Credential {
 	c, _ := ctx.Value(moduleCredentialKey).(*Credential)
 	return c
+}
+
+// EnvBaseCredential returns the Host/Port/Database derived from the SDK's
+// standard dev env vars (MS_LOCAL_DB_URL → DATABASE_URL → defaultDevURL),
+// matching what db.Open consults. Username and Token are left empty for
+// the caller to fill from per-invocation credentials — e.g. the install
+// request body carries a per-(app, module) username + token but the DB
+// location it should connect to comes from this helper.
+//
+// Production (deployed Lambda) will replace this with a Secrets Manager
+// fetch when that infra lands; the contract (returns a partial
+// Credential the caller completes with per-invocation fields) stays
+// identical so the install handler doesn't change.
+func EnvBaseCredential() (Credential, error) {
+	url := os.Getenv("MS_LOCAL_DB_URL")
+	if url == "" {
+		url = os.Getenv("DATABASE_URL")
+	}
+	if url == "" {
+		url = defaultDevURL
+	}
+	cfg, err := pgxpool.ParseConfig(url)
+	if err != nil {
+		return Credential{}, fmt.Errorf("mirrorstack/db: parse env URL: %w", err)
+	}
+	cc := cfg.ConnConfig
+	return Credential{Host: cc.Host, Port: int(cc.Port), Database: cc.Database}, nil
 }

--- a/db/credential.go
+++ b/db/credential.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -104,25 +103,18 @@ func ModuleCredentialFrom(ctx context.Context) *Credential {
 }
 
 // EnvBaseCredential returns the Host/Port/Database derived from the SDK's
-// standard dev env vars (MS_LOCAL_DB_URL → DATABASE_URL → defaultDevURL),
-// matching what db.Open consults. Username and Token are left empty for
-// the caller to fill from per-invocation credentials — e.g. the install
-// request body carries a per-(app, module) username + token but the DB
-// location it should connect to comes from this helper.
+// standard dev env vars (resolved via devEnvURL — same ladder db.Open
+// consults). Username and Token are left empty for the caller to fill
+// from per-invocation credentials — e.g. the install request body carries
+// a per-(app, module) username + token but the DB location it should
+// connect to comes from this helper.
 //
-// Production (deployed Lambda) will replace this with a Secrets Manager
-// fetch when that infra lands; the contract (returns a partial
-// Credential the caller completes with per-invocation fields) stays
-// identical so the install handler doesn't change.
+// Production (deployed runtime) will replace this with a managed-secret
+// fetch when that infra lands; the contract (returns a partial Credential
+// the caller completes with per-invocation fields) stays identical so the
+// install handler doesn't change.
 func EnvBaseCredential() (Credential, error) {
-	url := os.Getenv("MS_LOCAL_DB_URL")
-	if url == "" {
-		url = os.Getenv("DATABASE_URL")
-	}
-	if url == "" {
-		url = defaultDevURL
-	}
-	cfg, err := pgxpool.ParseConfig(url)
+	cfg, err := pgxpool.ParseConfig(devEnvURL())
 	if err != nil {
 		return Credential{}, fmt.Errorf("mirrorstack/db: parse env URL: %w", err)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -48,14 +48,22 @@ func Open(ctx context.Context) (*DB, error) {
 	if lambdaenv.IsSet() {
 		return nil, fmt.Errorf("mirrorstack/db: Open() cannot be used in Lambda — credentials are injected per-invocation")
 	}
-	url := os.Getenv("MS_LOCAL_DB_URL")
-	if url == "" {
-		url = os.Getenv("DATABASE_URL")
+	return New(ctx, devEnvURL())
+}
+
+// devEnvURL is the single source of truth for the dev DB URL precedence
+// ladder (MS_LOCAL_DB_URL > DATABASE_URL > defaultDevURL). Both Open
+// (production pool construction) and EnvBaseCredential (per-install
+// credential base) consult it so adding a new env var or changing the
+// fallback chain is a one-line edit.
+func devEnvURL() string {
+	if url := os.Getenv("MS_LOCAL_DB_URL"); url != "" {
+		return url
 	}
-	if url == "" {
-		url = defaultDevURL
+	if url := os.Getenv("DATABASE_URL"); url != "" {
+		return url
 	}
-	return New(ctx, url)
+	return defaultDevURL
 }
 
 // New creates a DB with the given connection string. The pool gets the same

--- a/system/lifecycle.go
+++ b/system/lifecycle.go
@@ -40,17 +40,32 @@ type VersionRequest struct {
 }
 
 // InstallRequest is the optional body for the install endpoint. The
-// platform's install service populates Credential + Schema so the SDK can
-// run migrations under the per-(app, module) Postgres role provisioned at
-// install time; AppID is metadata for module-side logging/auditing.
+// platform populates Credential + Schema so the SDK runs migrations
+// under the per-(app, module) role provisioned at install time; AppID
+// is metadata for module-side logging/auditing.
 //
 // All fields are optional — an empty body falls back to the dev path
-// (DATABASE_URL pool, default schema), matching the pre-B2b behavior that
-// `mirrorstack dev`'s migration auto-apply relies on.
+// (DATABASE_URL pool, default schema), matching the pre-B2b behavior
+// that `mirrorstack dev`'s migration auto-apply relies on.
 type InstallRequest struct {
-	AppID      string         `json:"appId,omitempty"`
-	Schema     string         `json:"schema,omitempty"`
-	Credential *db.Credential `json:"credential,omitempty"`
+	AppID      string             `json:"appId,omitempty"`
+	Schema     string             `json:"schema,omitempty"`
+	Credential *InstallCredential `json:"credential,omitempty"`
+}
+
+// InstallCredential is the per-install Postgres credential delivered in
+// the install request body. Only Username + Token live here — those are
+// the per-(app, module) values only the platform knows (minted when the
+// per-module role was created).
+//
+// Host/Port/Database deliberately do NOT live here. They come from the
+// module's own environment (db.EnvBaseCredential — backed by
+// MS_LOCAL_DB_URL / DATABASE_URL in dev, AWS Secrets Manager in
+// production) so the platform doesn't leak its DB location to every
+// install payload.
+type InstallCredential struct {
+	Username string `json:"username"`
+	Token    string `json:"token"`
 }
 
 // UninstallResult is the response for uninstall.
@@ -115,8 +130,15 @@ func injectInstallContext(w http.ResponseWriter, r *http.Request) (context.Conte
 	if req.Schema != "" {
 		ctx = db.WithSchema(ctx, req.Schema)
 	}
-	if req.Credential != nil {
-		ctx = db.WithCredential(ctx, *req.Credential)
+	if req.Credential != nil && (req.Credential.Username != "" || req.Credential.Token != "") {
+		base, err := db.EnvBaseCredential()
+		if err != nil {
+			httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: "resolve DB env base: " + err.Error()})
+			return ctx, false
+		}
+		base.Username = req.Credential.Username
+		base.Token = req.Credential.Token
+		ctx = db.WithCredential(ctx, base)
 	}
 	return ctx, true
 }

--- a/system/lifecycle.go
+++ b/system/lifecycle.go
@@ -130,6 +130,11 @@ func injectInstallContext(w http.ResponseWriter, r *http.Request) (context.Conte
 	if req.Schema != "" {
 		ctx = db.WithSchema(ctx, req.Schema)
 	}
+	// Treat empty username AND empty token as "no credential supplied" —
+	// caller sent `"credential":{}` for shape compat but the dev pool
+	// fallback should still apply. Avoids injecting a half-credential that
+	// would later trip resolvePool's "credential missing required fields"
+	// validation.
 	if req.Credential != nil && (req.Credential.Username != "" || req.Credential.Token != "") {
 		base, err := db.EnvBaseCredential()
 		if err != nil {

--- a/system/lifecycle_test.go
+++ b/system/lifecycle_test.go
@@ -259,7 +259,12 @@ func oneMigrationFS() fs.FS {
 }
 
 func TestInstallHandler_BodyInjectsCredentialAndSchema(t *testing.T) {
-	t.Parallel()
+	// Not t.Parallel because t.Setenv on MS_LOCAL_DB_URL would race with
+	// concurrent tests reading the env base.
+
+	// Point the env base at a known URL so we can assert host/port/database
+	// come from the environment, not the body.
+	t.Setenv("MS_LOCAL_DB_URL", "postgres://envuser:envpw@db.platform.local:6543/platform_apps?sslmode=disable")
 
 	var captured context.Context
 	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
@@ -268,9 +273,6 @@ func TestInstallHandler_BodyInjectsCredentialAndSchema(t *testing.T) {
 		"appId":  "6c8d1234-abcd-ef01-2345-6789abcdef00",
 		"schema": "app_6c8d1234_abcd_ef01_2345_6789abcdef00",
 		"credential": {
-			"host":     "127.0.0.1",
-			"port":     5432,
-			"database": "platform_apps",
 			"username": "r_6c8d1234_oauth-core",
 			"token":    "secret-token"
 		}
@@ -291,8 +293,13 @@ func TestInstallHandler_BodyInjectsCredentialAndSchema(t *testing.T) {
 	if cred == nil {
 		t.Fatal("CredentialFrom returned nil; expected per-module credential")
 	}
+	// Per-install fields from the body.
 	if cred.Username != "r_6c8d1234_oauth-core" || cred.Token != "secret-token" {
-		t.Errorf("credential = %+v, want username=r_6c8d1234_oauth-core token=secret-token", cred)
+		t.Errorf("credential per-install = username=%q token=%q, want r_6c8d1234_oauth-core / secret-token", cred.Username, cred.Token)
+	}
+	// Static fields from the env URL — the body does NOT carry these any more.
+	if cred.Host != "db.platform.local" || cred.Port != 6543 || cred.Database != "platform_apps" {
+		t.Errorf("credential env-base = host=%q port=%d db=%q, want db.platform.local/6543/platform_apps", cred.Host, cred.Port, cred.Database)
 	}
 }
 


### PR DESCRIPTION
## Summary

Revises the InstallRequest wire format shipped in PR #100. The original shape mirrored \`db.Credential\` 1:1 — five fields including \`host\`, \`port\`, \`database\`. That leaked the platform DB's location into every install payload. The static fields belong in the module's own environment (env var in dev, AWS Secrets Manager in production); only the per-(app, module) \`username + token\` are secrets the platform needs to deliver per install.

## What changes

- \`InstallRequest.Credential\` type changes from \`*db.Credential\` to \`*InstallCredential{Username, Token}\` — payload shrinks to two fields.
- New \`db.EnvBaseCredential()\` helper parses \`MS_LOCAL_DB_URL\` / \`DATABASE_URL\` / \`defaultDevURL\` to fill \`Host/Port/Database\`, leaving \`Username/Token\` empty for the caller to override with per-invocation secrets.
- \`injectInstallContext\` combines env base + payload creds at runtime before injecting via \`db.WithCredential\`.
- \`TestInstallHandler_BodyInjectsCredentialAndSchema\` uses \`t.Setenv\` to anchor the env URL and asserts the resulting credential combines env host/port/database with body username/token.

## New wire shape

\`\`\`json
{
  "appId":  "<uuid>",
  "schema": "app_<uuid_with_underscores>",
  "credential": {
    "username": "r_<app-prefix>_<module-id>",
    "token":    "<hex-password>"
  }
}
\`\`\`

## Why now

PR app-module-sdk#100 shipped the older 5-field shape, but the platform-side caller (api-platform#172) was closed before it landed. So the dormant InstallRequest type has no producers — this revision can safely change its shape with zero migration concerns. Setting up the right contract before the platform-side B2b lands the second time.

## Test plan

- [x] \`go test ./...\` — all packages green
- [x] \`gofmt -l\` on changed files clean
- [x] \`go vet ./...\` clean
- [x] New env-base helper + body-injection test exercises the combined credential shape
- [ ] Reviewer to confirm: in dev, the developer is expected to set \`MS_LOCAL_DB_URL\` pointing at the same Postgres the platform uses, so the role-isolation actually has somewhere to land. Worth a CLI dev-mount doc update later.

## Next

Follow-up PR in api-platform sends \`{appId, schema, credential: {username, token}}\` from the install service after \`EnsureModuleRole\`. Will pair with a doc revival of step-b-install.md's B2b row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)