### PR TITLE
feat(sdk): add UIPage.Surface field

### DIFF
--- a/internal/core/ui.go
+++ b/internal/core/ui.go
@@ -12,6 +12,13 @@ type (
 	UIPage      = registry.UIPage
 )
 
+// Known UIPage.Surface values, re-exported from registry so module
+// authors set ms.UISurfaceSettings rather than typing the literal.
+const (
+	UISurfaceMain     = registry.UISurfaceMain
+	UISurfaceSettings = registry.UISurfaceSettings
+)
+
 // RegisterUI declares the module's UI surface — agent-visible Components
 // plus DefaultPages mounted under /apps/<app-slug>/<module-slug>. See the
 // ModuleUI doc comment for the shape. Validates the input and panics on

--- a/internal/core/ui_test.go
+++ b/internal/core/ui_test.go
@@ -174,6 +174,85 @@ func TestRegisterUI_DuplicatePageRoutePanics(t *testing.T) {
 	})
 }
 
+// ---- RegisterUI: Surface field ----
+
+func TestRegisterUI_DefaultSurfaceIsMain(t *testing.T) {
+	t.Parallel()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{
+			{Route: "/", Title: "Home", Export: "mount"},
+		},
+	})
+	ui := m.registry.UI()
+	if ui.DefaultPages[0].Surface != UISurfaceMain {
+		t.Errorf("expected empty/main Surface by default, got %q", ui.DefaultPages[0].Surface)
+	}
+}
+
+func TestRegisterUI_AcceptsSettingsSurface(t *testing.T) {
+	t.Parallel()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{
+			{Route: "/", Title: "Home", Export: "mount"},
+			{Route: "/", Surface: UISurfaceSettings, Title: "Settings", Export: "mountSettings"},
+		},
+	})
+	got := m.registry.UI().DefaultPages
+	if len(got) != 2 {
+		t.Fatalf("expected 2 pages, got %d", len(got))
+	}
+	if got[0].Surface != UISurfaceMain || got[1].Surface != UISurfaceSettings {
+		t.Errorf("expected [main, settings], got [%q, %q]", got[0].Surface, got[1].Surface)
+	}
+}
+
+func TestRegisterUI_UnknownSurfacePanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on unknown Surface")
+		}
+	}()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{
+			{Route: "/", Surface: "bogus", Title: "X", Export: "X"},
+		},
+	})
+}
+
+func TestRegisterUI_DuplicateRouteAllowedAcrossSurfaces(t *testing.T) {
+	// Same route ("/") on different surfaces is fine — each surface
+	// has its own root and they mount under different platform shells.
+	t.Parallel()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{
+			{Route: "/", Title: "Main Home", Export: "mount"},
+			{Route: "/", Surface: UISurfaceSettings, Title: "Settings Home", Export: "mountSettings"},
+		},
+	})
+	// no panic => pass
+}
+
+func TestRegisterUI_DuplicateRouteSameSurfacePanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on duplicate (surface, route)")
+		}
+	}()
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{
+			{Route: "/cfg", Surface: UISurfaceSettings, Title: "A", Export: "A"},
+			{Route: "/cfg", Surface: UISurfaceSettings, Title: "B", Export: "B"},
+		},
+	})
+}
+
 // ---- RegisterUI: component validation ----
 
 func TestRegisterUI_DuplicateComponentNamePanics(t *testing.T) {

--- a/internal/registry/ui.go
+++ b/internal/registry/ui.go
@@ -60,15 +60,44 @@ type UIProp struct {
 // platform fetches the module's web bundle and renders the matching
 // named export for the requested route.
 //
+// Surface picks which platform-rendered shell the page mounts into:
+//
+//   - "" (default, UISurfaceMain) — the primary module surface at
+//     /apps/<app>/<module-slug>/<route>. Used for the module's
+//     day-to-day pages.
+//   - "settings" (UISurfaceSettings) — the per-module configuration
+//     surface at /apps/<app>/settings/module/<module-slug>/<route>.
+//     Used for install settings, secret entry, provider registries,
+//     and other configuration UIs that belong next to "manage this
+//     module" instead of next to "use this module".
+//
+// More surfaces ("admin", "dev", …) can be added without changing the
+// shape; the string value doubles as the URL segment the platform
+// mounts under, so a single field describes both the JSON manifest
+// and the routing convention.
+//
 // The page's nav-rail icon is the module's icon (Config.Icon). Pages
 // don't carry their own icon today — when distinct icons per page are
 // needed, an Icon field will be added back as optional.
 type UIPage struct {
 	Route       string `json:"route"`
+	Surface     string `json:"surface,omitempty"`
 	Title       string `json:"title"`
 	Description string `json:"description,omitempty"`
 	Export      string `json:"export"`
 }
+
+// Known UIPage.Surface values. Empty string defaults to the main
+// surface so existing module manifests keep working unchanged.
+const (
+	UISurfaceMain     = ""
+	UISurfaceSettings = "settings"
+)
+
+// validSurfaces is the closed set of surfaces the SDK accepts at
+// registration time. New surfaces must land here AND on the
+// platform-side router; an unknown surface is a programmer error.
+var validSurfaces = []string{UISurfaceMain, UISurfaceSettings}
 
 // pageSegmentRe is the route-segment rule: lowercase letters, digits,
 // and hyphens, 1–32 chars, must start and end with a letter or digit
@@ -122,7 +151,10 @@ func validateUI(ui ModuleUI) {
 		validateProps(c.Name, c.Props)
 	}
 
-	seenRoute := make(map[string]struct{}, len(ui.DefaultPages))
+	// Dedup is keyed on (surface, route) because the same route ("/")
+	// is legitimate on every surface — each surface has its own root.
+	type surfaceRoute struct{ surface, route string }
+	seenRoute := make(map[surfaceRoute]struct{}, len(ui.DefaultPages))
 	for i, p := range ui.DefaultPages {
 		if p.Title == "" {
 			panic(fmt.Sprintf("mirrorstack: RegisterUI: DefaultPages[%d] Title is empty", i))
@@ -130,11 +162,15 @@ func validateUI(ui ModuleUI) {
 		if p.Export == "" {
 			panic(fmt.Sprintf("mirrorstack: RegisterUI: DefaultPages[%d] (%q) Export is empty", i, p.Title))
 		}
-		validatePageRoute(p.Route, i)
-		if _, dup := seenRoute[p.Route]; dup {
-			panic(fmt.Sprintf("mirrorstack: RegisterUI: duplicate DefaultPages route %q", p.Route))
+		if !slices.Contains(validSurfaces, p.Surface) {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: DefaultPages[%d] (%q) invalid Surface %q (allowed: %q)", i, p.Title, p.Surface, validSurfaces))
 		}
-		seenRoute[p.Route] = struct{}{}
+		validatePageRoute(p.Route, i)
+		key := surfaceRoute{p.Surface, p.Route}
+		if _, dup := seenRoute[key]; dup {
+			panic(fmt.Sprintf("mirrorstack: RegisterUI: duplicate DefaultPages route %q on surface %q", p.Route, p.Surface))
+		}
+		seenRoute[key] = struct{}{}
 	}
 }
 

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -141,8 +141,19 @@ type UIComponent = core.UIComponent
 type UIProp = core.UIProp
 
 // UIPage is one entry in DefaultPages — a module-shipped React page
-// mounted by the platform under /apps/<app-slug>/<module-slug>/<Slug>.
+// mounted by the platform under /apps/<app-slug>/<module-slug>/<route>
+// (or /apps/<app-slug>/settings/module/<module-slug>/<route> when
+// Surface is UISurfaceSettings).
 type UIPage = core.UIPage
+
+// Known UIPage.Surface values. Empty (UISurfaceMain) is the default —
+// pages mount at /apps/<app>/<module-slug>/<route>. UISurfaceSettings
+// mounts pages at /apps/<app>/settings/module/<module-slug>/<route>
+// instead, for per-module configuration UIs.
+const (
+	UISurfaceMain     = core.UISurfaceMain
+	UISurfaceSettings = core.UISurfaceSettings
+)
 
 // RegisterUI declares the module's UI surface (agent-visible Components
 // plus DefaultPages). Panics on programmer errors (duplicate names,


### PR DESCRIPTION
## Summary

Adds a `Surface string` field to `UIPage` so modules can declare which platform-rendered shell each page mounts into:

| Surface | URL |
|---|---|
| `""` (default, `UISurfaceMain`) | `/apps/<app>/<slug>/<route>` |
| `"settings"` (`UISurfaceSettings`) | `/apps/<app>/settings/module/<slug>/<route>` |

The string value doubles as the URL segment, so a single field describes both the JSON manifest and the routing convention. New surfaces (`"admin"`, `"dev"`, …) can land later without schema changes — just extend `validSurfaces` + add a platform-side route.

## Why a string, not a bool

`Surface bool` would lock the SDK into exactly two surfaces. A string field is no harder to use (`UISurfaceSettings` constant is the same length to type as `true`) and extends cleanly. Also reads better in the manifest JSON: `"surface": "settings"` vs `"settings": true`.

## Validation

- Surface must be in `{"", "settings"}` — unknown values panic at registration (programmer error, not runtime input).
- Route dedup now keyed on `(surface, route)`. Same `/` route is legitimate on every surface — each surface has its own root.

## Tests

`internal/core/ui_test.go` adds:
- `TestRegisterUI_DefaultSurfaceIsMain`
- `TestRegisterUI_AcceptsSettingsSurface`
- `TestRegisterUI_UnknownSurfacePanics`
- `TestRegisterUI_DuplicateRouteAllowedAcrossSurfaces`
- `TestRegisterUI_DuplicateRouteSameSurfacePanics`

Existing tests pass unchanged — `Surface` omitted → `UISurfaceMain` (zero-value compatible).

## Follow-ups (tracked, not in this PR)

- `web-applications`: add `/apps/<app>/settings/module/<slug>/[[...page]]` route. Existing `/apps/<app>/<slug>/[[...page]]` filters `surface !== "settings"`. New route filters `surface === "settings"`.
- `ms-app-modules` PR #1 (oauth-core): set `Surface: UISurfaceSettings` on the Providers page so it lands under the settings surface.

## Test plan

- [x] `go test ./...` — all green
- [ ] Reviewer: confirm `validSurfaces` is the right gate (vs accepting any string + relying on platform-side filter)
- [ ] Reviewer: confirm `(surface, route)` dedup matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)