### PR TITLE
refactor!: rename DefineContribute → Provide (manifest field → provides)

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/lambdaenv"
@@ -16,6 +17,7 @@ import (
 // those callers assert via these headers.
 const (
 	HeaderInternalSecret = "X-MS-Internal-Secret"
+	HeaderPlatformToken  = "X-MS-Platform-Token"
 	HeaderUserID         = "X-MS-User-ID"
 	HeaderAppID          = "X-MS-App-ID"
 	HeaderAppRole        = "X-MS-App-Role"
@@ -46,7 +48,11 @@ func PlatformAuth() func(http.Handler) http.Handler {
 // platformAuth is the test seam; inLambda is injected so tests don't
 // mutate process env captured at package init.
 //
-// Behavior matrix (secret = MS_INTERNAL_SECRET):
+// Auth signal priority: MS_PLATFORM_TOKEN > MS_INTERNAL_SECRET.
+// When MS_PLATFORM_TOKEN is set, the caller must present
+// X-MS-Platform-Token. Otherwise, falls back to X-MS-Internal-Secret.
+//
+// Behavior matrix (secret = first non-empty of MS_PLATFORM_TOKEN, MS_INTERNAL_SECRET):
 //
 //	inLambda + secret unset → 503 (operator misconfig; platform alerting)
 //	inLambda + secret set   → enforce: validate secret + identity headers
@@ -57,9 +63,9 @@ func PlatformAuth() func(http.Handler) http.Handler {
 //	local    + secret set   → enforce (e.g. `mirrorstack dev --tunnel`
 //	                          where the CLI sets the secret)
 func platformAuth(inLambda bool) func(http.Handler) http.Handler {
-	expected := os.Getenv("MS_INTERNAL_SECRET")
-	if expected == "" && !inLambda {
-		log.Printf("mirrorstack: MS_INTERNAL_SECRET not set; platform routes bypass auth with synthetic admin identity (local dev)")
+	readSecret := platformSecretReader()
+	if expected, _ := readSecret(); expected == "" && !inLambda {
+		log.Printf("mirrorstack: no platform secret set; platform routes bypass auth with synthetic admin identity (local dev)")
 	}
 
 	return func(next http.Handler) http.Handler {
@@ -69,6 +75,8 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
+
+			expected, header := readSecret()
 
 			// Step 2: local-dev bypass — inject synthetic admin.
 			if expected == "" && !inLambda {
@@ -84,7 +92,6 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 			// Step 3: Lambda + no secret is a misconfig.
 			if expected == "" {
 				log.Printf("mirrorstack: platform auth rejected (no secret configured) from %s %s", r.RemoteAddr, r.URL.Path)
-				// SECURITY: generic body — same rationale as InternalAuth's 503.
 				httputil.JSON(w, http.StatusServiceUnavailable, httputil.ErrorResponse{
 					Error: "service unavailable",
 				})
@@ -93,9 +100,8 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 
 			// Step 4: trusted-forwarder path. Validate secret, then read
 			// identity headers.
-			secret := r.Header.Get(HeaderInternalSecret)
+			secret := r.Header.Get(header)
 			if !constantTimeEqual(secret, expected) {
-				// SECURITY: never log the header value; only presence.
 				log.Printf("mirrorstack: platform auth rejected (secret mismatch, header_present=%v) from %s %s", secret != "", r.RemoteAddr, r.URL.Path)
 				httputil.JSON(w, http.StatusUnauthorized, httputil.ErrorResponse{Error: "authentication required"})
 				return
@@ -142,10 +148,14 @@ func InternalAuth() func(http.Handler) http.Handler {
 // internalAuth is the test seam; inLambda is injected so tests don't mutate
 // process env captured at package init.
 //
-// Behavior matrix (secret = MS_INTERNAL_SECRET env var):
+// Auth signal priority: MS_PLATFORM_TOKEN > MS_INTERNAL_SECRET.
+// When MS_PLATFORM_TOKEN is set, the caller must present
+// X-MS-Platform-Token. Otherwise, falls back to X-MS-Internal-Secret.
+//
+// Behavior matrix (secret = first non-empty of MS_PLATFORM_TOKEN, MS_INTERNAL_SECRET):
 //
 //	inLambda + secret unset → 503 (operator misconfig; platform alerting)
-//	inLambda + secret set   → enforce X-MS-Internal-Secret header
+//	inLambda + secret set   → enforce matching header
 //	local    + secret unset → BYPASS (local-only; `mirrorstack dev` ergonomics)
 //	local    + secret set   → enforce (e.g. `mirrorstack dev --tunnel` exposes
 //	                          localhost to the platform, so the secret must
@@ -157,41 +167,33 @@ func InternalAuth() func(http.Handler) http.Handler {
 // unauthenticated traffic forwarded by dispatch (the CLI sets the secret
 // when tunneling).
 func internalAuth(inLambda bool) func(http.Handler) http.Handler {
-	expected := os.Getenv("MS_INTERNAL_SECRET")
-	if expected == "" {
+	readSecret := platformSecretReader()
+	if expected, _ := readSecret(); expected == "" {
 		if inLambda {
-			// SECURITY: never echo the `expected` value (or any prefix/suffix of it)
-			// in this log line — Lambda log output goes to CloudWatch which is
-			// commonly accessible to many roles in the org.
-			log.Printf("mirrorstack: WARNING — MS_INTERNAL_SECRET not set, all internal routes will be rejected")
+			log.Printf("mirrorstack: WARNING — no platform secret set, all internal routes will be rejected")
 		} else {
-			log.Printf("mirrorstack: MS_INTERNAL_SECRET not set; internal routes bypass auth (local dev)")
+			log.Printf("mirrorstack: no platform secret set; internal routes bypass auth (local dev)")
 		}
 	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			expected, header := readSecret()
+
 			if expected == "" {
 				if inLambda {
 					log.Printf("mirrorstack: internal auth rejected (no secret configured) from %s %s", r.RemoteAddr, r.URL.Path)
-					// SECURITY: generic body. The detailed reason is in the
-					// construction-time log line above; the 503 status itself
-					// is the platform's alerting signal. We don't want to
-					// confirm "this endpoint exists and the module is broken"
-					// to anonymous callers reaching us pre-WAF.
 					httputil.JSON(w, http.StatusServiceUnavailable, httputil.ErrorResponse{
 						Error: "service unavailable",
 					})
 					return
 				}
-				// Local dev bypass — see the doc-comment matrix above.
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			secret := r.Header.Get("X-MS-Internal-Secret")
+			secret := r.Header.Get(header)
 			if !constantTimeEqual(secret, expected) {
-				// SECURITY: never log the header value; only whether it was present
 				log.Printf("mirrorstack: internal auth rejected (secret mismatch, header_present=%v) from %s %s", secret != "", r.RemoteAddr, r.URL.Path)
 				httputil.JSON(w, http.StatusUnauthorized, httputil.ErrorResponse{Error: "internal authentication required"})
 				return
@@ -199,6 +201,32 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// secretReader returns the current secret and which header carries it.
+// The file-backed variant re-reads on every call so a refreshed token
+// (CLI reconnect) is picked up without restarting the module process.
+type secretReader func() (expected, header string)
+
+// platformSecretReader builds the reader once at middleware construction.
+//   - MS_PLATFORM_TOKEN_FILE set → read from file per call (dev)
+//   - MS_PLATFORM_TOKEN set      → static, captured once (prod / tunnel)
+//   - MS_INTERNAL_SECRET set     → static, captured once (legacy)
+func platformSecretReader() secretReader {
+	if file := os.Getenv("MS_PLATFORM_TOKEN_FILE"); file != "" {
+		return func() (string, string) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return "", HeaderPlatformToken
+			}
+			return strings.TrimSpace(string(data)), HeaderPlatformToken
+		}
+	}
+	if v := os.Getenv("MS_PLATFORM_TOKEN"); v != "" {
+		return func() (string, string) { return v, HeaderPlatformToken }
+	}
+	v := os.Getenv("MS_INTERNAL_SECRET")
+	return func() (string, string) { return v, HeaderInternalSecret }
 }
 
 func constantTimeEqual(a, b string) bool {

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -351,3 +351,144 @@ func TestInternalAuth_LogsHeaderAbsent(t *testing.T) {
 		t.Errorf("expected header_present=false in log, got: %q", got)
 	}
 }
+
+// --- MS_PLATFORM_TOKEN tests ---
+
+func TestInternalAuth_PlatformToken_ValidToken(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-456")
+	t.Setenv("MS_INTERNAL_SECRET", "old-secret")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/event", nil)
+	req.Header.Set(HeaderPlatformToken, "pt-secret-456")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with valid platform token, got %d", rec.Code)
+	}
+}
+
+func TestInternalAuth_PlatformToken_WrongToken_401(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-456")
+	t.Setenv("MS_INTERNAL_SECRET", "old-secret")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/event", nil)
+	req.Header.Set(HeaderPlatformToken, "wrong")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with wrong platform token, got %d", rec.Code)
+	}
+}
+
+func TestInternalAuth_PlatformToken_OldHeaderIgnored(t *testing.T) {
+	// When MS_PLATFORM_TOKEN is set, X-MS-Internal-Secret is not checked.
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-456")
+	t.Setenv("MS_INTERNAL_SECRET", "old-secret")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/event", nil)
+	req.Header.Set(HeaderInternalSecret, "old-secret") // correct old secret, wrong header
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when sending old header while platform token is configured, got %d", rec.Code)
+	}
+}
+
+func TestInternalAuth_PlatformToken_FallbackToInternalSecret(t *testing.T) {
+	// When MS_PLATFORM_TOKEN is empty, falls back to MS_INTERNAL_SECRET.
+	t.Setenv("MS_PLATFORM_TOKEN", "")
+	t.Setenv("MS_INTERNAL_SECRET", "old-secret")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/event", nil)
+	req.Header.Set(HeaderInternalSecret, "old-secret")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 with fallback to internal secret, got %d", rec.Code)
+	}
+}
+
+func TestInternalAuth_PlatformToken_NeitherSet_Bypass(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN", "")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	handler := internalAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("POST", "/event", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 bypass when neither secret set, got %d", rec.Code)
+	}
+}
+
+func TestPlatformAuth_PlatformToken_ValidToken_InjectsIdentity(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-789")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	var seen *Identity
+	handler := platformAuth(false)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = Get(r.Context())
+	}))
+
+	req := httptest.NewRequest("GET", "/platform/users", nil)
+	req.Header.Set(HeaderPlatformToken, "pt-secret-789")
+	req.Header.Set(HeaderUserID, "u-pt-1")
+	req.Header.Set(HeaderAppID, "a-pt-2")
+	req.Header.Set(HeaderAppRole, RoleMember)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK && rec.Code != 0 {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if seen == nil {
+		t.Fatal("expected Identity from platform token path; got nil")
+	}
+	if seen.UserID != "u-pt-1" || seen.AppID != "a-pt-2" || seen.AppRole != RoleMember {
+		t.Errorf("identity mismatch: got %+v", seen)
+	}
+}
+
+func TestPlatformAuth_PlatformToken_WrongToken_401(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-789")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	handler := platformAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("GET", "/platform/users", nil)
+	req.Header.Set(HeaderPlatformToken, "wrong")
+	req.Header.Set(HeaderUserID, "u-1")
+	req.Header.Set(HeaderAppID, "a-1")
+	req.Header.Set(HeaderAppRole, RoleAdmin)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with wrong platform token, got %d", rec.Code)
+	}
+}
+
+func TestPlatformAuth_PlatformToken_OldHeaderIgnored(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-789")
+	t.Setenv("MS_INTERNAL_SECRET", "old-secret")
+	handler := platformAuth(false)(http.HandlerFunc(okHandler))
+
+	req := httptest.NewRequest("GET", "/platform/users", nil)
+	req.Header.Set(HeaderInternalSecret, "old-secret") // old header, should be ignored
+	req.Header.Set(HeaderUserID, "u-1")
+	req.Header.Set(HeaderAppID, "a-1")
+	req.Header.Set(HeaderAppRole, RoleAdmin)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when sending old header while platform token is configured, got %d", rec.Code)
+	}
+}

--- a/docs/concepts/i18n.md
+++ b/docs/concepts/i18n.md
@@ -1,0 +1,129 @@
+# Module i18n — author-bundled (DESIGN — proposed)
+
+> **Status: proposed.** Design for review; not yet implemented. Follow-up,
+> not MVP (current line is agent-UX-first).
+>
+> **Decision: author-bundled catalogs, not agent/platform auto-translation —
+> for now.** Auto-translation was tried on web-account and produced strings
+> that needed manual correction; author-controlled translation is reliable
+> today. Auto-translation stays viable as a *swappable catalog source* later
+> (see Phasing) — it does not change the foundation below.
+
+## Why this is its own problem
+
+Each module ships its **own** React bundle — own React instance, own
+web-ui-kit instance. The platform's React tree never crosses into the
+module's (`web-applications/.../ModuleMount.tsx`), so a module **cannot**
+inherit web-account's `next-intl` provider. Module i18n must be delivered
+through the mount contract, not a shared React context.
+
+## Two surfaces (localized differently)
+
+| Surface | Rendered by | Examples |
+|---|---|---|
+| **Manifest strings** | the **platform** | module name + description (`ms.Describe`, `Config.Name`), `UIPage` title/description → nav-rail label, settings header |
+| **Bundle strings** | the **module** | everything inside the module's React pages |
+
+Out of scope for v1: Go handler error messages (developer-facing) and
+user-generated content (that's data, not chrome).
+
+## Locale source & delivery
+
+- Locale = the user's **account-preference** locale — the same source
+  web-account already uses (next-intl, cookie + `LocaleSync`). BCP-47
+  (`"en"`, `"zh-TW"`).
+- Delivery: add **`locale`** to `MountContext` (the platform→module mount
+  object). The platform sets `ctx.locale`; the module reads it. Backward-
+  compatible — bundles compiled before this field ignore it and render their
+  default language.
+
+## Bundle-string i18n (the module's UI)
+
+A module page reads i18n the **same way it already reads `apiBase`** —
+stashed at mount, read on demand. The bundle deliberately avoids React
+context / prop-drilling for mount values (see oauth-core `api.ts`: module-level
+stash "avoids prop-drilling MountContext through every page"). i18n mirrors that.
+
+1. **Catalogs** in the bundle: `web/src/locales/{en,zh-TW}.json`, flat keys,
+   **English as source + fallback**.
+2. **`createTranslator` helper** — home is **web-ui-kit** (every module bundle
+   already depends on it; there is no other shared module-web package). Pure
+   function, no provider:
+   ```ts
+   type Translator = (key: string, vars?: Record<string, string | number>) => string;
+   function createTranslator(messages, locale, fallback?): Translator;
+   // lookup: messages[key] → fallback[key] → key (missing key is visible, not blank)
+   // "{var}" interpolation from vars
+   ```
+   Deliberately NOT next-intl per module (bundle weight + each module
+   re-pulling it). Flat-JSON keys + `{var}` interpolation is enough.
+3. **Module-local `i18n.ts`** mirrors `api.ts`'s stash:
+   ```ts
+   const catalogs = { en, "zh-TW": zhTW };
+   let active = createTranslator(en, "en", en);
+   export function setLocale(locale) { active = createTranslator(catalogs[locale] ?? en, locale, en); }
+   export const t: Translator = (key, vars) => active(key, vars);   // stable ref pages import
+   ```
+4. **Wire at mount** (`index.tsx`, next to `setApiBase`): `if (ctx.locale) setLocale(ctx.locale);`
+5. **Page reads it** with `t("key")`:
+   ```tsx
+   import { t } from "../i18n";
+   <SettingRow title={t("settings.linkByEmail.title")}
+               description={t("settings.linkByEmail.desc")} control={<Switch … />} />
+   ```
+6. **Reactivity:** `setLocale` runs before `createRoot().render()`, so first
+   paint is correct. On account-language change, `ctx.locale` changes → platform
+   remounts the module (add `locale` to `ModuleMount`'s effect deps). Locale
+   switches are rare, so remount-on-change is the v1; a reactive
+   `useSyncExternalStore` hook is a later nicety.
+7. **web-ui-kit locale-aware formatting.** Today `formatRelativeDate(dateStr)`
+   takes no locale (English-only). It (and `formatDate`, number formatting)
+   must accept a locale so module dates/numbers localize.
+
+## Manifest-string i18n (platform-rendered)
+
+Two options — they differ only in whether the Go SDK changes:
+
+- **Option A (v1, no Go change):** manifest strings stay in the module's
+  default language; only bundle strings localize. The nav label / page title
+  shows e.g. English while the page body is translated. Partial but zero-cost.
+- **Option B (full):** the Go SDK lets authors declare locale variants for
+  `UIPage` title/description and `Config.Name`/`Describe` — e.g. an additive
+  `TitleI18n map[string]string` (or a small localized-string type). The
+  platform picks the variant for the user's locale, falling back to the
+  default. Additive + backward-compatible.
+
+**Recommendation: ship A, add B when manifest localization is actually
+wanted.** Keeps v1 entirely off the Go SDK.
+
+## SDK / package impact — *does the SDK change?*
+
+| Piece | Change for v1? | What |
+|---|---|---|
+| **Go `app-module-sdk`** | **No** (Option A) | Only if/when manifest strings localize (Option B): additive locale-variant fields on `UIPage` + `Config`/`Describe`. |
+| **web-ui-kit** | **Yes — main change** | `createTranslator` helper + make `formatRelativeDate`/`formatDate`/number utils accept a `locale`. Pre-1.0 **patch** bump + `release` label (kit convention). |
+| **MountContext** | **Yes** | Add `locale` field. It's **duplicated** (platform `ModuleMount.tsx` + each module `index.tsx`) — edit both; no shared type today. Optional cleanup: extract a shared MountContext type. |
+| **web-applications (platform)** | **Yes** | Inject the current account-preference locale into `ctx.locale` at mount. |
+| **Module author convention** | n/a | Ship `locales/*.json`, wire `createTranslator` at mount. Optionally update `/ms-init` scaffold + document in ms-app-modules-example. |
+
+Net: **the Go SDK is untouched for v1.** The shared lift is a small
+web-ui-kit addition + a one-field mount-contract change + the platform
+injecting locale.
+
+## Phasing
+
+1. `ctx.locale` + web-ui-kit `createTranslator` + locale-aware kit formatters;
+   localize **oauth-core** bundle strings as the reference module. *(No Go change.)*
+2. Manifest-string localization (Go SDK Option B) if/when nav labels + titles
+   need translating.
+3. *(Later, additive)* platform/agent auto-translation as a catalog **source** —
+   author still reviews/overrides. The foundation (1) is unchanged; only who
+   fills the non-English catalogs differs.
+
+## Open decisions
+
+- **Translator home:** web-ui-kit (lean) vs a new tiny `module-web-sdk` package.
+- **Catalog format:** flat JSON + `{var}` (lean) vs next-intl/ICU-compatible.
+- **Manifest localization:** Option A now / B deferred (lean) vs B now.
+- **Shared MountContext type:** extract one (so future ctx fields aren't
+  double-edited) vs keep duplicated for now.

--- a/docs/concepts/internal-calls.md
+++ b/docs/concepts/internal-calls.md
@@ -1,0 +1,137 @@
+# Internal calls — envelope, typed client, CORS (DESIGN — proposed)
+
+> **Status: proposed.** Design for review; not yet implemented. Decision
+> context in [ADR 0005](../../../mirrorstack-docs/adr/0005-module-internal-scope-stays-rest.md):
+> the Internal scope stays REST; this doc adds the three ergonomics that bank
+> billing-engine's useful parts without its routing shape.
+
+Three additive pieces. Parts 1 and 3 ship independently today. Part 2 (the
+typed client) is **gated** on the prod dispatch→module sender (see §4).
+
+---
+
+## 1. Response envelope helper (`internal/httputil`)
+
+Today handlers write `httputil.JSON(w, status, v)` and the only standard
+error shape is `ErrorResponse{Error string}` → `{"error":"…"}`. Cross-module
+callers have no uniform success/failure discriminator. Add billing's
+envelope (`billing-engine/cmd/account-api/main.go`) as opt-in helpers:
+
+```go
+// Envelope is the uniform Internal response shape (mirrors billing-engine).
+type Envelope struct {
+	OK       bool      `json:"ok"`
+	Response any       `json:"response,omitempty"`
+	Error    *EnvError `json:"error,omitempty"`
+}
+
+type EnvError struct {
+	Code    string `json:"code"`              // machine code, e.g. "not_found"
+	Message string `json:"message,omitempty"` // human detail, optional
+}
+
+// OK writes {ok:true, response:v}.
+func OK(w http.ResponseWriter, status int, v any)
+
+// Fail writes {ok:false, error:{code,message}}.
+func Fail(w http.ResponseWriter, status int, code, message string)
+```
+
+- **Scope of adoption:** Internal handlers should use `OK`/`Fail` — that is
+  the machine-to-machine boundary the typed client (§2) consumes. Platform/
+  Public responses are consumed by the browser/bundle and keep their existing
+  shape; no forced migration.
+- **Back-compat:** `JSON` and `ErrorResponse` stay. This is purely additive.
+- **Decision point:** do we migrate the example modules' existing `writeError`
+  (`{"error":…}`) to `Fail` for consistency, or leave them? *Recommendation:
+  migrate oauth-core's Internal handlers only, leave Platform/Public as-is.*
+
+---
+
+## 2. Typed cross-module client (`ms.CallModule`)
+
+One generic client replaces N hand-written per-procedure wrappers (billing's
+client is hand-written 6-line wrappers — exactly what the SDK should remove).
+Go forbids type params on methods, so this is a package-level generic func:
+
+```go
+// CallModule invokes a declared dependency's Internal route and decodes the
+// {ok,error} envelope into Resp. dep is the dependency slug declared via
+// ms.DependsOn. The inbound request's trusted identity (user/app/role) is
+// propagated so the call runs on-behalf-of the same caller.
+func CallModule[Req, Resp any](
+	ctx context.Context, dep, method, path string, req Req,
+) (Resp, error)
+```
+
+Behavior:
+1. **Resolve** the dep's Internal base from platform-injected dep routing
+   (see §4 — this is the gated piece).
+2. **Auth + identity:** attach the platform/internal secret, and forward
+   `X-MS-User-ID`/`X-MS-App-ID`/`X-MS-App-Role` read from `ctx` (the same
+   trusted fields `NewLambdaHandler` injected on the inbound request). This
+   preserves the trust model — the dep sees the original caller's identity,
+   not the calling module's.
+3. **Send** `method` + `path` + `json(req)`. Prod rides `lambda.Invoke` via
+   the platform sender (HTTP-shaped `LambdaRequest`); dev rides HTTP through
+   the dispatch proxy. The module author writes the same call either way.
+4. **Decode** the `Envelope`. `ok:true` → unmarshal `response` into `Resp`.
+   `ok:false` → return a typed `*CallError{Code, Message, Status}`.
+
+```go
+type CallError struct {
+	Code    string
+	Message string
+	Status  int
+}
+func (e *CallError) Error() string
+```
+
+Usage (a consumer reading an oauth-core user):
+```go
+user, err := ms.CallModule[struct{}, UserDTO](
+	r.Context(), "oauth-core", "GET", "/internal/users/"+id, struct{}{})
+```
+
+- **Type safety parity with RPC, without codegen or per-method wrappers.**
+- **Decision point:** package the request as a body for GET? Internal `GET`
+  with a body is fine over `lambda.Invoke` (it's a field on `LambdaRequest`),
+  but awkward over real HTTP. *Recommendation: for GETs, require `Req = struct{}{}`
+  and put params in `path`; bodies only on POST/PUT/DELETE.*
+
+---
+
+## 3. Drop CORS on the Internal mount
+
+Today `localDevCORS` is applied **router-wide** in the dev-bypass branch
+(`module.go:151-163`, `m.router.Use(localDevCORS)` when `MS_INTERNAL_SECRET`
+is unset). Internal routes are proxy/lambda-only — a browser never originates
+an Internal call — so CORS there is dead weight and the one bit of genuine
+"web baggage" the RPC camp correctly disliked.
+
+**Change:** apply `localDevCORS` only to the Platform and Public scoped
+subrouters, never to Internal (and never to the system internal routes under
+`/__mirrorstack/*`). Sketch: move the `Use(localDevCORS)` out of the global
+router and into `scopedRoutes` for `ScopePlatform`/`ScopePublic` only, or
+guard it by scope prefix. No behavior change for browser-facing scopes;
+Internal simply stops emitting CORS headers.
+
+---
+
+## 4. Gating dependency: the prod dispatch→module sender
+
+§2's `CallModule` needs to **resolve a dep's Internal base** and needs the
+platform to actually carry the call in prod. Neither exists yet — today's
+built path is the WSS dev tunnel (`api-platform/internal/dispatch/handler/dev_tunnel.go`);
+there is no prod module-invoke sender. Per ADR 0005 that sender MUST forward
+`{method, path, body}` into the SDK's HTTP-shaped `LambdaRequest`.
+
+So sequencing:
+- **Now (independent):** §1 envelope helper, §3 CORS scoping.
+- **Gated on the sender (task #116):** §2 typed client + dep-routing
+  injection (platform supplies each declared dep's reachable base, e.g. via
+  `Resources` or a `MS_DEP_<slug>_URL`-style map the SDK reads).
+
+Open question to settle when the sender lands: **how is dep routing injected** —
+as part of `runtime.Resources`, or a separate deps map? That choice belongs
+with the sender's design, not here.

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -1,0 +1,212 @@
+// Package i18n is the module-side internationalization loader for the SDK.
+//
+// A module ships nested JSON catalogs (one file per locale, e.g.
+// i18n/en-US.json, i18n/zh-TW.json) and registers them once at startup via
+// RegisterMessages. Catalogs are flattened to dotted keys so a nested
+// object like {"permissions":{"users.read":"View users"}} becomes the key
+// "permissions.users.read".
+//
+// The catalogs feed Label values (Text / T). Labels are opaque: they carry
+// either a literal string or a catalog key, and resolution to a per-locale
+// map happens lazily — typically at manifest build time when a permission is
+// declared (ms.RegisterPermission). This package never resolves at call time,
+// so the order of RegisterMessages vs. building Labels does not matter as long
+// as both run before the manifest is served.
+//
+// The registry is a process-global keyed by locale → flatKey → message. A
+// MirrorStack module is a single binary serving a single module identity, so
+// one global catalog per process is the right grain. Tests can call Reset to
+// clear it.
+package i18n
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// DefaultLocale is the fallback locale. Literal Text() labels resolve under
+// this locale, and catalog T() labels fall back to it (then to the raw key)
+// when no loaded locale carries the requested message.
+const DefaultLocale = "en-US"
+
+// registry is the process-global message store: locale → flatKey → message.
+// Guarded by mu. Populated by RegisterMessages; read by Label.Resolve.
+var (
+	mu       sync.RWMutex
+	registry = map[string]map[string]string{}
+)
+
+// RegisterMessages loads every <dir>/<locale>.json file from fsys into the
+// process-global catalog. The locale is the filename without its .json
+// extension (e.g. "en-US", "zh-TW"). Each file must be a nested JSON object;
+// it is flattened to dotted keys (a nested {"a":{"b":"x"}} becomes "a.b").
+//
+// Re-registering a locale merges into any existing entries for that locale
+// (last write wins per key), so a module may load multiple catalog dirs.
+// Returns an error if a file can't be read or isn't a JSON object; files that
+// are not *.json (or are sub-directories) are skipped.
+//
+//	//go:embed i18n/*.json
+//	var i18nFS embed.FS
+//	ms.RegisterMessages(i18nFS, "i18n")
+func RegisterMessages(fsys fs.FS, dir string) error {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return fmt.Errorf("i18n: read dir %q: %w", dir, err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		locale := strings.TrimSuffix(name, ".json")
+		if locale == "" {
+			continue
+		}
+
+		raw, err := fs.ReadFile(fsys, path.Join(dir, name))
+		if err != nil {
+			return fmt.Errorf("i18n: read file %q: %w", name, err)
+		}
+
+		var nested map[string]any
+		if err := json.Unmarshal(raw, &nested); err != nil {
+			return fmt.Errorf("i18n: %q is not a JSON object: %w", name, err)
+		}
+
+		flat := registry[locale]
+		if flat == nil {
+			flat = map[string]string{}
+			registry[locale] = flat
+		}
+		flatten("", nested, flat)
+	}
+	return nil
+}
+
+// flatten walks a nested map, writing each leaf string under its dotted path
+// into out. Non-string leaves (numbers, bools, arrays) are ignored — message
+// catalogs are string-valued.
+func flatten(prefix string, in map[string]any, out map[string]string) {
+	for k, v := range in {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch t := v.(type) {
+		case string:
+			out[key] = t
+		case map[string]any:
+			flatten(key, t, out)
+		}
+	}
+}
+
+// Reset clears the process-global catalog. Test-only helper so each test
+// starts from a known state.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	registry = map[string]map[string]string{}
+}
+
+// Label is an opaque, deferred-resolution display string. Construct one with
+// Text (a literal) or T (a catalog key). Resolution to a per-locale map happens
+// later via Resolve, reading the catalog registered by RegisterMessages.
+type Label struct {
+	// literal is set for Text() labels: the string resolves to
+	// {DefaultLocale: literal}. key is set for T() labels: it is looked up
+	// in the registry per loaded locale. Exactly one of the two is meaningful;
+	// isKey discriminates so an empty literal is still resolvable.
+	literal string
+	key     string
+	isKey   bool
+}
+
+// Text returns a literal Label. It resolves to {DefaultLocale: s}, ignoring
+// the catalog — use it for strings that are not translated (or whose
+// translation lives elsewhere).
+func Text(s string) Label { return Label{literal: s} }
+
+// T returns a catalog-key Label. At Resolve time it is looked up per loaded
+// locale (skipping locales that lack the key). If no loaded locale carries the
+// key, it falls back to {DefaultLocale: key} — the raw key, NOT a humanized
+// form — so a missing translation is unambiguous.
+func T(key string) Label { return Label{key: key, isKey: true} }
+
+// IsZero reports whether the Label was never set (the zero value). Callers use
+// this to omit empty Labels from the manifest (e.g. an undeclared Description).
+func (l Label) IsZero() bool {
+	return !l.isKey && l.literal == ""
+}
+
+// Resolve returns the locale → message map for this Label, reading the catalog
+// registered via RegisterMessages.
+//
+//   - A literal Text(s) resolves to {DefaultLocale: s}.
+//   - A catalog T(key) resolves to {locale: messages[locale][key]} for every
+//     loaded locale that has the key; locales missing the key are skipped. If
+//     NO loaded locale has it, it falls back to {DefaultLocale: key}.
+//
+// The returned map is freshly allocated and owned by the caller.
+func (l Label) Resolve() map[string]string {
+	if !l.isKey {
+		return map[string]string{DefaultLocale: l.literal}
+	}
+
+	mu.RLock()
+	defer mu.RUnlock()
+
+	out := map[string]string{}
+	for locale, flat := range registry {
+		if msg, ok := flat[l.key]; ok {
+			out[locale] = msg
+		}
+	}
+	if len(out) == 0 {
+		// No translation anywhere — fall back to the raw key under the
+		// default locale so the platform shows something unambiguous.
+		return map[string]string{DefaultLocale: l.key}
+	}
+	return out
+}
+
+// Lookup returns the locale → message map for a catalog key. Unlike
+// Label.Resolve it does NOT fall back to the raw key — an undeclared key yields
+// an empty map, so callers (e.g. manifest defaults) can omit the field entirely
+// and let a literal fallback win. The returned map is owned by the caller.
+func Lookup(key string) map[string]string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := map[string]string{}
+	for locale, flat := range registry {
+		if msg, ok := flat[key]; ok {
+			out[locale] = msg
+		}
+	}
+	return out
+}
+
+// Locales returns the sorted list of locales currently loaded. Test/debug aid.
+func Locales() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]string, 0, len(registry))
+	for locale := range registry {
+		out = append(out, locale)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -1,0 +1,91 @@
+package i18n
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+// loadFixture resets the global catalog and loads en-US + zh-TW from an
+// in-memory FS shaped like a real module's i18n/ dir.
+func loadFixture(t *testing.T) {
+	t.Helper()
+	Reset()
+	t.Cleanup(Reset)
+	fsys := fstest.MapFS{
+		"i18n/en-US.json": &fstest.MapFile{Data: []byte(`{"permissions":{"users.read":"View users","users.delete":"Delete users"}}`)},
+		"i18n/zh-TW.json": &fstest.MapFile{Data: []byte(`{"permissions":{"users.read":"檢視使用者"}}`)},
+		"i18n/README.md":  &fstest.MapFile{Data: []byte("ignored")},
+	}
+	if err := RegisterMessages(fsys, "i18n"); err != nil {
+		t.Fatalf("RegisterMessages: %v", err)
+	}
+}
+
+func TestRegisterMessages_FlattensNestedKeys(t *testing.T) {
+	loadFixture(t)
+
+	got := T("permissions.users.read").Resolve()
+	if got["en-US"] != "View users" {
+		t.Errorf("en-US = %q, want %q", got["en-US"], "View users")
+	}
+	if got["zh-TW"] != "檢視使用者" {
+		t.Errorf("zh-TW = %q, want %q", got["zh-TW"], "檢視使用者")
+	}
+}
+
+func TestT_SkipsLocalesMissingKey(t *testing.T) {
+	loadFixture(t)
+
+	// users.delete exists only in en-US — zh-TW must be omitted, not blank.
+	got := T("permissions.users.delete").Resolve()
+	if got["en-US"] != "Delete users" {
+		t.Errorf("en-US = %q, want %q", got["en-US"], "Delete users")
+	}
+	if _, ok := got["zh-TW"]; ok {
+		t.Errorf("zh-TW should be omitted for a key it lacks, got %q", got["zh-TW"])
+	}
+}
+
+func TestT_FallsBackToRawKey(t *testing.T) {
+	loadFixture(t)
+
+	// No locale has this key → fall back to {DefaultLocale: rawKey}.
+	got := T("permissions.nope").Resolve()
+	if len(got) != 1 || got[DefaultLocale] != "permissions.nope" {
+		t.Errorf("missing key fallback = %v, want {%s: permissions.nope}", got, DefaultLocale)
+	}
+}
+
+func TestText_ResolvesUnderDefaultLocale(t *testing.T) {
+	loadFixture(t)
+
+	got := Text("Literal label").Resolve()
+	if len(got) != 1 || got[DefaultLocale] != "Literal label" {
+		t.Errorf("Text resolve = %v, want {%s: Literal label}", got, DefaultLocale)
+	}
+}
+
+func TestLabel_IsZero(t *testing.T) {
+	if !(Label{}).IsZero() {
+		t.Error("zero Label should report IsZero()")
+	}
+	if Text("x").IsZero() {
+		t.Error("Text(x) should not be zero")
+	}
+	if T("k").IsZero() {
+		t.Error("T(k) should not be zero")
+	}
+	// A literal empty Text is still a deliberate value, but IsZero treats it as
+	// absent — matching the manifest-omit intent (nothing to show).
+	if !Text("").IsZero() {
+		t.Error("Text(\"\") is treated as zero for manifest-omit purposes")
+	}
+}
+
+func TestRegisterMessages_MissingDirErrors(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+	if err := RegisterMessages(fstest.MapFS{}, "i18n"); err == nil {
+		t.Error("expected error for missing dir")
+	}
+}

--- a/internal/contributions/types.go
+++ b/internal/contributions/types.go
@@ -1,6 +1,6 @@
 // Package contributions implements the SDK's host-side contribution
 // slots: a host module declares an extension point with
-// ms.DefineContribute, the SDK auto-mounts HTTP endpoints for
+// ms.Provide, the SDK auto-mounts HTTP endpoints for
 // register/unregister/list, and other modules register payloads
 // against the slot via the Contribute call (or direct HTTP).
 //
@@ -35,7 +35,7 @@ var (
 )
 
 // Slot is one declared contribution point. The validator closure is
-// produced by DefineContribute generic so the SDK can typecheck
+// produced by Provide generic so the SDK can typecheck
 // incoming payloads against the host's declared T at register time —
 // without the storage layer needing to know what T is.
 type Slot struct {
@@ -68,7 +68,7 @@ type Contribution struct {
 }
 
 // Registry holds all declared slots for one module. Populated at
-// DefineContribute time; consulted by the HTTP handlers + auto-mount
+// Provide time; consulted by the HTTP handlers + auto-mount
 // path to figure out which routes to expose.
 type Registry struct {
 	mu    sync.RWMutex
@@ -144,7 +144,7 @@ func (r *Registry) List() []SlotInfo {
 }
 
 // NewSlot constructs a Slot with a validator closure. Generic
-// DefineContribute[T] in the parent package builds the closure
+// Provide[T] in the parent package builds the closure
 // where T is in scope.
 func NewSlot(key string, schemaTag string, validate func(json.RawMessage) error) Slot {
 	return Slot{Key: key, schemaTag: schemaTag, validate: validate}

--- a/internal/core/contribute.go
+++ b/internal/core/contribute.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
+)
+
+// ContributesTo declares that this module pushes payload INTO another module's
+// contribution slot — the contributor side of DefineContribute. It is a
+// ZERO-RUNTIME declaration that mirrors DependsOn: the payload becomes manifest
+// metadata (contributesTo), and the platform catalog — or the CLI dev runner in
+// local dev — performs the actual registration into the host after app-owner
+// approval. The module's binary never calls the host directly.
+//
+// Pair it with ms.DependsOn(host) so the platform installs the host first and
+// can validate the slot exists against the host's definedContributions.
+//
+// payload must be a JSON-serializable value matching the host slot's declared
+// type (e.g. oauth-core's AuthProvider). Re-declaring the same (host, slot)
+// replaces the payload — last call wins.
+//
+// Panics on empty host/slot or an unmarshalable payload — programmer error,
+// caught at startup before serving.
+//
+//	ms.ContributesTo("oauth-core", "auth-provider", AuthProvider{
+//	    Slug: "google", Name: "Google", Icon: "login",
+//	    AuthorizeURL: "/authorize-url", CallbackURL: "/callback",
+//	})
+func (m *Module) ContributesTo(host, slot string, payload any) {
+	if host == "" {
+		panic("ms.ContributesTo: host is required")
+	}
+	if slot == "" {
+		panic("ms.ContributesTo: slot is required")
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		panic(fmt.Sprintf("ms.ContributesTo(%q, %q): marshal payload: %v", host, slot, err))
+	}
+	m.registry.AddOutboundContribution(registry.OutboundContribution{
+		Host:    host,
+		Slot:    slot,
+		Payload: raw,
+	})
+}
+
+// ContributesTo declares an outbound contribution on the default module. Panics
+// if Init has not been called. See Module.ContributesTo.
+func ContributesTo(host, slot string, payload any) {
+	mustDefault("ContributesTo").ContributesTo(host, slot, payload)
+}

--- a/internal/core/contribute.go
+++ b/internal/core/contribute.go
@@ -8,14 +8,14 @@ import (
 )
 
 // ContributesTo declares that this module pushes payload INTO another module's
-// contribution slot — the contributor side of DefineContribute. It is a
+// contribution slot — the contributor side of Provide. It is a
 // ZERO-RUNTIME declaration that mirrors DependsOn: the payload becomes manifest
 // metadata (contributesTo), and the platform catalog — or the CLI dev runner in
 // local dev — performs the actual registration into the host after app-owner
 // approval. The module's binary never calls the host directly.
 //
 // Pair it with ms.DependsOn(host) so the platform installs the host first and
-// can validate the slot exists against the host's definedContributions.
+// can validate the slot exists against the host's provides.
 //
 // payload must be a JSON-serializable value matching the host slot's declared
 // type (e.g. oauth-core's AuthProvider). Re-declaring the same (host, slot)

--- a/internal/core/dev_migrate.go
+++ b/internal/core/dev_migrate.go
@@ -8,9 +8,16 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
 )
+
+// devAppSchema is the schema app-scope migrations target in dev. There is no
+// per-app tenant locally, so every app migration shares one schema — public,
+// which is also on the default search_path m.DB/m.Tx fall back to at runtime
+// when no app schema is set, so handlers read the tables migrations create.
+const devAppSchema = "public"
 
 // devMigrateEnvVar is the local-dev signal set by `mirrorstack dev`. When
 // non-empty, the module is running under the CLI's dev lifecycle and applies
@@ -35,8 +42,9 @@ func (m *Module) devMigrateEnabled() bool {
 
 // applyDevMigrations runs every embedded migration that has not yet been
 // applied to the dev Postgres. Idempotent across module restarts — the
-// tracking table __ms_local.schema_migrations records what ran, keyed by
-// (scope, version).
+// per-module tracking table mod_<id>.schema_migrations records what ran, keyed
+// by (scope, version). Per-module (not a shared table) so two modules sharing
+// one dev Postgres don't collide on the same version number.
 //
 // Pre-creates the mod_<id> schema so module-scope migrations have a home;
 // app-scope migrations land in whatever schema the connection sees by
@@ -50,26 +58,31 @@ func (m *Module) applyDevMigrations(ctx context.Context) error {
 	}
 	defer release()
 
-	if _, err := pool.Exec(ctx, fmt.Sprintf(
-		`CREATE SCHEMA IF NOT EXISTS %s`,
-		pgx.Identifier{"mod_" + m.config.ID}.Sanitize(),
-	)); err != nil {
+	modSchema := pgx.Identifier{"mod_" + m.config.ID}.Sanitize()
+	if _, err := pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+modSchema); err != nil {
 		return fmt.Errorf("dev migrate: create mod schema: %w", err)
 	}
 
-	if _, err := pool.Exec(ctx, `
-		CREATE SCHEMA IF NOT EXISTS __ms_local;
-		CREATE TABLE IF NOT EXISTS __ms_local.schema_migrations (
+	// The tracking table lives in the module's OWN schema and MUST be
+	// per-module. Every module on a developer's machine shares one dev
+	// Postgres, so the old shared __ms_local.schema_migrations (keyed only by
+	// scope+version) collided across modules: module B's "app/0001" was
+	// skipped because module A had already recorded "app/0001", so B's tables
+	// were never created. Keyed per mod_<id> schema, each module's version
+	// space is independent.
+	trackingTable := pgx.Identifier{"mod_" + m.config.ID, "schema_migrations"}.Sanitize()
+	if _, err := pool.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
 			scope      text NOT NULL,
 			version    text NOT NULL,
 			applied_at timestamptz NOT NULL DEFAULT now(),
 			PRIMARY KEY (scope, version)
-		)`); err != nil {
+		)`, trackingTable)); err != nil {
 		return fmt.Errorf("dev migrate: create tracking table: %w", err)
 	}
 
 	for _, scope := range migration.AllScopes() {
-		if err := m.applyDevScope(ctx, pool, scope); err != nil {
+		if err := m.applyDevScope(ctx, pool, trackingTable, scope); err != nil {
 			return err
 		}
 	}
@@ -79,7 +92,7 @@ func (m *Module) applyDevMigrations(ctx context.Context) error {
 // applyDevScope filters the embedded sql/<scope>/ migrations down to those
 // not already recorded in the tracking table, then applies the remainder
 // via the same TxRunner the production install handler uses.
-func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, scope migration.Scope) error {
+func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, trackingTable string, scope migration.Scope) error {
 	all, err := migration.List(m.config.SQL, scope)
 	if err != nil {
 		return fmt.Errorf("dev migrate %s: list: %w", scope, err)
@@ -88,7 +101,7 @@ func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, scope mi
 		return nil
 	}
 
-	applied, err := loadAppliedVersions(ctx, pool, scope)
+	applied, err := loadAppliedVersions(ctx, pool, trackingTable, scope)
 	if err != nil {
 		return fmt.Errorf("dev migrate %s: load applied: %w", scope, err)
 	}
@@ -103,10 +116,22 @@ func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, scope mi
 		return nil
 	}
 
+	// App-scope migrations carry no per-app tenant in dev, so m.Tx would run
+	// each with an empty schema and fall back to the connection's default
+	// search_path. That default is not guaranteed identical across the pooled
+	// connections used for consecutive migrations, so a migration referencing
+	// an earlier one's table can fail with "relation does not exist". Pin the
+	// whole app sequence to one schema (public) so every migration lands in the
+	// same place. Module scope uses m.ModuleTx, which sets mod_<id> itself.
+	migrateCtx := ctx
+	if scope == migration.ScopeApp {
+		migrateCtx = db.WithSchema(ctx, devAppSchema)
+	}
+
 	runTx := m.lifecycleTxRunner(scope)
-	ran, err := migration.Apply(ctx, runTx, m.config.SQL, pending)
+	ran, err := migration.Apply(migrateCtx, runTx, m.config.SQL, pending)
 	// Record whatever ran before the failure (if any) so retries skip them.
-	if recErr := recordAppliedVersions(ctx, pool, scope, ran); recErr != nil && err == nil {
+	if recErr := recordAppliedVersions(ctx, pool, trackingTable, scope, ran); recErr != nil && err == nil {
 		return fmt.Errorf("dev migrate %s: record applied: %w", scope, recErr)
 	}
 	if err != nil {
@@ -116,9 +141,9 @@ func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, scope mi
 	return nil
 }
 
-func loadAppliedVersions(ctx context.Context, pool *pgxpool.Pool, scope migration.Scope) (map[string]bool, error) {
+func loadAppliedVersions(ctx context.Context, pool *pgxpool.Pool, trackingTable string, scope migration.Scope) (map[string]bool, error) {
 	rows, err := pool.Query(ctx,
-		`SELECT version FROM __ms_local.schema_migrations WHERE scope = $1`,
+		fmt.Sprintf(`SELECT version FROM %s WHERE scope = $1`, trackingTable),
 		string(scope))
 	if err != nil {
 		return nil, err
@@ -135,11 +160,11 @@ func loadAppliedVersions(ctx context.Context, pool *pgxpool.Pool, scope migratio
 	return out, rows.Err()
 }
 
-func recordAppliedVersions(ctx context.Context, pool *pgxpool.Pool, scope migration.Scope, versions []string) error {
+func recordAppliedVersions(ctx context.Context, pool *pgxpool.Pool, trackingTable string, scope migration.Scope, versions []string) error {
 	for _, v := range versions {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO __ms_local.schema_migrations (scope, version) VALUES ($1, $2)
-			 ON CONFLICT DO NOTHING`,
+			fmt.Sprintf(`INSERT INTO %s (scope, version) VALUES ($1, $2)
+			 ON CONFLICT DO NOTHING`, trackingTable),
 			string(scope), v); err != nil {
 			return err
 		}

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/i18n"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/contributions"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
@@ -49,6 +50,10 @@ type Config struct {
 	// Optional in dev; the publish pipeline is where slugs become required.
 	Name string // Default display name (platform can override)
 	Icon string // Default Material icon name (platform can override)
+
+	// Tags are module-level category badges (e.g. "Auth", "Payments") shown in
+	// the platform's module catalog / settings. Surfaced via manifest defaults.
+	Tags []string
 
 	// SQL is an optional filesystem containing the module's sql/ directory
 	// (typically an embed.FS from `//go:embed sql/*`). The manifest endpoint
@@ -286,28 +291,110 @@ func (m *Module) scopedRoutes(scope registry.Scope, scopeMiddleware func(http.Ha
 	}
 }
 
-// RequirePermission returns chi middleware that checks AppRole against the
-// allowed roles AND records the permission on this Module's registry so it
-// appears in the manifest payload. Call this at route registration time
-// (alongside m.Platform/Public/Internal), NOT from inside a request handler
-// — registry append is O(N), so dynamic per-request names would leak memory
-// and slow down every subsequent registration.
+// Label is a deferred-resolution display string built from Text (literal) or
+// T (i18n catalog key). It is an alias of i18n.Label so module code constructs
+// it through the ms facade (ms.Text / ms.T) without importing the i18n package
+// directly.
+type Label = i18n.Label
+
+// Text returns a literal Label resolving to {i18n.DefaultLocale: s}.
+func Text(s string) Label { return i18n.Text(s) }
+
+// T returns a catalog-key Label resolved per loaded locale at manifest-build
+// time. See i18n.T.
+func T(key string) Label { return i18n.T(key) }
+
+// RegisterMessages loads the module's i18n catalogs (one <locale>.json per
+// file under dir) into the SDK's message registry. See i18n.RegisterMessages.
+func RegisterMessages(fsys fs.FS, dir string) error { return i18n.RegisterMessages(fsys, dir) }
+
+// PermissionOpts configures a permission declared via RegisterPermission.
 //
-// Permission names are auto-namespaced with the module slug so two modules
-// can each declare a "users.read" permission without colliding in the
-// platform's catalog. Developers write the short name; the manifest stores
-// "<slug>.<name>":
+// DefaultRole is the role the permission lands on (commonly roles.Viewer();
+// roles.Admin() keeps it admin-only). Admin is ALWAYS implicit — it is never
+// stored in the role set. CustomRoles are extra role keys beyond the default.
 //
-//	import p "github.com/mirrorstack-ai/app-module-sdk/roles"
-//	// Module slug "oauth-core" → manifest records "oauth-core.users.view".
-//	r.With(mod.RequirePermission("users.view", p.Admin(), p.Viewer())).Get("/items", listItems)
+// Label and Description are optional display strings, built from ms.Text /
+// ms.T. They are resolved against the module's i18n catalogs at registration
+// and folded into the manifest (per-locale), so the platform's roles UI can
+// show a localized human label instead of the raw permission key. A zero
+// Label is omitted entirely.
+type PermissionOpts struct {
+	DefaultRole roles.Role
+	CustomRoles []string
+	Label       Label
+	Description Label
+}
+
+// RegisterPermission declares a module permission ONCE, recording its default
+// role, custom roles, and resolved i18n Labels/Descriptions into this Module's
+// registry so they appear in the manifest. Call it at startup (typically in a
+// declare/ package) BEFORE the routes that gate on it. First-wins by name:
+// re-declaring the same permission is a no-op.
 //
-// If the caller already prefixed the name with the slug (manual or
-// imported from a constant), the prefix is left alone — no double-prefix.
-func (m *Module) RequirePermission(name string, allowed ...roles.Role) func(http.Handler) http.Handler {
-	keys := roles.Keys(allowed)
-	m.registry.AddPermission(qualifyPermissionName(m.config.Slug, name), keys)
-	return auth.RequireRoles(keys...)
+// Permission names are auto-namespaced with the module slug so two modules can
+// each declare a "users.read" without colliding in the platform's catalog.
+// Developers pass the SHORT name; the manifest stores "<slug>.<name>". If the
+// caller already prefixed the name with the slug, the prefix is left alone.
+//
+//	import "github.com/mirrorstack-ai/app-module-sdk/roles"
+//	ms.RegisterPermission("users.read", ms.PermissionOpts{
+//	    DefaultRole: roles.Viewer(),
+//	    Label:       ms.T("permissions.users.read"),
+//	})
+func (m *Module) RegisterPermission(name string, opts PermissionOpts) {
+	// Manifest records the default role + any custom roles; admin is implicit.
+	declared := append([]string{opts.DefaultRole.Key}, opts.CustomRoles...)
+	perm := registry.Permission{
+		Name:        qualifyPermissionName(m.config.Slug, name),
+		Roles:       declared,
+		DefaultRole: opts.DefaultRole.Key,
+	}
+	if !opts.Label.IsZero() {
+		perm.Labels = opts.Label.Resolve()
+	}
+	if !opts.Description.IsZero() {
+		perm.Descriptions = opts.Description.Resolve()
+	}
+	m.registry.AddPermissionWithMeta(perm)
+}
+
+// RequirePermission returns chi middleware that gates a route on a permission
+// declared via RegisterPermission, looked up BY NAME. It reads the registered
+// permission's role set and enforces it (admin always passes). Call this at
+// route registration time (alongside m.Platform/Public/Internal), NOT from
+// inside a request handler.
+//
+//	import "github.com/mirrorstack-ai/app-module-sdk/roles"
+//	// in declare/: ms.RegisterPermission("users.view", ms.PermissionOpts{DefaultRole: roles.Viewer()})
+//	// in routes:
+//	r.With(mod.RequirePermission("users.view")).Get("/items", listItems)
+//
+// The name is slug-qualified the same way RegisterPermission qualifies it, so
+// the short name used here matches the short name used there.
+//
+// Safe-by-default: if the name was never RegisterPermission'd, it is registered
+// lazily as ADMIN-ONLY (an isDev warning is logged) so a forgotten declaration
+// locks the route down rather than opening it.
+func (m *Module) RequirePermission(name string) func(http.Handler) http.Handler {
+	qualified := qualifyPermissionName(m.config.Slug, name)
+	declared, ok := m.registry.PermissionRoles(qualified)
+	if !ok {
+		// Lazy admin-only registration: a route gated on an undeclared
+		// permission must NOT silently open. Warn in dev so the author
+		// notices the missing RegisterPermission.
+		if !runtime.IsLambda() {
+			m.logger.Printf("RequirePermission(%q): no RegisterPermission found — defaulting to admin-only. Declare it via ms.RegisterPermission.", name)
+		}
+		m.registry.AddPermissionWithMeta(registry.Permission{
+			Name:        qualified,
+			Roles:       []string{roles.Admin().Key},
+			DefaultRole: roles.Admin().Key,
+		})
+		declared = []string{roles.Admin().Key}
+	}
+	// Runtime: admin always passes, plus the declared roles.
+	return auth.RequireRoles(append([]string{roles.Admin().Key}, declared...)...)
 }
 
 // qualifyPermissionName prepends "<slug>." to name. No-op if name is
@@ -324,18 +411,23 @@ func qualifyPermissionName(slug, name string) string {
 	return prefix + name
 }
 
+// RegisterPermission declares a permission on the default Module created by
+// Init(). Calling this before Init() panics — match Platform/Public/Internal.
+func RegisterPermission(name string, opts PermissionOpts) {
+	mustDefault("RegisterPermission").RegisterPermission(name, opts)
+}
+
 // RequirePermission is the convenience wrapper that dispatches to the default
 // Module created by Init(). Calling this before Init() panics — match the
 // behavior of Platform/Public/Internal.
 //
-//	import p "github.com/mirrorstack-ai/app-module-sdk/roles"
-//
 //	ms.Init(...)
+//	ms.RegisterPermission("media.view", ms.PermissionOpts{DefaultRole: roles.Viewer()})
 //	ms.Platform(func(r chi.Router) {
-//	    r.With(ms.RequirePermission("media.view", p.Admin(), p.Viewer())).Get(...)
+//	    r.With(ms.RequirePermission("media.view")).Get(...)
 //	})
-func RequirePermission(name string, allowed ...roles.Role) func(http.Handler) http.Handler {
-	return mustDefault("RequirePermission").RequirePermission(name, allowed...)
+func RequirePermission(name string) func(http.Handler) http.Handler {
+	return mustDefault("RequirePermission").RequirePermission(name)
 }
 
 // Start auto-detects the runtime mode and starts serving:
@@ -549,7 +641,7 @@ func (m *Module) mountSystemRoutes() {
 			r.Use(httputil.MaxBytes(64 * 1024)) // 64 KB — lifecycle bodies are tiny
 			r.Use(m.internalAuth)
 			r.Get("/manifest", system.ManifestHandler(
-				m.config.ID, m.config.Slug, m.config.Name, m.config.Icon,
+				m.config.ID, m.config.Slug, m.config.Name, m.config.Icon, m.config.Tags,
 				m.config.SQL, m.config.Versions, m.registry, m.contribReg,
 			))
 			r.Route("/lifecycle", func(r chi.Router) {
@@ -672,6 +764,28 @@ func Contributions() []contributions.SlotInfo {
 		return nil
 	}
 	return defaultModule.contribReg.List()
+}
+
+// StoredContributions returns the contributions OTHER modules have registered
+// into one of THIS module's slots (slot key as declared via DefineContribute),
+// newest first. It reads the SDK-managed <moduleID>_contributions store — the
+// canonical registry the platform's install-time auto-register writes to. Each
+// entry's ID is the contributing module's id (the registration key), which a
+// host can use to address that module. Use this on the HOST side to consume
+// contributions (e.g. oauth-core listing its registered auth providers).
+func (m *Module) StoredContributions(ctx context.Context, slot string) ([]contributions.Contribution, error) {
+	q, release, err := DB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return m.contribStorage.List(ctx, q, slot)
+}
+
+// StoredContributions reads stored contributions for a slot on the default
+// module. Panics if Init has not been called. See Module.StoredContributions.
+func StoredContributions(ctx context.Context, slot string) ([]contributions.Contribution, error) {
+	return mustDefault("StoredContributions").StoredContributions(ctx, slot)
 }
 
 // localDevCORS echoes the request Origin (with credentials) and answers

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -460,7 +460,7 @@ func (m *Module) Start() error {
 
 	// Auto-create the contributions table when any slot is declared.
 	// CREATE TABLE IF NOT EXISTS is safe to call on every Start; the
-	// guard keeps modules that never use DefineContribute from
+	// guard keeps modules that never use Provide from
 	// touching their DB for an empty feature. Production schema
 	// management lands via the lifecycle install hook in a follow-up.
 	if m.contribReg.Len() > 0 {
@@ -620,7 +620,7 @@ func (m *Module) mountSystemRoutes() {
 		r.Options("/web/*", system.WebHandler(m.config.WebDir))
 
 		// Contribution slots — host modules declare with
-		// ms.DefineContribute and the SDK auto-mounts register /
+		// ms.Provide and the SDK auto-mounts register /
 		// unregister / list endpoints here. Internal scope because
 		// writes move trusted module-to-module; the read path is
 		// inside the same group for symmetry — host modules that want
@@ -719,14 +719,14 @@ func Internal(fn func(r chi.Router)) { mustDefault("Internal").Internal(fn) }
 // DefaultModule returns the default module for advanced use cases.
 func DefaultModule() *Module { return defaultModule }
 
-// DefineContributeSlot is the non-generic core. The exported
+// ProvideSlot is the non-generic core. The exported
 // generic wrapper lives in mirrorstack.go where T is in scope —
 // methods can't be generic in Go, so the type-aware closure is
 // built once at the call site and the Module just stores the
 // resulting Slot.
-func (m *Module) DefineContributeSlot(slot contributions.Slot) {
+func (m *Module) ProvideSlot(slot contributions.Slot) {
 	if err := m.contribReg.Define(slot); err != nil {
-		panic("mirrorstack: DefineContribute: " + err.Error())
+		panic("mirrorstack: Provide: " + err.Error())
 	}
 }
 
@@ -745,16 +745,16 @@ func NewContributionSlot[T any](key string) contributions.Slot {
 	})
 }
 
-// DefineContribute is the top-level entry point modules call from
-// main.go:
+// Provide is the top-level entry point modules call from
+// main.go to declare an extension slot others contribute to:
 //
-//	ms.DefineContribute[ProviderContribution]("providers")
+//	ms.Provide[ProviderContribution]("providers")
 //
 // Builds the type-aware Slot and stores it on the default module.
 // Panics on duplicate key or before ms.Init — matches the existing
 // RegisterUI / RequirePermission startup-error conventions.
-func DefineContribute[T any](key string) {
-	mustDefault("DefineContribute").DefineContributeSlot(NewContributionSlot[T](key))
+func Provide[T any](key string) {
+	mustDefault("Provide").ProvideSlot(NewContributionSlot[T](key))
 }
 
 // Contributions returns every contribution slot the default module
@@ -767,7 +767,7 @@ func Contributions() []contributions.SlotInfo {
 }
 
 // StoredContributions returns the contributions OTHER modules have registered
-// into one of THIS module's slots (slot key as declared via DefineContribute),
+// into one of THIS module's slots (slot key as declared via Provide),
 // newest first. It reads the SDK-managed <moduleID>_contributions store — the
 // canonical registry the platform's install-time auto-register writes to. Each
 // entry's ID is the contributing module's id (the registration key), which a

--- a/internal/core/module_test.go
+++ b/internal/core/module_test.go
@@ -321,8 +321,9 @@ func TestRequirePermission_AllowsMember(t *testing.T) {
 	t.Parallel() // safe now that permission state lives on the Module instance, not auth package globals
 
 	m, _ := New(Config{ID: "test", Name: "Test"})
+	m.RegisterPermission("media.view", PermissionOpts{DefaultRole: p.Viewer(), CustomRoles: []string{"member"}})
 	m.Platform(func(r chi.Router) {
-		r.With(m.RequirePermission("media.view", p.Admin(), p.Custom("member"), p.Viewer())).Get("/items", func(w http.ResponseWriter, r *http.Request) {
+		r.With(m.RequirePermission("media.view")).Get("/items", func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("ok"))
 		})
 	})
@@ -337,8 +338,9 @@ func TestRequirePermission_RejectsViewer(t *testing.T) {
 	t.Parallel()
 
 	m, _ := New(Config{ID: "test", Name: "Test"})
+	m.RegisterPermission("media.delete", PermissionOpts{DefaultRole: p.Admin()})
 	m.Platform(func(r chi.Router) {
-		r.With(m.RequirePermission("media.delete", p.Admin())).Delete("/items/{id}", func(w http.ResponseWriter, r *http.Request) {
+		r.With(m.RequirePermission("media.delete")).Delete("/items/{id}", func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte("deleted"))
 		})
 	})
@@ -358,12 +360,15 @@ func TestRequirePermission_AppearsInManifest(t *testing.T) {
 	m1, _ := New(Config{ID: "media", Name: "Media"})
 	m2, _ := New(Config{ID: "video", Name: "Video"})
 
+	m1.RegisterPermission("media.upload", PermissionOpts{DefaultRole: p.Admin(), CustomRoles: []string{"member"}})
+	m1.RegisterPermission("media.view", PermissionOpts{DefaultRole: p.Viewer(), CustomRoles: []string{"member"}})
 	m1.Platform(func(r chi.Router) {
-		r.With(m1.RequirePermission("media.upload", p.Admin(), p.Custom("member"))).Post("/upload", func(w http.ResponseWriter, r *http.Request) {})
-		r.With(m1.RequirePermission("media.view", p.Admin(), p.Custom("member"), p.Viewer())).Get("/items", func(w http.ResponseWriter, r *http.Request) {})
+		r.With(m1.RequirePermission("media.upload")).Post("/upload", func(w http.ResponseWriter, r *http.Request) {})
+		r.With(m1.RequirePermission("media.view")).Get("/items", func(w http.ResponseWriter, r *http.Request) {})
 	})
+	m2.RegisterPermission("video.transcode", PermissionOpts{DefaultRole: p.Admin()})
 	m2.Platform(func(r chi.Router) {
-		r.With(m2.RequirePermission("video.transcode", p.Admin())).Post("/transcode", func(w http.ResponseWriter, r *http.Request) {})
+		r.With(m2.RequirePermission("video.transcode")).Post("/transcode", func(w http.ResponseWriter, r *http.Request) {})
 	})
 
 	rec := doRequestWithSecret(t, m1.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
@@ -412,8 +417,9 @@ func TestRequirePermission_AutoPrefix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("MS_INTERNAL_SECRET", "secret")
 			m, _ := New(Config{ID: "test", Slug: tc.slug, Name: "Test"})
+			m.RegisterPermission(tc.permission, PermissionOpts{DefaultRole: p.Admin()})
 			m.Platform(func(r chi.Router) {
-				r.With(m.RequirePermission(tc.permission, p.Admin())).Get("/x", func(w http.ResponseWriter, r *http.Request) {})
+				r.With(m.RequirePermission(tc.permission)).Get("/x", func(w http.ResponseWriter, r *http.Request) {})
 			})
 
 			got := fetchManifest(t, m)
@@ -828,7 +834,8 @@ func TestScopesPanic_BeforeInit(t *testing.T) {
 		"Platform":          func() { Platform(func(r chi.Router) {}) },
 		"Public":            func() { Public(func(r chi.Router) {}) },
 		"Internal":          func() { Internal(func(r chi.Router) {}) },
-		"RequirePermission": func() { RequirePermission("media.view", p.Admin()) },
+		"RegisterPermission": func() { RegisterPermission("media.view", PermissionOpts{DefaultRole: p.Admin()}) },
+		"RequirePermission":  func() { RequirePermission("media.view") },
 		"OnEvent":           func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) },
 		"Emits":             func() { Emits("created") },
 		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -66,9 +66,21 @@ type Task struct {
 
 // Permission is a declared module permission. Exposed in the manifest so the
 // platform can surface "what does this module need" on its install screen.
+//
+// DefaultRole is the role key the permission lands on by default (e.g.
+// "viewer"); admin is always implicit and never stored. It is informational
+// metadata for the platform UI — the enforced role set is Roles.
+//
+// Labels and Descriptions are per-locale display strings (locale → text),
+// resolved at registration from the module's i18n catalogs. Both are
+// omitempty: a module that declares no Label/Description ships neither key,
+// and the platform falls back to the raw permission name.
 type Permission struct {
-	Name  string   `json:"name"`
-	Roles []string `json:"roles"`
+	Name         string            `json:"name"`
+	Roles        []string          `json:"roles"`
+	DefaultRole  string            `json:"defaultRole,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	Descriptions map[string]string `json:"descriptions,omitempty"`
 }
 
 // Dependency is a declared dependency on another module. Optional=true
@@ -93,6 +105,20 @@ type Dependency struct {
 	Optional bool     `json:"optional,omitempty"`
 	Tables   []string `json:"tables,omitempty"`
 	Events   []string `json:"events,omitempty"`
+}
+
+// OutboundContribution declares that this module pushes a payload INTO another
+// module's contribution slot — the contributor side of DefineContribute. Like
+// Dependency it is pure manifest metadata: the module's binary never makes the
+// call. The platform catalog (or the CLI dev runner) reads it at install /
+// tunnel-up, validates Host+Slot against the host's definedContributions, and —
+// after app-owner approval — performs the registration on the contributor's
+// behalf. The contributor declares WHAT and WHERE; it never holds the host's
+// address or credentials.
+type OutboundContribution struct {
+	Host    string          `json:"host"`    // host module spec/id, e.g. "oauth-core"
+	Slot    string          `json:"slot"`    // slot key on the host, e.g. "auth-provider"
+	Payload json.RawMessage `json:"payload"` // typed payload, validated by the host's slot at registration
 }
 
 // MCPToolHandler is the type-erased handler signature used after generic
@@ -124,18 +150,19 @@ type MCPResourceDecl struct {
 // Registry is the per-module registry of routes/events/schedules/tasks/permissions.
 // All operations are safe for concurrent use.
 type Registry struct {
-	mu           sync.RWMutex
-	routes       map[Scope][]Route
-	emits        []string
-	subscribes   map[string]string // event name → internal path
-	schedules    []Schedule
-	tasks        []Task
-	permissions  []Permission
-	description  string
-	dependencies []Dependency
-	mcpTools     []MCPToolDecl
-	mcpResources []MCPResourceDecl
-	ui           *ModuleUI
+	mu                    sync.RWMutex
+	routes                map[Scope][]Route
+	emits                 []string
+	subscribes            map[string]string // event name → internal path
+	schedules             []Schedule
+	tasks                 []Task
+	permissions           []Permission
+	description           string
+	dependencies          []Dependency
+	outboundContributions []OutboundContribution
+	mcpTools              []MCPToolDecl
+	mcpResources          []MCPResourceDecl
+	ui                    *ModuleUI
 }
 
 func New() *Registry {
@@ -197,6 +224,39 @@ func (r *Registry) AddDependency(dep Dependency) bool {
 	dep.Events = slices.Clone(dep.Events)
 	r.dependencies = append(r.dependencies, dep)
 	return true
+}
+
+// AddOutboundContribution records (or replaces) an outbound contribution keyed
+// by (Host, Slot). Re-declaring the same Host+Slot overwrites the payload —
+// last declaration wins — so a module contributes at most once per host slot.
+func (r *Registry) AddOutboundContribution(c OutboundContribution) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, existing := range r.outboundContributions {
+		if existing.Host == c.Host && existing.Slot == c.Slot {
+			r.outboundContributions[i].Payload = slices.Clone(c.Payload)
+			return
+		}
+	}
+	c.Payload = slices.Clone(c.Payload)
+	r.outboundContributions = append(r.outboundContributions, c)
+}
+
+// OutboundContributions returns a non-nil deep copy of all declared outbound
+// contributions in registration order. Payloads are cloned so callers can't
+// mutate the registry through the returned slice.
+func (r *Registry) OutboundContributions() []OutboundContribution {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]OutboundContribution, len(r.outboundContributions))
+	for i, c := range r.outboundContributions {
+		out[i] = OutboundContribution{
+			Host:    c.Host,
+			Slot:    c.Slot,
+			Payload: slices.Clone(c.Payload),
+		}
+	}
+	return out
 }
 
 // mergeStrings returns the set union of two string slices, preserving the
@@ -389,18 +449,47 @@ func (r *Registry) Tasks() []Task {
 // downstream consumers (DB columns, log parsers) from receiving malformed
 // strings via the manifest.
 func (r *Registry) AddPermission(name string, roles []string) {
-	ValidateName("RequirePermission", name)
+	r.AddPermissionWithMeta(Permission{Name: name, Roles: roles})
+}
+
+// AddPermissionWithMeta records a declared permission carrying optional
+// metadata (DefaultRole, Labels, Descriptions). Same first-wins-by-name dedup,
+// validation, and clone-on-store semantics as AddPermission — the simple
+// AddPermission is just this with empty metadata. The Roles, Labels, and
+// Descriptions are cloned so caller mutations after the call cannot leak into
+// the stored copy.
+func (r *Registry) AddPermissionWithMeta(p Permission) {
+	ValidateName("RequirePermission", p.Name)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, existing := range r.permissions {
-		if existing.Name == name {
+		if existing.Name == p.Name {
 			return
 		}
 	}
 	r.permissions = append(r.permissions, Permission{
-		Name:  name,
-		Roles: slices.Clone(roles),
+		Name:         p.Name,
+		Roles:        slices.Clone(p.Roles),
+		DefaultRole:  p.DefaultRole,
+		Labels:       maps.Clone(p.Labels),
+		Descriptions: maps.Clone(p.Descriptions),
 	})
+}
+
+// PermissionRoles returns the enforced role set for a registered permission by
+// its (already-qualified) name, and whether such a permission was registered.
+// The returned slice is a clone so callers can't mutate the stored copy. Used
+// by Module.RequirePermission to look up the roles declared via
+// RegisterPermission.
+func (r *Registry) PermissionRoles(name string) ([]string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.permissions {
+		if p.Name == name {
+			return slices.Clone(p.Roles), true
+		}
+	}
+	return nil, false
 }
 
 // Permissions returns a non-nil deep copy of all declared permissions. The
@@ -417,7 +506,13 @@ func (r *Registry) Permissions() []Permission {
 	}
 	out := make([]Permission, len(r.permissions))
 	for i, p := range r.permissions {
-		out[i] = Permission{Name: p.Name, Roles: slices.Clone(p.Roles)}
+		out[i] = Permission{
+			Name:         p.Name,
+			Roles:        slices.Clone(p.Roles),
+			DefaultRole:  p.DefaultRole,
+			Labels:       maps.Clone(p.Labels),
+			Descriptions: maps.Clone(p.Descriptions),
+		}
 	}
 	return out
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -108,10 +108,10 @@ type Dependency struct {
 }
 
 // OutboundContribution declares that this module pushes a payload INTO another
-// module's contribution slot — the contributor side of DefineContribute. Like
+// module's contribution slot — the contributor side of Provide. Like
 // Dependency it is pure manifest metadata: the module's binary never makes the
 // call. The platform catalog (or the CLI dev runner) reads it at install /
-// tunnel-up, validates Host+Slot against the host's definedContributions, and —
+// tunnel-up, validates Host+Slot against the host's provides, and —
 // after app-owner approval — performs the registration on the contributor's
 // behalf. The contributor declares WHAT and WHERE; it never holds the host's
 // address or credentials.

--- a/internal/registry/ui.go
+++ b/internal/registry/ui.go
@@ -84,6 +84,7 @@ type UIPage struct {
 	Surface     string `json:"surface,omitempty"`
 	Title       string `json:"title"`
 	Description string `json:"description,omitempty"`
+	Icon        string `json:"icon,omitempty"`
 	Export      string `json:"export"`
 }
 

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -172,7 +172,7 @@ func OptionalDependOn(spec string, configure ...func(*Need)) OnEventOption {
 func Resolve[T any](id string) (T, bool) { return core.Resolve[T](id) }
 
 // ContributesTo declares that this module pushes payload into host module's
-// slot — the contributor side of DefineContribute. Zero-runtime: it becomes
+// slot — the contributor side of Provide. Zero-runtime: it becomes
 // manifest metadata and the platform (CLI in dev) performs the registration
 // after app-owner approval. Pair with ms.DependsOn(host). See core.ContributesTo.
 func ContributesTo(host, slot string, payload any) { core.ContributesTo(host, slot, payload) }
@@ -259,8 +259,8 @@ func RunTask(ctx context.Context, name string, payload json.RawMessage) (string,
 // ContributionSlot is the manifest projection of a declared slot.
 type ContributionSlot = contributions.SlotInfo
 
-// DefineContribute declares a contribution slot on the default
-// module. The type parameter T fixes the payload shape — incoming
+// Provide declares an extension slot others contribute to on the
+// default module. The type parameter T fixes the payload shape — incoming
 // register requests must unmarshal cleanly into T. The SDK
 // auto-mounts:
 //
@@ -283,9 +283,9 @@ type ContributionSlot = contributions.SlotInfo
 //	    CallbackPath string `json:"callback_path"`
 //	}
 //
-//	ms.DefineContribute[ProviderContribution]("providers")
-func DefineContribute[T any](key string) {
-	core.DefineContribute[T](key)
+//	ms.Provide[ProviderContribution]("providers")
+func Provide[T any](key string) {
+	core.Provide[T](key)
 }
 
 // Contributions returns every contribution slot declared on the
@@ -298,7 +298,7 @@ func Contributions() []ContributionSlot { return core.Contributions() }
 type Contribution = contributions.Contribution
 
 // StoredContributions returns the contributions other modules have registered
-// into this module's slot (the host-read side of DefineContribute), newest
+// into this module's slot (the host-read side of Provide), newest
 // first. The platform's install-time auto-register writes here; a host consumes
 // them at runtime (e.g. oauth-core listing registered auth providers). See
 // core.StoredContributions.

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -9,6 +9,7 @@ package mirrorstack
 import (
 	"context"
 	"encoding/json"
+	"io/fs"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -18,7 +19,6 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/internal/contributions"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/core"
 	"github.com/mirrorstack-ai/app-module-sdk/meter"
-	"github.com/mirrorstack-ai/app-module-sdk/roles"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 )
 
@@ -64,10 +64,54 @@ func Public(fn func(r chi.Router)) { core.Public(fn) }
 // Internal registers internal-scoped routes on the default module.
 func Internal(fn func(r chi.Router)) { core.Internal(fn) }
 
-// RequirePermission returns Chi middleware that enforces the given roles and
-// registers the permission on the manifest.
-func RequirePermission(name string, allowed ...roles.Role) func(http.Handler) http.Handler {
-	return core.RequirePermission(name, allowed...)
+// PermissionOpts configures a permission declared via RegisterPermission:
+// its default role, extra custom roles, and optional i18n Label/Description.
+type PermissionOpts = core.PermissionOpts
+
+// Label is a deferred-resolution display string built from Text (literal) or
+// T (i18n catalog key). Pass it as PermissionOpts.Label / .Description.
+type Label = core.Label
+
+// Text returns a literal Label resolving to the default locale.
+func Text(s string) Label { return core.Text(s) }
+
+// T returns a catalog-key Label, resolved per loaded locale at manifest build
+// from catalogs loaded via RegisterMessages.
+func T(key string) Label { return core.T(key) }
+
+// RegisterMessages loads the module's i18n catalogs from fsys/dir (one
+// <locale>.json per file, nested JSON flattened to dotted keys). Call once at
+// startup, typically with a //go:embed of i18n/*.json. These catalogs back the
+// Labels resolved by RegisterPermission and surfaced in the manifest.
+//
+//	//go:embed i18n/*.json
+//	var i18nFS embed.FS
+//	ms.RegisterMessages(i18nFS, "i18n")
+func RegisterMessages(fsys fs.FS, dir string) error { return core.RegisterMessages(fsys, dir) }
+
+// RegisterPermission declares a module permission ONCE — its default role,
+// custom roles, and resolved i18n Labels/Descriptions — recording it in the
+// manifest. Call at startup (typically a declare/ package) BEFORE the routes
+// that gate on it. First-wins by name. Names are slug-qualified automatically.
+//
+//	import "github.com/mirrorstack-ai/app-module-sdk/roles"
+//	ms.RegisterPermission("users.read", ms.PermissionOpts{
+//	    DefaultRole: roles.Viewer(),
+//	    Label:       ms.T("permissions.users.read"),
+//	})
+func RegisterPermission(name string, opts PermissionOpts) {
+	core.RegisterPermission(name, opts)
+}
+
+// RequirePermission returns Chi middleware gating a route on a permission
+// previously declared via RegisterPermission, looked up by NAME:
+//
+//	ms.RequirePermission("users.read")
+//
+// Admin always passes. If the name was never RegisterPermission'd it is
+// registered lazily as admin-only (safe-by-default) with a dev warning.
+func RequirePermission(name string) func(http.Handler) http.Handler {
+	return core.RequirePermission(name)
 }
 
 // --- Data ---
@@ -126,6 +170,12 @@ func OptionalDependOn(spec string, configure ...func(*Need)) OnEventOption {
 // Resolve looks up a typed client registered by another module. v1 stub
 // always returns (zero, false).
 func Resolve[T any](id string) (T, bool) { return core.Resolve[T](id) }
+
+// ContributesTo declares that this module pushes payload into host module's
+// slot — the contributor side of DefineContribute. Zero-runtime: it becomes
+// manifest metadata and the platform (CLI in dev) performs the registration
+// after app-owner approval. Pair with ms.DependsOn(host). See core.ContributesTo.
+func ContributesTo(host, slot string, payload any) { core.ContributesTo(host, slot, payload) }
 
 // --- UI surface ---
 
@@ -242,3 +292,16 @@ func DefineContribute[T any](key string) {
 // default module. Useful for tests and for hosts that want to expose
 // a /platform/* read endpoint listing what they accept.
 func Contributions() []ContributionSlot { return core.Contributions() }
+
+// Contribution is a stored contribution row: ID is the contributing module's
+// id (the registration key), Payload is its JSON contribution.
+type Contribution = contributions.Contribution
+
+// StoredContributions returns the contributions other modules have registered
+// into this module's slot (the host-read side of DefineContribute), newest
+// first. The platform's install-time auto-register writes here; a host consumes
+// them at runtime (e.g. oauth-core listing registered auth providers). See
+// core.StoredContributions.
+func StoredContributions(ctx context.Context, slot string) ([]Contribution, error) {
+	return core.StoredContributions(ctx, slot)
+}

--- a/roles/roles.go
+++ b/roles/roles.go
@@ -5,10 +5,16 @@
 // the call-site API. The canonical roles are Admin and Viewer; Custom
 // accepts any string for module-specific roles.
 //
+// ms.RegisterPermission takes a DEFAULT role (Admin is always implicit, so it's
+// only passed to mean "admin-only") plus optional custom role keys; routes then
+// gate on the declared permission by name via ms.RequirePermission:
+//
 //	import p "github.com/mirrorstack-ai/app-module-sdk/roles"
 //
-//	ms.RequirePermission("media.view", p.Admin(), p.Viewer())
-//	ms.RequirePermission("media.moderate", p.Custom("moderator"))
+//	ms.RegisterPermission("media.view", ms.PermissionOpts{DefaultRole: p.Viewer()})              // admin implicit; viewer default
+//	ms.RegisterPermission("media.delete", ms.PermissionOpts{DefaultRole: p.Admin()})             // admin-only
+//	ms.RegisterPermission("media.moderate", ms.PermissionOpts{DefaultRole: p.Viewer(), CustomRoles: []string{"moderator"}})
+//	r.With(ms.RequirePermission("media.view")).Get(...)
 package roles
 
 // Role is a typed wrapper around a role key. Equality comparisons use Key.

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/mirrorstack-ai/app-module-sdk/i18n"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/contributions"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
@@ -40,6 +41,12 @@ type ManifestPayload struct {
 	// what other modules can plug into. Always present; empty array
 	// when no slots are declared.
 	DefinedContributions []contributions.SlotInfo `json:"definedContributions"`
+	// ContributesTo lists the host slots this module pushes INTO
+	// (ms.ContributesTo) — the contributor side. The catalog (CLI in dev)
+	// validates each against the host's definedContributions and performs
+	// the registration after app-owner approval. Always present; empty
+	// array when the module contributes nothing.
+	ContributesTo []registry.OutboundContribution `json:"contributesTo"`
 }
 
 // ManifestMCP declares the MCP tool and resource surface of the module. The
@@ -63,11 +70,17 @@ type MigrationVersions struct {
 	Module string `json:"module,omitempty"`
 }
 
-// ManifestDefaults is the default display name and icon. The platform may
-// override these per-app installation.
+// ManifestDefaults is the default display name, icon, and tags. The platform
+// may override name/icon per-app installation; tags are module-level badges.
+//
+// NameLabels carries per-locale display names (resolved from the module's
+// i18n catalog key "module.name"); empty when the module declared none, in
+// which case the platform falls back to Name.
 type ManifestDefaults struct {
-	Name string `json:"name"`
-	Icon string `json:"icon"`
+	Name       string            `json:"name"`
+	Icon       string            `json:"icon"`
+	Tags       []string          `json:"tags,omitempty"`
+	NameLabels map[string]string `json:"nameLabels,omitempty"`
 }
 
 // ManifestEvents declares which events the module emits and which it subscribes to.
@@ -99,7 +112,7 @@ func buildManifestMCP(reg *registry.Registry) ManifestMCP {
 //
 // contribReg is the module's contribution-slot registry. Pass nil to omit
 // declared contributions from the manifest entirely (e.g. tests).
-func ManifestHandler(id, slug, name, icon string, sqlFS fs.FS, versions map[string]MigrationVersions, reg *registry.Registry, contribReg *contributions.Registry) http.HandlerFunc {
+func ManifestHandler(id, slug, name, icon string, tags []string, sqlFS fs.FS, versions map[string]MigrationVersions, reg *registry.Registry, contribReg *contributions.Registry) http.HandlerFunc {
 	if versions == nil {
 		versions = map[string]MigrationVersions{}
 	}
@@ -129,7 +142,7 @@ func ManifestHandler(id, slug, name, icon string, sqlFS fs.FS, versions map[stri
 		httputil.JSON(w, http.StatusOK, ManifestPayload{
 			ID:                   id,
 			Slug:                 slug,
-			Defaults:             ManifestDefaults{Name: name, Icon: icon},
+			Defaults:             ManifestDefaults{Name: name, Icon: icon, Tags: tags, NameLabels: i18n.Lookup("module.name")},
 			Description:          reg.Description(),
 			Dependencies:         reg.Dependencies(),
 			Migration:            MigrationVersions{App: appVersion, Module: moduleVersion},
@@ -142,6 +155,7 @@ func ManifestHandler(id, slug, name, icon string, sqlFS fs.FS, versions map[stri
 			MCP:                  buildManifestMCP(reg),
 			UI:                   reg.UI(),
 			DefinedContributions: contribSlots,
+			ContributesTo:        reg.OutboundContributions(),
 		})
 	}
 }

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -36,14 +36,14 @@ type ManifestPayload struct {
 	// UI is the module's declared UI surface (RegisterUI). Nil/absent when
 	// the module ships no UI — callers must nil-check before reading.
 	UI *registry.ModuleUI `json:"ui,omitempty"`
-	// DefinedContributions lists the contribution slots this module
-	// accepts (ms.DefineContribute). The catalog reads this to know
+	// Provides lists the extension slots this module declares for
+	// others to contribute to (ms.Provide). The catalog reads this to know
 	// what other modules can plug into. Always present; empty array
 	// when no slots are declared.
-	DefinedContributions []contributions.SlotInfo `json:"definedContributions"`
+	Provides []contributions.SlotInfo `json:"provides"`
 	// ContributesTo lists the host slots this module pushes INTO
 	// (ms.ContributesTo) — the contributor side. The catalog (CLI in dev)
-	// validates each against the host's definedContributions and performs
+	// validates each against the host's provides and performs
 	// the registration after app-owner approval. Always present; empty
 	// array when the module contributes nothing.
 	ContributesTo []registry.OutboundContribution `json:"contributesTo"`
@@ -140,22 +140,22 @@ func ManifestHandler(id, slug, name, icon string, tags []string, sqlFS fs.FS, ve
 		}
 
 		httputil.JSON(w, http.StatusOK, ManifestPayload{
-			ID:                   id,
-			Slug:                 slug,
-			Defaults:             ManifestDefaults{Name: name, Icon: icon, Tags: tags, NameLabels: i18n.Lookup("module.name")},
-			Description:          reg.Description(),
-			Dependencies:         reg.Dependencies(),
-			Migration:            MigrationVersions{App: appVersion, Module: moduleVersion},
-			Versions:             versions,
-			Routes:               reg.Routes(),
-			Events:               ManifestEvents{Emits: reg.Emits(), Subscribes: reg.Subscribes()},
-			Schedules:            reg.Schedules(),
-			Tasks:                reg.Tasks(),
-			Permissions:          reg.Permissions(),
-			MCP:                  buildManifestMCP(reg),
-			UI:                   reg.UI(),
-			DefinedContributions: contribSlots,
-			ContributesTo:        reg.OutboundContributions(),
+			ID:            id,
+			Slug:          slug,
+			Defaults:      ManifestDefaults{Name: name, Icon: icon, Tags: tags, NameLabels: i18n.Lookup("module.name")},
+			Description:   reg.Description(),
+			Dependencies:  reg.Dependencies(),
+			Migration:     MigrationVersions{App: appVersion, Module: moduleVersion},
+			Versions:      versions,
+			Routes:        reg.Routes(),
+			Events:        ManifestEvents{Emits: reg.Emits(), Subscribes: reg.Subscribes()},
+			Schedules:     reg.Schedules(),
+			Tasks:         reg.Tasks(),
+			Permissions:   reg.Permissions(),
+			MCP:           buildManifestMCP(reg),
+			UI:            reg.UI(),
+			Provides:      contribSlots,
+			ContributesTo: reg.OutboundContributions(),
 		})
 	}
 }

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -29,7 +29,7 @@ func decodeManifest(t *testing.T, h http.HandlerFunc) ManifestPayload {
 func TestManifest_IDAndDefaults(t *testing.T) {
 	t.Parallel()
 
-	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, registry.New(), nil))
+	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil))
 
 	if got.ID != "media" {
 		t.Errorf("id = %q, want media", got.ID)
@@ -44,7 +44,7 @@ func TestManifest_IDAndDefaults(t *testing.T) {
 
 func TestManifest_SlugSurfaced(t *testing.T) {
 	t.Parallel()
-	got := decodeManifest(t, ManifestHandler("m15c0f543cf164433b524d312dbf68159", "oauth", "Google Sign-In", "vpn_key", nil, nil, registry.New(), nil))
+	got := decodeManifest(t, ManifestHandler("m15c0f543cf164433b524d312dbf68159", "oauth", "Google Sign-In", "vpn_key", nil, nil, nil, registry.New(), nil))
 	if got.Slug != "oauth" {
 		t.Errorf("slug = %q, want oauth", got.Slug)
 	}
@@ -54,7 +54,7 @@ func TestManifest_SlugOmittedWhenEmpty(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("media", "", "Media", "perm_media", nil, nil, registry.New(), nil).ServeHTTP(rec, req)
+	ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil).ServeHTTP(rec, req)
 	if strings.Contains(rec.Body.String(), `"slug"`) {
 		t.Errorf("expected \"slug\" key to be omitted when empty, got: %s", rec.Body.String())
 	}
@@ -69,7 +69,7 @@ func TestManifest_RoutesFromAllScopes(t *testing.T) {
 	reg.AddRoute(registry.ScopePublic, "GET", "/items")
 	reg.AddRoute(registry.ScopeInternal, "POST", "/events/on-user-deleted")
 
-	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, reg, nil))
+	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, reg, nil))
 
 	if len(got.Routes[registry.ScopePlatform]) != 2 {
 		t.Errorf("platform routes = %d, want 2", len(got.Routes[registry.ScopePlatform]))
@@ -85,7 +85,7 @@ func TestManifest_RoutesFromAllScopes(t *testing.T) {
 func TestManifest_EmptyScopesPresent(t *testing.T) {
 	t.Parallel()
 
-	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, registry.New(), nil))
+	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil))
 
 	for _, scope := range registry.AllScopes() {
 		s, ok := got.Routes[scope]
@@ -106,7 +106,7 @@ func TestManifest_EventsAndSchedules(t *testing.T) {
 	reg.AddSubscribe("oauth.user_deleted", "/internal/events/on-user-deleted")
 	reg.AddSchedule("cleanup-temp", "0 3 * * *", "/crons/cleanup-temp")
 
-	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, reg, nil))
+	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, reg, nil))
 
 	if len(got.Events.Emits) != 1 || got.Events.Emits[0] != "created" {
 		t.Errorf("events.emits = %v, want [created]", got.Events.Emits)
@@ -125,7 +125,7 @@ func TestManifest_EmptyEventsAndSchedules_NotNull(t *testing.T) {
 	// Verify the JSON has [] / {} not null when nothing is declared.
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("media", "", "Media", "perm_media", nil, nil, registry.New(), nil).ServeHTTP(rec, req)
+	ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil).ServeHTTP(rec, req)
 
 	body := rec.Body.String()
 	// Note: "module" is omitempty on MigrationVersions and VersionEntry, so
@@ -167,7 +167,7 @@ func TestManifest_MigrationVersions(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", tc.fsys, nil, registry.New(), nil))
+			got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, tc.fsys, nil, registry.New(), nil))
 			if got.Migration != tc.want {
 				t.Errorf("migration = %+v, want %+v", got.Migration, tc.want)
 			}
@@ -178,7 +178,7 @@ func TestManifest_MigrationVersions(t *testing.T) {
 func TestManifest_NilSQL_EmptyMigration(t *testing.T) {
 	t.Parallel()
 
-	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, registry.New(), nil))
+	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil))
 	if got.Migration.App != "" || got.Migration.Module != "" {
 		t.Errorf("migration = %+v, want both empty when SQL fs is nil", got.Migration)
 	}
@@ -197,7 +197,7 @@ func TestManifest_Versions(t *testing.T) {
 		"v0.1.0": {App: "0008", Module: "0002"},
 		"v0.2.0": {App: "0012"},
 	}
-	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, versions, registry.New(), nil))
+	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, versions, registry.New(), nil))
 
 	if len(got.Versions) != 2 {
 		t.Fatalf("versions = %v, want 2 entries", got.Versions)
@@ -222,7 +222,7 @@ func TestManifest_Permissions(t *testing.T) {
 	reg.AddPermission("media.upload", []string{"admin", "member"})
 	reg.AddPermission("media.view", []string{"admin"}) // duplicate name → dropped
 
-	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, reg, nil))
+	got := decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, reg, nil))
 
 	if len(got.Permissions) != 2 {
 		t.Fatalf("permissions = %d, want 2: %+v", len(got.Permissions), got.Permissions)
@@ -249,7 +249,7 @@ func TestManifest_DescriptionPopulated(t *testing.T) {
 	reg := registry.New()
 	reg.SetDescription("A demo module")
 
-	got := decodeManifest(t, ManifestHandler("demo", "", "Demo", "box", nil, nil, reg, nil))
+	got := decodeManifest(t, ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, reg, nil))
 	if got.Description != "A demo module" {
 		t.Errorf("description = %q, want %q", got.Description, "A demo module")
 	}
@@ -260,7 +260,7 @@ func TestManifest_DescriptionOmittedWhenEmpty(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("demo", "", "Demo", "box", nil, nil, registry.New(), nil).ServeHTTP(rec, req)
+	ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, registry.New(), nil).ServeHTTP(rec, req)
 
 	if strings.Contains(rec.Body.String(), `"description"`) {
 		t.Errorf("expected \"description\" key to be omitted when empty, got: %s", rec.Body.String())
@@ -274,7 +274,7 @@ func TestManifest_DependenciesPopulated(t *testing.T) {
 	reg.AddDependency(registry.Dependency{ID: "oauth-core"})
 	reg.AddDependency(registry.Dependency{ID: "video", Optional: true})
 
-	got := decodeManifest(t, ManifestHandler("demo", "", "Demo", "box", nil, nil, reg, nil))
+	got := decodeManifest(t, ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, reg, nil))
 	if len(got.Dependencies) != 2 {
 		t.Fatalf("len(dependencies) = %d, want 2", len(got.Dependencies))
 	}
@@ -291,7 +291,7 @@ func TestManifest_EmptyDependenciesIsArrayNotNull(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("demo", "", "Demo", "box", nil, nil, registry.New(), nil).ServeHTTP(rec, req)
+	ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, registry.New(), nil).ServeHTTP(rec, req)
 
 	body := rec.Body.String()
 	if !strings.Contains(body, `"dependencies":[]`) {
@@ -307,7 +307,7 @@ func TestManifest_OptionalOmittedInJSONWhenFalse(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("demo", "", "Demo", "box", nil, nil, reg, nil).ServeHTTP(rec, req)
+	ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, reg, nil).ServeHTTP(rec, req)
 
 	body := rec.Body.String()
 	// Required dep should not carry "optional":false in wire shape.
@@ -332,7 +332,7 @@ func TestManifest_UIPopulatedWhenRegistered(t *testing.T) {
 		},
 	})
 
-	got := decodeManifest(t, ManifestHandler("demo", "", "Demo", "box", nil, nil, reg, nil))
+	got := decodeManifest(t, ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, reg, nil))
 	if got.UI == nil {
 		t.Fatal("manifest.ui is nil; expected populated UI")
 	}
@@ -349,7 +349,7 @@ func TestManifest_UIOmittedWhenNotRegistered(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("demo", "", "Demo", "box", nil, nil, registry.New(), nil).ServeHTTP(rec, req)
+	ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, registry.New(), nil).ServeHTTP(rec, req)
 
 	if strings.Contains(rec.Body.String(), `"ui"`) {
 		t.Errorf("expected \"ui\" key omitted when no RegisterUI was called, got: %s", rec.Body.String())

--- a/system/mcp_test.go
+++ b/system/mcp_test.go
@@ -254,7 +254,7 @@ func TestManifest_IncludesMCP(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("demo", "", "Demo", "box", nil, nil, reg, nil).ServeHTTP(rec, req)
+	ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, reg, nil).ServeHTTP(rec, req)
 
 	var got ManifestPayload
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
@@ -278,7 +278,7 @@ func TestManifest_EmptyMCPIsEmptyArrays(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/__mirrorstack/platform/manifest", nil)
 	rec := httptest.NewRecorder()
-	ManifestHandler("demo", "", "Demo", "box", nil, nil, registry.New(), nil).ServeHTTP(rec, req)
+	ManifestHandler("demo", "", "Demo", "box", nil, nil, nil, registry.New(), nil).ServeHTTP(rec, req)
 
 	body := rec.Body.String()
 	if !strings.Contains(body, `"mcp":{"tools":[],"resources":[]}`) {


### PR DESCRIPTION
SDK↔frontend vocabulary parity: the host-slot API `DefineContribute[T]` → **`Provide[T]`** (and `DefineContributeSlot`→`ProvideSlot`), and the manifest field `definedContributions` → **`provides`** (the FE already calls exposed slots "provides"). `ContributesTo` / `StoredContributions` / the `contributesTo` field are unchanged.

Pure mechanical rename — no logic change; `go build ./...` + `go vet` green; adversarial-reviewed.

**Coordination note:** this is a breaking SDK API change. Module repos that call `ms.DefineContribute` (ms-app-modules: oauth-core etc.) must move to `ms.Provide` and require this SDK version — those module PRs follow once this is tagged/published. (Includes one prior `feat/platform-token` SDK commit in the diff — its base isn't on main yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)