### PR TITLE
feat(sdk): ms.Emit — fire module events to the platform event bus

### DIFF
--- a/internal/core/emit.go
+++ b/internal/core/emit.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/ids"
+)
+
+// eventEnvelope is the wire shape every emitted event takes. The dispatch
+// forwards this struct byte-for-byte to each LIVE subscriber session, so the
+// JSON field names here are a SHARED CONTRACT with the dispatch and the
+// subscriber-side /__mirrorstack/events/{name} handler — don't rename them
+// without changing both sides.
+type eventEnvelope struct {
+	ID             string `json:"id"`             // per-emit UUID (idempotency key for at-least-once delivery)
+	Name           string `json:"name"`           // event name as passed to Emit
+	SourceModuleID string `json:"sourceModuleID"` // emitting module's Config.ID
+	SentAt         string `json:"sentAt"`         // RFC3339 UTC timestamp of emission
+	Payload        any    `json:"payload"`        // caller-supplied payload, marshaled as-is
+}
+
+// resolveEventBusURL builds the platform-dispatch URL the envelope is POSTed to:
+//
+//	{base}/apps/{appID}/events/{name}
+//
+// base is MS_DISPATCH_URL (the container->dispatch base) with the
+// host.docker.internal:8083 dev fallback when unset — the same resolution
+// core.Call uses for inter-module hops.
+//
+// DEV/DISPATCH TRANSPORT. Prod event-bus endpoint resolution is task #146 —
+// this resolver is the seam where that plugs in, mirroring resolveCallURL. In
+// prod the event bus is not a single dev dispatch base; when #146 lands, swap
+// the body of this function (and only this function) to consult the prod
+// transport. Emit's marshal/auth/error contract stays put.
+func resolveEventBusURL(appID, name string) string {
+	base := os.Getenv("MS_DISPATCH_URL")
+	if base == "" {
+		base = devDispatchFallback
+	}
+	base = strings.TrimRight(base, "/")
+	return fmt.Sprintf("%s/apps/%s/events/%s", base, appID, name)
+}
+
+// Emit publishes an event to every LIVE module that subscribes to name within
+// the current app. It wraps payload in the event envelope (a fresh UUID id, the
+// emitting module's Config.ID as sourceModuleID, and an RFC3339 UTC sentAt),
+// then POSTs the envelope to the platform dispatch event bus scoped to the
+// current app. The dispatch fans the SAME envelope out to each subscriber
+// session — the emitter never addresses subscribers directly.
+//
+// The app id is read from the request context (auth.Get) — the same identity
+// the SDK injects for handlers — and is encoded in the dispatch URL. An empty
+// app id is an error (no panic): Emit needs an app scope to know which installs
+// can receive the event.
+//
+// Delivery is AT-LEAST-ONCE and best-effort per subscriber (the dispatch logs
+// per-subscriber failures and never fails the whole call); subscriber handlers
+// must be idempotent. A non-2xx response from the dispatch itself is returned
+// as an error with the response body truncated to ~2 KB.
+//
+// DEV/DISPATCH TRANSPORT — see resolveEventBusURL for the prod (#146) seam.
+func (m *Module) Emit(ctx context.Context, name string, payload any) error {
+	appID := ""
+	if a := auth.Get(ctx); a != nil {
+		appID = a.AppID
+	}
+	if appID == "" {
+		return errors.New("mirrorstack: Emit requires an app-scoped context (no AppID in auth identity)")
+	}
+
+	env := eventEnvelope{
+		ID:             ids.NewUUID(),
+		Name:           name,
+		SourceModuleID: m.config.ID,
+		SentAt:         time.Now().UTC().Format(time.RFC3339Nano),
+		Payload:        payload,
+	}
+	buf, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	u := resolveEventBusURL(appID, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-MS-App-ID", appID)
+
+	resp, err := callHTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("ms.Emit %s -> %d: %s", req.URL.Path, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
+// Emit publishes an event on the default module created by Init(). Panics
+// before Init — matches Call/CallGet/CallPost.
+func Emit(ctx context.Context, name string, payload any) error {
+	return mustDefault("Emit").Emit(ctx, name, payload)
+}

--- a/internal/core/emit_test.go
+++ b/internal/core/emit_test.go
@@ -1,0 +1,162 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+)
+
+func TestResolveEventBusURL_Building(t *testing.T) {
+	cases := []struct {
+		name     string
+		dispatch string // value for MS_DISPATCH_URL ("" = unset -> dev fallback)
+		appID    string
+		event    string
+		want     string
+	}{
+		{
+			name:     "dev fallback when unset",
+			dispatch: "",
+			appID:    "a-456",
+			event:    "user.created",
+			want:     devDispatchFallback + "/apps/a-456/events/user.created",
+		},
+		{
+			name:     "explicit base",
+			dispatch: "http://dispatch:8083",
+			appID:    "a-456",
+			event:    "user.created",
+			want:     "http://dispatch:8083/apps/a-456/events/user.created",
+		},
+		{
+			name:     "trailing slash on base is trimmed",
+			dispatch: "http://dispatch:8083/",
+			appID:    "a-456",
+			event:    "user.created",
+			want:     "http://dispatch:8083/apps/a-456/events/user.created",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MS_DISPATCH_URL", tc.dispatch)
+			if got := resolveEventBusURL(tc.appID, tc.event); got != tc.want {
+				t.Errorf("resolveEventBusURL(%q, %q) = %q, want %q", tc.appID, tc.event, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmit_PostsEnvelopeFromContextAppID(t *testing.T) {
+	var gotMethod, gotPath, gotAppID, gotCT string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAppID = r.Header.Get("X-MS-App-ID")
+		gotCT = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"delivered":2}`))
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+
+	m, _ := New(Config{ID: "billing"})
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+
+	if err := m.Emit(ctx, "payment.captured", map[string]any{"amount": 100}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	// appID is taken from ctx via auth.Set, encoded into both URL and header.
+	if gotPath != "/apps/a-456/events/payment.captured" {
+		t.Errorf("path = %q, want /apps/a-456/events/payment.captured", gotPath)
+	}
+	if gotAppID != "a-456" {
+		t.Errorf("X-MS-App-ID = %q, want a-456", gotAppID)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+
+	var env struct {
+		ID             string         `json:"id"`
+		Name           string         `json:"name"`
+		SourceModuleID string         `json:"sourceModuleID"`
+		SentAt         string         `json:"sentAt"`
+		Payload        map[string]any `json:"payload"`
+	}
+	if err := json.Unmarshal(gotBody, &env); err != nil {
+		t.Fatalf("envelope unmarshal: %v (body=%s)", err, gotBody)
+	}
+	if env.ID == "" {
+		t.Error("envelope id is empty, want a generated UUID")
+	}
+	if env.Name != "payment.captured" {
+		t.Errorf("envelope name = %q, want payment.captured", env.Name)
+	}
+	if env.SourceModuleID != "billing" {
+		t.Errorf("envelope sourceModuleID = %q, want billing (Config.ID)", env.SourceModuleID)
+	}
+	if env.SentAt == "" {
+		t.Error("envelope sentAt is empty, want an RFC3339 timestamp")
+	}
+	if got := env.Payload["amount"]; got != float64(100) {
+		t.Errorf("envelope payload.amount = %v, want 100", got)
+	}
+}
+
+func TestEmit_EmptyAppContextErrorsWithoutHTTP(t *testing.T) {
+	var hit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+
+	m, _ := New(Config{ID: "billing"})
+	// No auth identity on the context -> no AppID.
+	if err := m.Emit(context.Background(), "payment.captured", nil); err == nil {
+		t.Fatal("expected error on empty-app context, got nil")
+	}
+	if hit {
+		t.Error("Emit made an HTTP call despite empty app context")
+	}
+}
+
+func TestEmit_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("event bus unavailable"))
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+
+	m, _ := New(Config{ID: "billing"})
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+
+	err := m.Emit(ctx, "payment.captured", nil)
+	if err == nil {
+		t.Fatal("expected error on non-2xx, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "502") {
+		t.Errorf("error %q missing status 502", msg)
+	}
+	if !strings.Contains(msg, "event bus unavailable") {
+		t.Errorf("error %q missing upstream body", msg)
+	}
+	if !strings.Contains(msg, "/apps/a-456/events/payment.captured") {
+		t.Errorf("error %q missing request path", msg)
+	}
+}

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -171,6 +171,23 @@ func CallPost(ctx context.Context, targetModuleID, path string, body, out any) e
 	return core.CallPost(ctx, targetModuleID, path, body, out)
 }
 
+// Emit publishes an event to every LIVE module that subscribes to name within
+// the current app, scoped to the current app (app id read from ctx via the
+// SDK's auth identity — callers don't pass it). The SDK wraps payload in the
+// event envelope ({id, name, sourceModuleID, sentAt, payload}) and POSTs it to
+// the platform dispatch event bus, which fans the SAME envelope out to each
+// subscriber session. An empty app-scope context is an error (no panic).
+//
+// Delivery is AT-LEAST-ONCE and best-effort per subscriber — subscriber
+// handlers (ms.OnEvent) must be idempotent. Declare the event vocabulary with
+// ms.Emits so subscribers can discover it.
+//
+// Dev/dispatch transport today; prod event-bus endpoint resolution is the
+// documented #146 seam (see core.resolveEventBusURL, mirroring core.resolveCallURL).
+func Emit(ctx context.Context, name string, payload any) error {
+	return core.Emit(ctx, name, payload)
+}
+
 // WithAppID returns a context whose inter-module Call scope is the given app,
 // overriding the ambient identity's app. ms.Call reads the app id from the
 // context (auth.Get) — for a handler that is the request's authenticated app,


### PR DESCRIPTION
Adds `ms.Emit(ctx, name string, payload any) error` — the missing **fire** half of the events surface (`ms.Emits` declares, `ms.OnEvent` subscribes, now `ms.Emit` fires).

- Mirrors `ms.Call`: appID from `ctx` (`auth.Get`), shared HTTP client, non-2xx → error (truncated body).
- Envelope: `{id, name, sourceModuleID (=Config.ID), sentAt (RFC3339Nano UTC), payload}` — id + provenance for idempotency.
- POSTs to `resolveEventBusURL(appID,name)` = `{base}/apps/{appID}/events/{name}` (`MS_DISPATCH_URL` or `host.docker.internal:8083` dev fallback). `resolveEventBusURL` is the prod (#146) seam, documented like `core.resolveCallURL`.

Pairs with the dispatch event-router (separate api-platform PR) that fans the envelope out to subscribed modules' `/__mirrorstack/events/{name}`.

`go build`/`vet` green; `internal/core` tests pass (envelope shape, ctx appID, empty-app error, non-2xx). Reviewed (Go reviewer: ship).