### PR TITLE
feat(sdk)!: Description on ms.Config; remove ms.Describe

### DIFF
--- a/examples/template/main.go
+++ b/examples/template/main.go
@@ -2,7 +2,7 @@
 // files which register themselves via postInitHooks — main.go never changes
 // when the CLI adds or removes features.
 //
-// Replace the placeholders in Config + Describe and delete any sibling file
+// Replace the placeholders in Config and delete any sibling file
 // for a feature you don't need.
 package main
 
@@ -27,18 +27,17 @@ var postInitHooks []func()
 
 func main() {
 	if err := ms.Init(ms.Config{
-		ID:   "template",
-		Name: "Template",
-		Icon: "extension",
-		SQL:  sqlFS,
+		ID:          "template",
+		Name:        "Template",
+		Icon:        "extension",
+		Description: "A MirrorStack module template. Replace this description with your module's purpose.",
+		SQL:         sqlFS,
 		Versions: map[string]system.MigrationVersions{
 			"v0.1.0": {App: "0001"},
 		},
 	}); err != nil {
 		log.Fatalf("mirrorstack: init failed: %v", err)
 	}
-
-	ms.Describe("A MirrorStack module template. Replace this description with your module's purpose.")
 
 	// Required deps go here — these become install-time preconditions.
 	// Auto-detected as required because they're called literally inside main().

--- a/internal/core/describe.go
+++ b/internal/core/describe.go
@@ -14,6 +14,8 @@ import (
 // sentences is typical. Last call wins.
 //
 //	ms.Describe("Google OAuth provider: authorize, callback, session issue.")
+//
+// Deprecated: set Description on ms.Config passed to ms.Init() instead.
 func (m *Module) Describe(s string) {
 	m.registry.SetDescription(s)
 }
@@ -120,6 +122,8 @@ func parseDepSpec(spec string) (id, constraint string) {
 // Package-level convenience wrappers — dispatch to defaultModule.
 
 // Describe sets the default module's description. Panics if Init has not been called.
+//
+// Deprecated: set Description on ms.Config passed to ms.Init() instead.
 func Describe(s string) { mustDefault("Describe").Describe(s) }
 
 // DependsOn declares a required dependency on the default module. Panics

--- a/internal/core/describe.go
+++ b/internal/core/describe.go
@@ -9,17 +9,6 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 )
 
-// Describe sets the module's human-readable description. Used by the
-// catalog for agent discovery ("find a module that does X"). One to three
-// sentences is typical. Last call wins.
-//
-//	ms.Describe("Google OAuth provider: authorize, callback, session issue.")
-//
-// Deprecated: set Description on ms.Config passed to ms.Init() instead.
-func (m *Module) Describe(s string) {
-	m.registry.SetDescription(s)
-}
-
 // DependsOn declares a REQUIRED dependency on another module. Install
 // fails if no published version of the dep matches the constraint.
 //
@@ -120,11 +109,6 @@ func parseDepSpec(spec string) (id, constraint string) {
 }
 
 // Package-level convenience wrappers — dispatch to defaultModule.
-
-// Describe sets the default module's description. Panics if Init has not been called.
-//
-// Deprecated: set Description on ms.Config passed to ms.Init() instead.
-func Describe(s string) { mustDefault("Describe").Describe(s) }
 
 // DependsOn declares a required dependency on the default module. Panics
 // if Init has not been called. See Module.DependsOn for spec syntax and

--- a/internal/core/describe_test.go
+++ b/internal/core/describe_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 )
 
-// ---- Describe / DependsOn / OptionalDependOn / Resolve ----
+// ---- Config.Description / DependsOn / OptionalDependOn / Resolve ----
 
-func TestDescribe_PopulatesRegistry(t *testing.T) {
+func TestConfigDescription_PopulatesRegistry(t *testing.T) {
 	t.Parallel()
 
-	m, _ := New(Config{ID: "demo"})
-	m.Describe("A demo module")
+	m, _ := New(Config{ID: "demo", Description: "A demo module"})
 	if got := m.registry.Description(); got != "A demo module" {
 		t.Errorf("Description = %q, want %q", got, "A demo module")
 	}

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -195,9 +195,8 @@ func New(cfg Config) (*Module, error) {
 		m.meterClient = meter.NewDev(m.logger)
 	}
 
-	// A Config-provided description flows to the same registry slot that
-	// ms.Describe() writes, so it reaches the manifest like Name/Tags. Skip
-	// when empty so a later ms.Describe() call isn't clobbered by a blank.
+	// A Config-provided description flows to the registry so it reaches the
+	// manifest like Name/Tags. Skip when empty to avoid a blank override.
 	if cfg.Description != "" {
 		m.registry.SetDescription(cfg.Description)
 	}
@@ -209,7 +208,7 @@ func New(cfg Config) (*Module, error) {
 func (m *Module) Config() Config   { return m.config }
 func (m *Module) Router() *chi.Mux { return m.router }
 
-// DB/Tx/ModuleDB/ModuleTx, Cache/Storage/Meter, Describe/DependsOn/OptionalDependOn,
+// DB/Tx/ModuleDB/ModuleTx, Cache/Storage/Meter, DependsOn/OptionalDependOn,
 // MCPTool/MCPResource: see db.go, resources.go, describe.go, and mcp.go.
 
 // Platform registers routes with platform auth scope. All routes

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -51,6 +51,9 @@ type Config struct {
 	Name string // Default display name (platform can override)
 	Icon string // Default Material icon name (platform can override)
 
+	// Description is a short, plain-language summary shown in the catalog/agent discovery. Optional.
+	Description string
+
 	// Tags are module-level category badges (e.g. "Auth", "Payments") shown in
 	// the platform's module catalog / settings. Surfaced via manifest defaults.
 	Tags []string
@@ -190,6 +193,13 @@ func New(cfg Config) (*Module, error) {
 		m.meterClient = meterClient
 	} else {
 		m.meterClient = meter.NewDev(m.logger)
+	}
+
+	// A Config-provided description flows to the same registry slot that
+	// ms.Describe() writes, so it reaches the manifest like Name/Tags. Skip
+	// when empty so a later ms.Describe() call isn't clobbered by a blank.
+	if cfg.Description != "" {
+		m.registry.SetDescription(cfg.Description)
 	}
 
 	m.mountSystemRoutes()

--- a/internal/core/module_test.go
+++ b/internal/core/module_test.go
@@ -831,21 +831,20 @@ func TestInternalRoutes_MaxBytesLimit(t *testing.T) {
 
 func TestScopesPanic_BeforeInit(t *testing.T) {
 	fns := map[string]func(){
-		"Platform":          func() { Platform(func(r chi.Router) {}) },
-		"Public":            func() { Public(func(r chi.Router) {}) },
-		"Internal":          func() { Internal(func(r chi.Router) {}) },
+		"Platform":           func() { Platform(func(r chi.Router) {}) },
+		"Public":             func() { Public(func(r chi.Router) {}) },
+		"Internal":           func() { Internal(func(r chi.Router) {}) },
 		"RegisterPermission": func() { RegisterPermission("media.view", PermissionOpts{DefaultRole: p.Admin()}) },
 		"RequirePermission":  func() { RequirePermission("media.view") },
-		"OnEvent":           func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) },
-		"Emits":             func() { Emits("created") },
-		"Cron":              func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
-		"OnTask":            func() { OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil }) },
-		"RunTask":           func() { _, _ = RunTask(context.Background(), "work", nil) },
-		"Meter":             func() { _ = Meter(context.Background()).Record("m", 1) },
-		"ModuleDB":          func() { _, _, _ = ModuleDB(context.Background()) },
-		"ModuleTx":          func() { _ = ModuleTx(context.Background(), func(q db.Querier) error { return nil }) },
-		"Describe":          func() { Describe("a module") },
-		"DependsOn":         func() { DependsOn("other") },
+		"OnEvent":            func() { OnEvent("user.created", func(w http.ResponseWriter, r *http.Request) {}) },
+		"Emits":              func() { Emits("created") },
+		"Cron":               func() { Cron("cleanup", "0 3 * * *", func(w http.ResponseWriter, r *http.Request) {}) },
+		"OnTask":             func() { OnTask("work", func(ctx context.Context, p json.RawMessage) error { return nil }) },
+		"RunTask":            func() { _, _ = RunTask(context.Background(), "work", nil) },
+		"Meter":              func() { _ = Meter(context.Background()).Record("m", 1) },
+		"ModuleDB":           func() { _, _, _ = ModuleDB(context.Background()) },
+		"ModuleTx":           func() { _ = ModuleTx(context.Background(), func(q db.Querier) error { return nil }) },
+		"DependsOn":          func() { DependsOn("other") },
 	}
 	for name, fn := range fns {
 		t.Run(name, func(t *testing.T) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -173,7 +173,7 @@ func New() *Registry {
 }
 
 // SetDescription sets the module's human-readable description. Last-write-wins;
-// typically called once at module init via ms.Describe.
+// typically set once via Description on ms.Config passed to ms.Init.
 func (r *Registry) SetDescription(s string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -142,6 +142,8 @@ func Meter(ctx context.Context) meter.Meter { return core.Meter(ctx) }
 // --- Dependency declarations ---
 
 // Describe sets the default module's human-readable description.
+//
+// Deprecated: set Description on ms.Config passed to ms.Init() instead.
 func Describe(s string) { core.Describe(s) }
 
 // Need is the configuration handle passed to DependsOn /

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -141,11 +141,6 @@ func Meter(ctx context.Context) meter.Meter { return core.Meter(ctx) }
 
 // --- Dependency declarations ---
 
-// Describe sets the default module's human-readable description.
-//
-// Deprecated: set Description on ms.Config passed to ms.Init() instead.
-func Describe(s string) { core.Describe(s) }
-
 // Need is the configuration handle passed to DependsOn /
 // OptionalDependOn callbacks. Use n.Table(name) to declare a SELECT
 // request, n.Event(name) to declare an event subscription.


### PR DESCRIPTION
Module identity description is now set as a Config field at `ms.Init()` (alongside Name/Icon/Tags) and flows to the same registry slot. The runtime `ms.Describe()` API is removed outright. Consolidates all static module identity in Config for cleaner AI-agent authoring (per oauth-core architecture review Q5).

## Change
- Add `Description string` field to `ms.Config` (canonical `core.Config`; the `mirrorstack.Config` alias inherits it).
- In `core.New()`: when `cfg.Description != ""`, call `m.registry.SetDescription(cfg.Description)` so it reaches the manifest like Name/Tags. Empty is skipped to avoid a blank override.
- Remove the `ms.Describe` facade, `core.Describe`, and `(*Module).Describe`. The registry's internal `SetDescription` sink stays (it's what `Config.Description` writes to).
- Migrate the SDK's own callers: `examples/template/main.go` now sets `Description:` on `ms.Config`; tests updated.

## Verify
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Zero `Describe` func definitions or callsites remain in the SDK.

## BREAKING
BREAKING: ms.Describe removed (no third-party modules → no deprecation grace). All modules set Description on ms.Config instead; canonical oauth-core / oauth-google / analytics must migrate before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)