### PR TITLE
feat(sdk): ms.Call inter-module transport (dev/dispatch)

### DIFF
--- a/internal/core/call.go
+++ b/internal/core/call.go
@@ -1,0 +1,136 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+)
+
+// devDispatchFallback is used when MS_DISPATCH_URL is unset. Modules run inside
+// docker; the platform dispatch listens on the host at :8083, reachable via
+// host.docker.internal (the same convention docker-compose uses for
+// AWS_ENDPOINT_URL). The CLI sets MS_DISPATCH_URL explicitly in dev, and prod
+// points it at the real dispatch — this default only keeps local runs working.
+const devDispatchFallback = "http://host.docker.internal:8083"
+
+// callTimeout bounds a single inter-module hop. Matches the value the
+// hand-rolled oauth-core dispatchclient used.
+const callTimeout = 15 * time.Second
+
+// callHTTP is the shared client for inter-module calls. A single client with a
+// per-request timeout is enough — context cancellation still applies on top.
+var callHTTP = &http.Client{Timeout: callTimeout}
+
+// resolveCallURL builds the platform-dispatch URL for a module->module hop:
+//
+//	{base}/module/{targetModuleID}{path}
+//
+// base is MS_DISPATCH_URL (the container->dispatch base) with the
+// host.docker.internal:8083 dev fallback when unset.
+//
+// DEV/DISPATCH TRANSPORT. Prod catalog/Lambda endpoint resolution is task
+// #146 — this resolver is the seam where that plugs in. In prod the target
+// module is not reachable through a single dev dispatch base; the platform
+// catalog resolves the installed module's Lambda endpoint per app. When #146
+// lands, swap the body of this function (and only this function) to consult
+// the catalog/Lambda resolver; Call's marshal/auth/error contract stays put.
+func resolveCallURL(targetModuleID, path string) string {
+	base := os.Getenv("MS_DISPATCH_URL")
+	if base == "" {
+		base = devDispatchFallback
+	}
+	base = strings.TrimRight(base, "/")
+	return fmt.Sprintf("%s/module/%s%s", base, targetModuleID, path)
+}
+
+// Call makes one server-mediated module-to-module hop through the platform
+// dispatch. It marshals body to JSON (omitted for a nil body), POST/GET/etc to
+// the resolved dispatch URL scoped to the current app, and decodes the JSON
+// response into out (skipped when out is nil).
+//
+// The app id is read from the request context (auth.Get) — the same identity
+// the SDK injects for handlers — and sent as X-MS-App-ID so the dispatch can
+// resolve the install. The CALLER never holds the callee's credentials:
+// dispatch injects the TARGET module's per-session token + identity before
+// forwarding.
+//
+// path must include its leading slash and any raw query string, e.g.
+// "/internal/exchange" or "/internal/users?limit=10".
+//
+// DEV/DISPATCH TRANSPORT — see resolveCallURL for the prod (#146) seam.
+func (m *Module) Call(ctx context.Context, targetModuleID, method, path string, body, out any) error {
+	appID := ""
+	if a := auth.Get(ctx); a != nil {
+		appID = a.AppID
+	}
+
+	var reader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(buf)
+	}
+
+	u := resolveCallURL(targetModuleID, path)
+	req, err := http.NewRequestWithContext(ctx, method, u, reader)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-MS-App-ID", appID)
+
+	resp, err := callHTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("ms.Call %s %s -> %d: %s", method, req.URL.Path, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// CallGet is Call specialized to GET (no request body). path carries any raw
+// query string, e.g. "/internal/users?limit=10".
+func (m *Module) CallGet(ctx context.Context, targetModuleID, path string, out any) error {
+	return m.Call(ctx, targetModuleID, http.MethodGet, path, nil, out)
+}
+
+// CallPost is Call specialized to POST with a JSON body.
+func (m *Module) CallPost(ctx context.Context, targetModuleID, path string, body, out any) error {
+	return m.Call(ctx, targetModuleID, http.MethodPost, path, body, out)
+}
+
+// Package-level convenience wrappers — dispatch to defaultModule.
+
+// Call makes one inter-module hop through the platform dispatch on the default
+// module. Panics before Init.
+func Call(ctx context.Context, targetModuleID, method, path string, body, out any) error {
+	return mustDefault("Call").Call(ctx, targetModuleID, method, path, body, out)
+}
+
+// CallGet is Call specialized to GET on the default module. Panics before Init.
+func CallGet(ctx context.Context, targetModuleID, path string, out any) error {
+	return mustDefault("CallGet").CallGet(ctx, targetModuleID, path, out)
+}
+
+// CallPost is Call specialized to POST on the default module. Panics before Init.
+func CallPost(ctx context.Context, targetModuleID, path string, body, out any) error {
+	return mustDefault("CallPost").CallPost(ctx, targetModuleID, path, body, out)
+}

--- a/internal/core/call_test.go
+++ b/internal/core/call_test.go
@@ -1,0 +1,144 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+)
+
+func TestResolveCallURL_Building(t *testing.T) {
+	cases := []struct {
+		name     string
+		dispatch string // value for MS_DISPATCH_URL ("" = unset -> dev fallback)
+		target   string
+		path     string
+		want     string
+	}{
+		{
+			name:     "dev fallback when unset",
+			dispatch: "",
+			target:   "m0123",
+			path:     "/internal/exchange",
+			want:     devDispatchFallback + "/module/m0123/internal/exchange",
+		},
+		{
+			name:     "explicit base",
+			dispatch: "http://dispatch:8083",
+			target:   "m0123",
+			path:     "/internal/users",
+			want:     "http://dispatch:8083/module/m0123/internal/users",
+		},
+		{
+			name:     "trailing slash on base is trimmed",
+			dispatch: "http://dispatch:8083/",
+			target:   "m0123",
+			path:     "/internal/users",
+			want:     "http://dispatch:8083/module/m0123/internal/users",
+		},
+		{
+			name:     "raw query carried in path",
+			dispatch: "http://dispatch:8083",
+			target:   "m0123",
+			path:     "/internal/users?limit=10",
+			want:     "http://dispatch:8083/module/m0123/internal/users?limit=10",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.dispatch == "" {
+				t.Setenv("MS_DISPATCH_URL", "")
+			} else {
+				t.Setenv("MS_DISPATCH_URL", tc.dispatch)
+			}
+			if got := resolveCallURL(tc.target, tc.path); got != tc.want {
+				t.Errorf("resolveCallURL(%q, %q) = %q, want %q", tc.target, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCall_SendsAppIDAndDecodesResponse(t *testing.T) {
+	var gotMethod, gotPath, gotAppID, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAppID = r.Header.Get("X-MS-App-ID")
+		gotCT = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+
+	m, _ := New(Config{ID: "demo"})
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := m.CallPost(ctx, "m0123", "/internal/exchange", map[string]string{"code": "x"}, &out); err != nil {
+		t.Fatalf("CallPost: %v", err)
+	}
+	if !out.OK {
+		t.Errorf("out.OK = false, want true")
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/module/m0123/internal/exchange" {
+		t.Errorf("path = %q, want /module/m0123/internal/exchange", gotPath)
+	}
+	if gotAppID != "a-456" {
+		t.Errorf("X-MS-App-ID = %q, want a-456", gotAppID)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+}
+
+func TestCall_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream module unavailable"))
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+
+	m, _ := New(Config{ID: "demo"})
+	err := m.CallGet(context.Background(), "m0123", "/internal/users", nil)
+	if err == nil {
+		t.Fatal("expected error on non-2xx, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "502") {
+		t.Errorf("error %q missing status 502", msg)
+	}
+	if !strings.Contains(msg, "upstream module unavailable") {
+		t.Errorf("error %q missing upstream body", msg)
+	}
+	if !strings.Contains(msg, "/module/m0123/internal/users") {
+		t.Errorf("error %q missing request path", msg)
+	}
+}
+
+func TestCallGet_NoBodyNoContentType(t *testing.T) {
+	var hadCT bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hadCT = r.Header.Get("Content-Type") != ""
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+
+	m, _ := New(Config{ID: "demo"})
+	if err := m.CallGet(context.Background(), "m0123", "/internal/ping", nil); err != nil {
+		t.Fatalf("CallGet: %v", err)
+	}
+	if hadCT {
+		t.Error("GET set a Content-Type header, want none (no body)")
+	}
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/contributions"
@@ -167,6 +168,27 @@ func CallGet(ctx context.Context, targetModuleID, path string, out any) error {
 // CallPost is Call specialized to POST with a JSON body on the default module.
 func CallPost(ctx context.Context, targetModuleID, path string, body, out any) error {
 	return core.CallPost(ctx, targetModuleID, path, body, out)
+}
+
+// WithAppID returns a context whose inter-module Call scope is the given app,
+// overriding the ambient identity's app. ms.Call reads the app id from the
+// context (auth.Get) — for a handler that is the request's authenticated app,
+// so authenticated callers need nothing extra. PUBLIC/proxy flows have no
+// ambient identity (e.g. a sign-in proxy on ms.Public routes, where the target
+// app arrives as request data, not as the caller's identity), so they set it
+// explicitly:
+//
+//	ctx = ms.WithAppID(ctx, appID)
+//	ms.CallGet(ctx, providerModuleID, "/internal/authorize-url?"+q, &out)
+//
+// Any existing UserID/AppRole on the context is preserved; only AppID changes.
+func WithAppID(ctx context.Context, appID string) context.Context {
+	var id auth.Identity
+	if cur := auth.Get(ctx); cur != nil {
+		id = *cur
+	}
+	id.AppID = appID
+	return auth.Set(ctx, id)
 }
 
 // --- Dependency declarations ---

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -139,6 +139,36 @@ func Storage(ctx context.Context) (storage.Storer, error) { return core.Storage(
 // Meter returns a scoped meter for recording usage events on the default module.
 func Meter(ctx context.Context) meter.Meter { return core.Meter(ctx) }
 
+// --- Inter-module calls ---
+
+// Call makes one server-mediated module-to-module hop through the platform
+// dispatch, scoped to the current app (app id read from ctx via the SDK's
+// auth identity — callers don't pass it). It JSON-marshals body, sends
+// method to the target module's path, and decodes the JSON response into
+// out (pass nil body for GET, nil out to ignore the response). path must
+// include its leading slash and any raw query, e.g. "/internal/users?limit=10".
+//
+// The caller never holds the callee's credentials: dispatch injects the
+// TARGET module's per-session token + identity before forwarding. Declare the
+// target as a dependency (ms.DependsOn) — inter-module calls without a declared
+// dep are a wiring bug the platform enforces.
+//
+// Dev/dispatch transport today; prod catalog/Lambda endpoint resolution is the
+// documented #146 seam (see core.resolveCallURL).
+func Call(ctx context.Context, targetModuleID, method, path string, body, out any) error {
+	return core.Call(ctx, targetModuleID, method, path, body, out)
+}
+
+// CallGet is Call specialized to GET (no request body) on the default module.
+func CallGet(ctx context.Context, targetModuleID, path string, out any) error {
+	return core.CallGet(ctx, targetModuleID, path, out)
+}
+
+// CallPost is Call specialized to POST with a JSON body on the default module.
+func CallPost(ctx context.Context, targetModuleID, path string, body, out any) error {
+	return core.CallPost(ctx, targetModuleID, path, body, out)
+}
+
 // --- Dependency declarations ---
 
 // Describe sets the default module's human-readable description.

--- a/withappid_test.go
+++ b/withappid_test.go
@@ -1,0 +1,49 @@
+package mirrorstack_test
+
+import (
+	"context"
+	"testing"
+
+	ms "github.com/mirrorstack-ai/app-module-sdk"
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+)
+
+func TestWithAppID(t *testing.T) {
+	t.Run("sets app id on a bare context", func(t *testing.T) {
+		ctx := ms.WithAppID(context.Background(), "app-1")
+		got := auth.Get(ctx)
+		if got == nil {
+			t.Fatal("expected identity, got nil")
+		}
+		if got.AppID != "app-1" {
+			t.Errorf("AppID = %q, want app-1", got.AppID)
+		}
+		if got.UserID != "" || got.AppRole != "" {
+			t.Errorf("expected empty UserID/AppRole, got %q/%q", got.UserID, got.AppRole)
+		}
+	})
+
+	t.Run("overrides app id but preserves user and role", func(t *testing.T) {
+		base := auth.Set(context.Background(), auth.Identity{
+			UserID:  "u-1",
+			AppID:   "app-old",
+			AppRole: auth.RoleAdmin,
+		})
+		ctx := ms.WithAppID(base, "app-new")
+		got := auth.Get(ctx)
+		if got.AppID != "app-new" {
+			t.Errorf("AppID = %q, want app-new", got.AppID)
+		}
+		if got.UserID != "u-1" || got.AppRole != auth.RoleAdmin {
+			t.Errorf("UserID/AppRole not preserved: %q/%q", got.UserID, got.AppRole)
+		}
+	})
+
+	t.Run("does not mutate the source identity", func(t *testing.T) {
+		base := auth.Set(context.Background(), auth.Identity{AppID: "app-old"})
+		_ = ms.WithAppID(base, "app-new")
+		if src := auth.Get(base); src.AppID != "app-old" {
+			t.Errorf("source identity mutated: AppID = %q, want app-old", src.AppID)
+		}
+	})
+}


### PR DESCRIPTION
Generalizes oauth-core's `internal/dispatchclient` into the SDK: `ms.Call` routes a module→module server hop through the platform dispatch (`MS_DISPATCH_URL/module/{uuid}{path}`, dev fallback `host.docker.internal:8083`), `X-MS-App-ID` scoped; dispatch injects the callee's per-session token + identity so the caller never holds the callee's creds.

## API

```go
func Call(ctx, targetModuleID, method, path string, body, out any) error
func CallGet(ctx, targetModuleID, path string, out any) error
func CallPost(ctx, targetModuleID, path string, body, out any) error
```

App id is resolved from `ctx` via the SDK's `auth.Get` identity — callers don't pass it (matches `Cache`/`Storage`/`Meter`/`DB`). `path` carries its leading slash and any raw query. JSON marshal/unmarshal, non-2xx → error with truncated (2 KB) body, 15 s default timeout.

Dev/dispatch impl now; prod catalog/Lambda endpoint resolution is the documented **#146** seam, isolated to `core.resolveCallURL` (swap only that function's body when #146 lands; `Call`'s marshal/auth/error contract stays put).

oauth-core will adopt `ms.Call` and delete its `internal/dispatchclient`.

## Verify
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (full suite green; added `internal/core/call_test.go` covering URL building, X-MS-App-ID + JSON decode, non-2xx truncated-body error, GET-no-Content-Type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)