### PR TITLE
feat(sdk): auto-prefix scopes + permissions

### DIFF
--- a/internal/core/cron.go
+++ b/internal/core/cron.go
@@ -3,7 +3,6 @@ package core
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 )
 
 // cronPathPrefix mounts under the reserved /__mirrorstack/ namespace.
@@ -35,9 +34,9 @@ func (m *Module) Cron(name, schedule string, handler http.HandlerFunc) {
 	if !m.registry.AddSchedule(name, schedule, path) {
 		panic("mirrorstack: Cron(" + name + ") registered twice")
 	}
-	m.Internal(func(r chi.Router) {
-		r.Post(path, handler)
-	})
+	// SDK system path — bypass Module.Internal()'s /internal/ auto-prefix
+	// so the manifest URL matches cronPathPrefix.
+	m.mountSystemInternalRoute("POST", path, handler)
 }
 
 // Cron registers a cron job on the default Module created by Init(). Panics

--- a/internal/core/cron.go
+++ b/internal/core/cron.go
@@ -34,8 +34,6 @@ func (m *Module) Cron(name, schedule string, handler http.HandlerFunc) {
 	if !m.registry.AddSchedule(name, schedule, path) {
 		panic("mirrorstack: Cron(" + name + ") registered twice")
 	}
-	// SDK system path — bypass Module.Internal()'s /internal/ auto-prefix
-	// so the manifest URL matches cronPathPrefix.
 	m.mountSystemInternalRoute("POST", path, handler)
 }
 

--- a/internal/core/event.go
+++ b/internal/core/event.go
@@ -3,7 +3,6 @@ package core
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 )
@@ -63,9 +62,9 @@ func (m *Module) OnEvent(name string, handler http.HandlerFunc, opts ...OnEventO
 	if !m.registry.AddSubscribe(name, path) {
 		panic("mirrorstack: OnEvent(" + name + ") registered twice")
 	}
-	m.Internal(func(r chi.Router) {
-		r.Post(path, handler)
-	})
+	// SDK system path — bypass Module.Internal()'s /internal/ auto-prefix
+	// so the manifest URL matches the eventPathPrefix contract.
+	m.mountSystemInternalRoute("POST", path, handler)
 }
 
 // Emits declares that this module emits an event of the given name. The

--- a/internal/core/event.go
+++ b/internal/core/event.go
@@ -62,8 +62,6 @@ func (m *Module) OnEvent(name string, handler http.HandlerFunc, opts ...OnEventO
 	if !m.registry.AddSubscribe(name, path) {
 		panic("mirrorstack: OnEvent(" + name + ") registered twice")
 	}
-	// SDK system path — bypass Module.Internal()'s /internal/ auto-prefix
-	// so the manifest URL matches the eventPathPrefix contract.
 	m.mountSystemInternalRoute("POST", path, handler)
 }
 

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -232,8 +232,9 @@ const internalRouteBodyCap = 1 << 20 // 1 MB
 // mountSystemInternalRoute mounts an absolute-path route gated by
 // internalAuth + the internal body cap, and records it in the registry
 // under ScopeInternal. SDK system surfaces (events, crons, tasks) call
-// here so their paths (e.g. /__mirrorstack/events/{name}) bypass the
-// auto-/internal/ prefix that user-facing Module.Internal() now applies.
+// here so their paths (e.g. /__mirrorstack/events/{name}) keep their
+// fixed shape — user-facing Module.Internal() routes go through
+// scopedRoutes instead and pick up the /internal/ prefix.
 func (m *Module) mountSystemInternalRoute(method, path string, handler http.HandlerFunc) {
 	m.registry.AddRoute(registry.ScopeInternal, method, path)
 	m.router.With(httputil.MaxBytes(internalRouteBodyCap), m.internalAuth).Method(method, path, handler)
@@ -274,9 +275,6 @@ func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Ha
 	if scopeMiddleware != nil {
 		sub.Use(scopeMiddleware)
 	}
-	// Mount the developer's routes under "/<scope>". chi.Walk below will
-	// see paths with the prefix already baked in, so both registry rows
-	// and live router entries reflect the final URL.
 	sub.Route("/"+string(scope), fn)
 
 	if err := chi.Walk(sub, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
@@ -312,13 +310,9 @@ func (m *Module) RequirePermission(name string, allowed ...roles.Role) func(http
 	return auth.RequireRoles(keys...)
 }
 
-// qualifyPermissionName prepends "<slug>." to name unless it's already
-// prefixed. Slug-less modules (Config.Slug == "") get no prefix —
-// they're typically internal/test fixtures, and prepending "." would
-// produce gibberish manifest entries. Exported via
-// Module.RequirePermission only — direct registry callers (none in v1)
-// would bypass this, which is the point: the namespacing is a
-// registration-time concern, not a storage concern.
+// qualifyPermissionName prepends "<slug>." to name. No-op if name is
+// already slug-prefixed, or if the module has no slug (avoids a
+// leading "." for test fixtures and internal-only modules).
 func qualifyPermissionName(slug, name string) string {
 	if slug == "" {
 		return name

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -196,19 +197,26 @@ func (m *Module) Router() *chi.Mux { return m.router }
 // DB/Tx/ModuleDB/ModuleTx, Cache/Storage/Meter, Describe/DependsOn/OptionalDependOn,
 // MCPTool/MCPResource: see db.go, resources.go, describe.go, and mcp.go.
 
-// Platform registers routes with platform auth scope.
-// Default: admin only. Use Module.RequirePermission for member/viewer access.
+// Platform registers routes with platform auth scope. All routes
+// declared inside fn are auto-mounted under /platform/ — write
+// `r.Get("/users", ...)` and the route lands at /platform/users.
+// Default role gate: admin only. Use Module.RequirePermission to
+// open routes to member/viewer.
 func (m *Module) Platform(fn func(r chi.Router)) {
 	m.scopedRoutes(registry.ScopePlatform, auth.PlatformAuth(), fn)
 }
 
-// Public registers routes with public auth scope (anyone, including anonymous).
+// Public registers routes with public auth scope (anyone, including
+// anonymous). Auto-mounted under /public/ — write `r.Get("/me", ...)`
+// and the route lands at /public/me.
 func (m *Module) Public(fn func(r chi.Router)) {
 	m.scopedRoutes(registry.ScopePublic, nil, fn)
 }
 
-// Internal registers routes with internal auth scope (platform-to-module only).
-// Validates X-MS-Internal-Secret via constant-time comparison. The middleware
+// Internal registers routes with internal auth scope (platform-to-module
+// only). Auto-mounted under /internal/ — write `r.Post("/sessions", ...)`
+// and the route lands at /internal/sessions. Validates
+// X-MS-Internal-Secret via constant-time comparison. The middleware
 // is cached on the Module at New() so OnEvent / Cron registrations reuse a
 // single closure instead of constructing one per call.
 func (m *Module) Internal(fn func(r chi.Router)) {
@@ -221,8 +229,24 @@ func (m *Module) Internal(fn func(r chi.Router)) {
 // unbounded without this.
 const internalRouteBodyCap = 1 << 20 // 1 MB
 
+// mountSystemInternalRoute mounts an absolute-path route gated by
+// internalAuth + the internal body cap, and records it in the registry
+// under ScopeInternal. SDK system surfaces (events, crons, tasks) call
+// here so their paths (e.g. /__mirrorstack/events/{name}) bypass the
+// auto-/internal/ prefix that user-facing Module.Internal() now applies.
+func (m *Module) mountSystemInternalRoute(method, path string, handler http.HandlerFunc) {
+	m.registry.AddRoute(registry.ScopeInternal, method, path)
+	m.router.With(httputil.MaxBytes(internalRouteBodyCap), m.internalAuth).Method(method, path, handler)
+}
+
 // scopedRoutes records every route fn registers under the given scope, then
 // re-attaches them to the main router with the scope's auth middleware.
+//
+// Routes are auto-mounted under "/<scope>/..." (e.g. /platform/users for
+// Platform-scope, /internal/sessions for Internal-scope). Developers write
+// just the suffix in fn — the prefix is added by sub.Route here so the
+// URL contract stays in lockstep with the auth scope (no way to declare a
+// Platform-scoped route at a non-/platform path).
 //
 // We use a sub-router + chi.Walk so the manifest endpoint can list every
 // declared route per scope. Walking after fn() returns gives us the full
@@ -250,7 +274,10 @@ func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Ha
 	if scopeMiddleware != nil {
 		sub.Use(scopeMiddleware)
 	}
-	fn(sub)
+	// Mount the developer's routes under "/<scope>". chi.Walk below will
+	// see paths with the prefix already baked in, so both registry rows
+	// and live router entries reflect the final URL.
+	sub.Route("/"+string(scope), fn)
 
 	if err := chi.Walk(sub, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
 		m.registry.AddRoute(scope, method, route)
@@ -268,15 +295,39 @@ func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Ha
 // — registry append is O(N), so dynamic per-request names would leak memory
 // and slow down every subsequent registration.
 //
-// Roles are typed values from the roles package (Admin, Viewer, Custom) to
-// prevent typos and enable IDE autocomplete:
+// Permission names are auto-namespaced with the module slug so two modules
+// can each declare a "users.read" permission without colliding in the
+// platform's catalog. Developers write the short name; the manifest stores
+// "<slug>.<name>":
 //
 //	import p "github.com/mirrorstack-ai/app-module-sdk/roles"
-//	r.With(mod.RequirePermission("media.view", p.Admin(), p.Viewer())).Get("/items", listItems)
+//	// Module slug "oauth-core" → manifest records "oauth-core.users.view".
+//	r.With(mod.RequirePermission("users.view", p.Admin(), p.Viewer())).Get("/items", listItems)
+//
+// If the caller already prefixed the name with the slug (manual or
+// imported from a constant), the prefix is left alone — no double-prefix.
 func (m *Module) RequirePermission(name string, allowed ...roles.Role) func(http.Handler) http.Handler {
 	keys := roles.Keys(allowed)
-	m.registry.AddPermission(name, keys)
+	m.registry.AddPermission(qualifyPermissionName(m.config.Slug, name), keys)
 	return auth.RequireRoles(keys...)
+}
+
+// qualifyPermissionName prepends "<slug>." to name unless it's already
+// prefixed. Slug-less modules (Config.Slug == "") get no prefix —
+// they're typically internal/test fixtures, and prepending "." would
+// produce gibberish manifest entries. Exported via
+// Module.RequirePermission only — direct registry callers (none in v1)
+// would bypass this, which is the point: the namespacing is a
+// registration-time concern, not a storage concern.
+func qualifyPermissionName(slug, name string) string {
+	if slug == "" {
+		return name
+	}
+	prefix := slug + "."
+	if strings.HasPrefix(name, prefix) {
+		return name
+	}
+	return prefix + name
 }
 
 // RequirePermission is the convenience wrapper that dispatches to the default

--- a/internal/core/module_test.go
+++ b/internal/core/module_test.go
@@ -384,105 +384,93 @@ func TestRequirePermission_AppearsInManifest(t *testing.T) {
 
 // --- Auto-prefix behavior ---
 
-func TestRequirePermission_AutoPrefixesWithSlug(t *testing.T) {
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "oauth", Slug: "oauth-core", Name: "OAuth"})
-	m.Platform(func(r chi.Router) {
-		r.With(m.RequirePermission("users.view", p.Admin())).Get("/users", func(w http.ResponseWriter, r *http.Request) {})
-	})
-
+// fetchManifest hits the system /__mirrorstack/platform/manifest endpoint
+// with the test secret and decodes the response. Shared by the permission
+// auto-prefix tests so each test asserts on the manifest shape directly.
+func fetchManifest(t *testing.T, m *Module) system.ManifestPayload {
+	t.Helper()
 	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
 	var got system.ManifestPayload
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode manifest: %v", err)
 	}
-	if len(got.Permissions) != 1 || got.Permissions[0].Name != "oauth-core.users.view" {
-		t.Errorf("expected one permission 'oauth-core.users.view', got %+v", got.Permissions)
-	}
+	return got
 }
 
-func TestRequirePermission_PreservesAlreadyQualifiedName(t *testing.T) {
-	// If the developer passes the slug-prefixed name (e.g. importing a
-	// shared constant), don't double-prefix.
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "oauth", Slug: "oauth-core", Name: "OAuth"})
-	m.Platform(func(r chi.Router) {
-		r.With(m.RequirePermission("oauth-core.users.view", p.Admin())).Get("/users", func(w http.ResponseWriter, r *http.Request) {})
-	})
-
-	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
-	var got system.ManifestPayload
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode manifest: %v", err)
+func TestRequirePermission_AutoPrefix(t *testing.T) {
+	cases := []struct {
+		name       string
+		slug       string
+		permission string
+		want       string
+	}{
+		{"adds slug prefix", "oauth-core", "users.view", "oauth-core.users.view"},
+		{"preserves already-qualified name", "oauth-core", "oauth-core.users.view", "oauth-core.users.view"},
+		{"slug-less module skips prefix", "", "media.view", "media.view"},
 	}
-	if len(got.Permissions) != 1 || got.Permissions[0].Name != "oauth-core.users.view" {
-		t.Errorf("expected 'oauth-core.users.view' (no double-prefix), got %+v", got.Permissions)
-	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MS_INTERNAL_SECRET", "secret")
+			m, _ := New(Config{ID: "test", Slug: tc.slug, Name: "Test"})
+			m.Platform(func(r chi.Router) {
+				r.With(m.RequirePermission(tc.permission, p.Admin())).Get("/x", func(w http.ResponseWriter, r *http.Request) {})
+			})
 
-func TestRequirePermission_SlugLessLeavesNameUnchanged(t *testing.T) {
-	// Modules with no slug (test fixtures, internal-only) skip the prefix.
-	t.Setenv("MS_INTERNAL_SECRET", "secret")
-	m, _ := New(Config{ID: "raw", Name: "Raw"})
-	m.Platform(func(r chi.Router) {
-		r.With(m.RequirePermission("media.view", p.Admin())).Get("/media", func(w http.ResponseWriter, r *http.Request) {})
-	})
-
-	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
-	var got system.ManifestPayload
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode manifest: %v", err)
-	}
-	if len(got.Permissions) != 1 || got.Permissions[0].Name != "media.view" {
-		t.Errorf("expected 'media.view' (unprefixed), got %+v", got.Permissions)
-	}
-}
-
-func TestPlatform_AutoMountsUnderPlatformPrefix(t *testing.T) {
-	// r.Get("/users", ...) inside Platform() → resolves at /platform/users
-	// AND the route is NOT reachable at the bare path.
-	m, _ := New(Config{ID: "test", Name: "Test"})
-	m.Platform(func(r chi.Router) {
-		r.Get("/users", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("ok"))
+			got := fetchManifest(t, m)
+			if len(got.Permissions) != 1 || got.Permissions[0].Name != tc.want {
+				t.Errorf("permissions = %+v, want one entry %q", got.Permissions, tc.want)
+			}
 		})
-	})
-	// Local-dev bypass injects synthetic admin; both 200 prefixed AND 404 bare are required.
-	if rec := doRequest(t, m.Router(), "GET", "/platform/users"); rec.Code != 200 {
-		t.Errorf("prefixed /platform/users: got %d, want 200", rec.Code)
-	}
-	if rec := doRequest(t, m.Router(), "GET", "/users"); rec.Code != 404 {
-		t.Errorf("bare /users must NOT resolve (would bypass the scope prefix): got %d, want 404", rec.Code)
 	}
 }
 
-func TestPublic_AutoMountsUnderPublicPrefix(t *testing.T) {
-	m, _ := New(Config{ID: "test", Name: "Test"})
-	m.Public(func(r chi.Router) {
-		r.Get("/me", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("ok"))
-		})
-	})
-	if rec := doRequest(t, m.Router(), "GET", "/public/me"); rec.Code != 200 {
-		t.Errorf("prefixed /public/me: got %d, want 200", rec.Code)
+// TestScopes_AutoMountUnderPrefix asserts each scope's routes resolve under
+// the conventional /<scope>/ prefix AND that the bare path 404s — so a
+// future regression that drops the wrapping doesn't pass silently.
+func TestScopes_AutoMountUnderPrefix(t *testing.T) {
+	cases := []struct {
+		scope     registry.Scope
+		method    string
+		suffix    string
+		needsAuth bool // Internal scope needs MS_INTERNAL_SECRET to reach the handler
+	}{
+		{registry.ScopePlatform, "GET", "/users", false}, // local-dev bypass injects synthetic admin
+		{registry.ScopePublic, "GET", "/me", false},
+		{registry.ScopeInternal, "POST", "/sessions", true},
 	}
-	if rec := doRequest(t, m.Router(), "GET", "/me"); rec.Code != 404 {
-		t.Errorf("bare /me must NOT resolve: got %d, want 404", rec.Code)
-	}
-}
+	for _, tc := range cases {
+		t.Run(string(tc.scope), func(t *testing.T) {
+			var m *Module
+			if tc.needsAuth {
+				m = newTestModuleWithSecret(t, "test")
+			} else {
+				m, _ = New(Config{ID: "test", Name: "Test"})
+			}
+			mount := map[registry.Scope]func(func(chi.Router)){
+				registry.ScopePlatform: m.Platform,
+				registry.ScopePublic:   m.Public,
+				registry.ScopeInternal: m.Internal,
+			}[tc.scope]
+			mount(func(r chi.Router) {
+				r.Method(tc.method, tc.suffix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte("ok"))
+				}))
+			})
 
-func TestInternal_AutoMountsUnderInternalPrefix(t *testing.T) {
-	m := newTestModuleWithSecret(t, "test")
-	m.Internal(func(r chi.Router) {
-		r.Post("/sessions", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("ok"))
+			prefixed := "/" + string(tc.scope) + tc.suffix
+			req := func(path string) int {
+				if tc.needsAuth {
+					return doRequestWithSecret(t, m.Router(), tc.method, path, "secret").Code
+				}
+				return doRequest(t, m.Router(), tc.method, path).Code
+			}
+			if got := req(prefixed); got != 200 {
+				t.Errorf("prefixed %s: got %d, want 200", prefixed, got)
+			}
+			if got := req(tc.suffix); got != 404 {
+				t.Errorf("bare %s must NOT resolve: got %d, want 404", tc.suffix, got)
+			}
 		})
-	})
-	if rec := doRequestWithSecret(t, m.Router(), "POST", "/internal/sessions", "secret"); rec.Code != 200 {
-		t.Errorf("prefixed /internal/sessions: got %d, want 200", rec.Code)
-	}
-	if rec := doRequestWithSecret(t, m.Router(), "POST", "/sessions", "secret"); rec.Code != 404 {
-		t.Errorf("bare /sessions must NOT resolve: got %d, want 404", rec.Code)
 	}
 }
 

--- a/internal/core/module_test.go
+++ b/internal/core/module_test.go
@@ -231,7 +231,7 @@ func TestPlatform_LocalDevBypass_InjectsSyntheticAdmin(t *testing.T) {
 		})
 	})
 
-	rec := doRequest(t, m.Router(), "GET", "/admin")
+	rec := doRequest(t, m.Router(), "GET", "/platform/admin")
 	if rec.Code != 200 {
 		t.Errorf("expected 200 (synthetic admin injected), got %d", rec.Code)
 	}
@@ -249,7 +249,7 @@ func TestPlatform_SecretSet_RejectsNoHeader(t *testing.T) {
 		})
 	})
 
-	rec := doRequest(t, m.Router(), "GET", "/admin")
+	rec := doRequest(t, m.Router(), "GET", "/platform/admin")
 	if rec.Code != 401 {
 		t.Errorf("expected 401 without trusted-forwarder header, got %d", rec.Code)
 	}
@@ -266,7 +266,7 @@ func TestPlatform_AcceptsAnyRole(t *testing.T) {
 	// PlatformAuth checks authentication only — any role passes
 	// Use RequirePermission for authorization (which roles)
 	for _, role := range []string{auth.RoleAdmin, auth.RoleMember, auth.RoleViewer} {
-		rec := doRequestWithRole(t, m.Router(), "GET", "/dashboard", role)
+		rec := doRequestWithRole(t, m.Router(), "GET", "/platform/dashboard", role)
 		if rec.Code != 200 {
 			t.Errorf("role %q: expected 200, got %d", role, rec.Code)
 		}
@@ -281,7 +281,7 @@ func TestPublic_AcceptsAnonymous(t *testing.T) {
 		})
 	})
 
-	rec := doRequest(t, m.Router(), "GET", "/items")
+	rec := doRequest(t, m.Router(), "GET", "/public/items")
 	if rec.Code != 200 {
 		t.Errorf("expected 200 for anonymous, got %d", rec.Code)
 	}
@@ -295,7 +295,7 @@ func TestInternal_RejectsNoSecret(t *testing.T) {
 		})
 	})
 
-	rec := doRequest(t, m.Router(), "POST", "/event")
+	rec := doRequest(t, m.Router(), "POST", "/internal/event")
 	if rec.Code != 401 {
 		t.Errorf("expected 401 without secret, got %d", rec.Code)
 	}
@@ -309,7 +309,7 @@ func TestInternal_AcceptsValidSecret(t *testing.T) {
 		})
 	})
 
-	rec := doRequestWithSecret(t, m.Router(), "POST", "/event", "secret")
+	rec := doRequestWithSecret(t, m.Router(), "POST", "/internal/event", "secret")
 	if rec.Code != 200 {
 		t.Errorf("expected 200 with valid secret, got %d", rec.Code)
 	}
@@ -327,7 +327,7 @@ func TestRequirePermission_AllowsMember(t *testing.T) {
 		})
 	})
 
-	rec := doRequestWithRole(t, m.Router(), "GET", "/items", auth.RoleMember)
+	rec := doRequestWithRole(t, m.Router(), "GET", "/platform/items", auth.RoleMember)
 	if rec.Code != 200 {
 		t.Errorf("expected 200 for member with media.view, got %d", rec.Code)
 	}
@@ -343,7 +343,7 @@ func TestRequirePermission_RejectsViewer(t *testing.T) {
 		})
 	})
 
-	rec := doRequestWithRole(t, m.Router(), "DELETE", "/items/123", auth.RoleViewer)
+	rec := doRequestWithRole(t, m.Router(), "DELETE", "/platform/items/123", auth.RoleViewer)
 	if rec.Code != 403 {
 		t.Errorf("expected 403 for viewer on admin-only permission, got %d", rec.Code)
 	}
@@ -379,6 +379,110 @@ func TestRequirePermission_AppearsInManifest(t *testing.T) {
 		if p.Name == "video.transcode" {
 			t.Errorf("m1 manifest leaked permission from m2: %+v", p)
 		}
+	}
+}
+
+// --- Auto-prefix behavior ---
+
+func TestRequirePermission_AutoPrefixesWithSlug(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "oauth", Slug: "oauth-core", Name: "OAuth"})
+	m.Platform(func(r chi.Router) {
+		r.With(m.RequirePermission("users.view", p.Admin())).Get("/users", func(w http.ResponseWriter, r *http.Request) {})
+	})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if len(got.Permissions) != 1 || got.Permissions[0].Name != "oauth-core.users.view" {
+		t.Errorf("expected one permission 'oauth-core.users.view', got %+v", got.Permissions)
+	}
+}
+
+func TestRequirePermission_PreservesAlreadyQualifiedName(t *testing.T) {
+	// If the developer passes the slug-prefixed name (e.g. importing a
+	// shared constant), don't double-prefix.
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "oauth", Slug: "oauth-core", Name: "OAuth"})
+	m.Platform(func(r chi.Router) {
+		r.With(m.RequirePermission("oauth-core.users.view", p.Admin())).Get("/users", func(w http.ResponseWriter, r *http.Request) {})
+	})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if len(got.Permissions) != 1 || got.Permissions[0].Name != "oauth-core.users.view" {
+		t.Errorf("expected 'oauth-core.users.view' (no double-prefix), got %+v", got.Permissions)
+	}
+}
+
+func TestRequirePermission_SlugLessLeavesNameUnchanged(t *testing.T) {
+	// Modules with no slug (test fixtures, internal-only) skip the prefix.
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, _ := New(Config{ID: "raw", Name: "Raw"})
+	m.Platform(func(r chi.Router) {
+		r.With(m.RequirePermission("media.view", p.Admin())).Get("/media", func(w http.ResponseWriter, r *http.Request) {})
+	})
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if len(got.Permissions) != 1 || got.Permissions[0].Name != "media.view" {
+		t.Errorf("expected 'media.view' (unprefixed), got %+v", got.Permissions)
+	}
+}
+
+func TestPlatform_AutoMountsUnderPlatformPrefix(t *testing.T) {
+	// r.Get("/users", ...) inside Platform() → resolves at /platform/users
+	// AND the route is NOT reachable at the bare path.
+	m, _ := New(Config{ID: "test", Name: "Test"})
+	m.Platform(func(r chi.Router) {
+		r.Get("/users", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		})
+	})
+	// Local-dev bypass injects synthetic admin; both 200 prefixed AND 404 bare are required.
+	if rec := doRequest(t, m.Router(), "GET", "/platform/users"); rec.Code != 200 {
+		t.Errorf("prefixed /platform/users: got %d, want 200", rec.Code)
+	}
+	if rec := doRequest(t, m.Router(), "GET", "/users"); rec.Code != 404 {
+		t.Errorf("bare /users must NOT resolve (would bypass the scope prefix): got %d, want 404", rec.Code)
+	}
+}
+
+func TestPublic_AutoMountsUnderPublicPrefix(t *testing.T) {
+	m, _ := New(Config{ID: "test", Name: "Test"})
+	m.Public(func(r chi.Router) {
+		r.Get("/me", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		})
+	})
+	if rec := doRequest(t, m.Router(), "GET", "/public/me"); rec.Code != 200 {
+		t.Errorf("prefixed /public/me: got %d, want 200", rec.Code)
+	}
+	if rec := doRequest(t, m.Router(), "GET", "/me"); rec.Code != 404 {
+		t.Errorf("bare /me must NOT resolve: got %d, want 404", rec.Code)
+	}
+}
+
+func TestInternal_AutoMountsUnderInternalPrefix(t *testing.T) {
+	m := newTestModuleWithSecret(t, "test")
+	m.Internal(func(r chi.Router) {
+		r.Post("/sessions", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		})
+	})
+	if rec := doRequestWithSecret(t, m.Router(), "POST", "/internal/sessions", "secret"); rec.Code != 200 {
+		t.Errorf("prefixed /internal/sessions: got %d, want 200", rec.Code)
+	}
+	if rec := doRequestWithSecret(t, m.Router(), "POST", "/sessions", "secret"); rec.Code != 404 {
+		t.Errorf("bare /sessions must NOT resolve: got %d, want 404", rec.Code)
 	}
 }
 
@@ -621,7 +725,7 @@ func TestManifest_RegisteredScopesStillRouteCorrectly(t *testing.T) {
 		})
 	})
 	m.Public(func(r chi.Router) {
-		r.Get("/public/feed", func(w http.ResponseWriter, r *http.Request) {
+		r.Get("/feed", func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("public"))
 		})
 	})
@@ -631,11 +735,11 @@ func TestManifest_RegisteredScopesStillRouteCorrectly(t *testing.T) {
 		t.Errorf("public route: code = %d, want 200", rec.Code)
 	}
 	// Platform route without auth → 401
-	if rec := doRequest(t, m.Router(), "GET", "/admin/items"); rec.Code != 401 {
+	if rec := doRequest(t, m.Router(), "GET", "/platform/admin/items"); rec.Code != 401 {
 		t.Errorf("platform route without auth: code = %d, want 401", rec.Code)
 	}
 	// Platform route with auth → 200
-	if rec := doRequestWithRole(t, m.Router(), "GET", "/admin/items", auth.RoleAdmin); rec.Code != 200 {
+	if rec := doRequestWithRole(t, m.Router(), "GET", "/platform/admin/items", auth.RoleAdmin); rec.Code != 200 {
 		t.Errorf("platform route with admin: code = %d, want 200", rec.Code)
 	}
 }

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -89,9 +89,7 @@ func (m *Module) OnTask(name string, handler TaskHandler, opts ...TaskOption) {
 	}
 
 	// Mount a dev/debug HTTP endpoint on the Internal scope so developers
-	// can test task handlers via curl without SQS infrastructure. SDK
-	// system path — bypass Module.Internal()'s /internal/ auto-prefix so
-	// the URL stays at taskPathPrefix.
+	// can test task handlers via curl without SQS infrastructure.
 	path := taskPathPrefix + name
 	m.mountSystemInternalRoute("POST", path, m.taskHTTPHandler(name))
 }

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
@@ -90,11 +89,11 @@ func (m *Module) OnTask(name string, handler TaskHandler, opts ...TaskOption) {
 	}
 
 	// Mount a dev/debug HTTP endpoint on the Internal scope so developers
-	// can test task handlers via curl without SQS infrastructure.
+	// can test task handlers via curl without SQS infrastructure. SDK
+	// system path — bypass Module.Internal()'s /internal/ auto-prefix so
+	// the URL stays at taskPathPrefix.
 	path := taskPathPrefix + name
-	m.Internal(func(r chi.Router) {
-		r.Post(path, m.taskHTTPHandler(name))
-	})
+	m.mountSystemInternalRoute("POST", path, m.taskHTTPHandler(name))
 }
 
 // taskHTTPHandler returns an http.HandlerFunc that dispatches to the named


### PR DESCRIPTION
## Summary

Two ergonomics fixes for module authors, surfaced during the PR #1 review on ms-app-modules. Breaking change for any module that manually wrote `/platform/*` URLs or `<slug>.*` permission names — fine right now, no public modules exist yet.

1. **`Module.Platform`/`Public`/`Internal` auto-mount under `/<scope>/`**

   | Before | After |
   |---|---|
   | `r.Get("/platform/users", h)` inside `Platform()` | `r.Get("/users", h)` → resolves at `/platform/users` |
   | `r.Get("/me", h)` inside `Public()` | `r.Get("/me", h)` → `/public/me` |
   | `r.Post("/sessions", h)` inside `Internal()` | `r.Post("/sessions", h)` → `/internal/sessions` |

   The URL contract stays in lockstep with the auth scope — no way to declare a Platform-route at a non-`/platform` path.

   System routes (events, crons, tasks) keep their `/__mirrorstack/*` paths via a new private `mountSystemInternalRoute` helper that bypasses the auto-prefix.

2. **`Module.RequirePermission` auto-prepends `<slug>.` to the name**

   - Slug `oauth-core` + `RequirePermission("users.view", ...)` → manifest stores `oauth-core.users.view`
   - Idempotent: if caller already prefixed, no double-prefix
   - Slug-less modules skip the prefix (avoids leading `.` gibberish)

## Tests

6 new regression tests in `internal/core/module_test.go`:

- `TestRequirePermission_AutoPrefixesWithSlug`
- `TestRequirePermission_PreservesAlreadyQualifiedName`
- `TestRequirePermission_SlugLessLeavesNameUnchanged`
- `TestPlatform_AutoMountsUnderPlatformPrefix`
- `TestPublic_AutoMountsUnderPublicPrefix`
- `TestInternal_AutoMountsUnderInternalPrefix`

Each Auto*Prefix test also asserts the bare path 404s so a future change that drops the wrapping doesn't pass silently.

Updated 9 existing tests to use the new prefixed URLs (`/admin` → `/platform/admin`, etc.).

## Follow-up

oauth-core (ms-app-modules#1) will drop its manual `/platform/` URL prefix and its manual `oauth-core.` permission prefix in a follow-up commit once this lands. Tracked.

## Test plan

- [x] `go test ./...` — all green
- [ ] Reviewer: confirm the `mountSystemInternalRoute` helper preserves existing event/cron/task behavior
- [ ] Reviewer: confirm `qualifyPermissionName` no-op on slug-less modules is desired (alt: fall back to ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)