### PR TITLE
feat(sdk): export ms.WriteJSON / ms.WriteError + ErrorResponse

### DIFF
--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/contributions"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/core"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/meter"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 )
@@ -189,6 +190,37 @@ func WithAppID(ctx context.Context, appID string) context.Context {
 	}
 	id.AppID = appID
 	return auth.Set(ctx, id)
+}
+
+// --- HTTP responses ---
+
+// ErrorResponse is the SDK's JSON error envelope: {"error": "<message>"}. It is
+// the shape WriteError emits and the same shape the SDK's own auth/permission
+// middleware returns, so module errors and platform errors are indistinguishable
+// on the wire. Exported so callers can decode an error body into a typed value.
+type ErrorResponse = httputil.ErrorResponse
+
+// WriteJSON writes v to w as JSON with the given status code and a
+// Content-Type: application/json header. A nil v writes only the status and
+// header with no body (for 204-style empty responses). An encode error is
+// logged, not returned — the status line is already committed by then.
+//
+// This is the response writer every module otherwise hand-rolls; it backs the
+// same internal helper the SDK uses for its own endpoints.
+func WriteJSON(w http.ResponseWriter, status int, v any) {
+	if v == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		return
+	}
+	httputil.JSON(w, status, v)
+}
+
+// WriteError writes the JSON error envelope {"error": msg} with the given
+// status code, via WriteJSON. Use the canonical ErrorResponse shape rather than
+// an ad-hoc map so module errors match the SDK's own error wire format.
+func WriteError(w http.ResponseWriter, status int, msg string) {
+	WriteJSON(w, status, ErrorResponse{Error: msg})
 }
 
 // --- Dependency declarations ---

--- a/writejson_test.go
+++ b/writejson_test.go
@@ -1,0 +1,63 @@
+package mirrorstack_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ms "github.com/mirrorstack-ai/app-module-sdk"
+)
+
+func TestWriteJSON(t *testing.T) {
+	t.Run("encodes body with status + content-type", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ms.WriteJSON(rec, http.StatusCreated, map[string]string{"hello": "world"})
+		if rec.Code != http.StatusCreated {
+			t.Errorf("status = %d, want 201", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("content-type = %q, want application/json", ct)
+		}
+		var got map[string]string
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("body not JSON: %v", err)
+		}
+		if got["hello"] != "world" {
+			t.Errorf("body = %v", got)
+		}
+	})
+
+	t.Run("nil body writes status + header, no body", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ms.WriteJSON(rec, http.StatusNoContent, nil)
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("status = %d, want 204", rec.Code)
+		}
+		if rec.Header().Get("Content-Type") != "application/json" {
+			t.Errorf("content-type not set on empty body")
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("expected empty body, got %q", rec.Body.String())
+		}
+	})
+}
+
+func TestWriteError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ms.WriteError(rec, http.StatusBadRequest, "nope")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	var got ms.ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not an ErrorResponse: %v", err)
+	}
+	if got.Error != "nope" {
+		t.Errorf("error = %q, want nope", got.Error)
+	}
+	// Wire shape must be exactly {"error": "..."} — match the SDK middleware envelope.
+	if s := rec.Body.String(); s != "{\"error\":\"nope\"}\n" {
+		t.Errorf("wire shape = %q, want {\"error\":\"nope\"}\\n", s)
+	}
+}


### PR DESCRIPTION
## What
Promotes the JSON response writer that every module hand-rolls into the SDK facade.

- `ms.WriteJSON(w, status, v)` — `Content-Type: application/json` + status + JSON body, with a **nil-body guard** (skip encode for 204-style empty responses) so it's a true drop-in for the module copies. Backs onto the existing `internal/httputil.JSON`.
- `ms.WriteError(w, status, msg)` — emits the canonical `ErrorResponse` envelope `{"error": msg}` (not an ad-hoc `map[string]string`), matching the SDK's own auth/permission middleware so module and platform errors are identical on the wire.
- `ms.ErrorResponse` — exported alias of the internal envelope for typed decoding.

## Why
Audit of oauth-core (+ oauth-google, analytics-core, analytics-replay) found this is the single highest-recurrence boilerplate: byte-identical `writeJSON`/`writeError` in all 4 modules (analytics-core/replay literally comment *"copied from oauth-core; the JSON response contract is identical"*), 65 call sites in oauth-core alone. The SDK already owns the shape (`httputil.JSON`/`ErrorResponse`, 90+ internal sites) — it just never exported it. No delegation seam (unlike the contributions read), so it's a clean kernel gap — same shape as the `dispatchclient`→`ms.Call` promotion.

## Verify
`go build` / `go vet` / `go test ./...` green; added `writejson_test.go` (status/content-type/body, nil-body 204 path, and exact `{"error":"..."}` wire shape).

## Follow-up
Modules adopt `ms.WriteJSON`/`ms.WriteError` and delete their copies (starts with oauth-core).