### PR TITLE
fix(sdk): isolate module data per app in dev (app_<id> schemas)

### DIFF
--- a/internal/core/dev_migrate.go
+++ b/internal/core/dev_migrate.go
@@ -13,12 +13,6 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
 )
 
-// devAppSchema is the schema app-scope migrations target in dev. There is no
-// per-app tenant locally, so every app migration shares one schema — public,
-// which is also on the default search_path m.DB/m.Tx fall back to at runtime
-// when no app schema is set, so handlers read the tables migrations create.
-const devAppSchema = "public"
-
 // devMigrateEnvVar is the local-dev signal set by `mirrorstack dev`. When
 // non-empty, the module is running under the CLI's dev lifecycle and applies
 // its embedded migrations on every start so the developer's local Postgres
@@ -40,37 +34,77 @@ func (m *Module) devMigrateEnabled() bool {
 	return os.Getenv(devMigrateEnvVar) != ""
 }
 
-// applyDevMigrations runs every embedded migration that has not yet been
-// applied to the dev Postgres. Idempotent across module restarts — the
-// per-module tracking table mod_<id>.schema_migrations records what ran, keyed
-// by (scope, version). Per-module (not a shared table) so two modules sharing
-// one dev Postgres don't collide on the same version number.
+// applyDevMigrations applies MODULE-scope migrations into mod_<id> at startup.
 //
-// Pre-creates the mod_<id> schema so module-scope migrations have a home;
-// app-scope migrations land in whatever schema the connection sees by
-// default (public in dev — there is no real per-app tenant). Production
-// install lifecycle handles both with proper schemas; this is the dev
-// shortcut.
+// App-scope migrations are deliberately NOT run here: there is no app at boot
+// time. They are provisioned lazily, once per app, on the first request that
+// carries an app identity — see Module.ensureDevAppSchema. This mirrors
+// production, where each app gets its own app_<id> schema (the platform's
+// install lifecycle creates and migrates it), instead of every app sharing one
+// schema locally. Sharing one schema is exactly what broke per-app isolation in
+// dev: two apps installing the same module read and wrote the same tables.
+//
+// Module scope is shared across apps by design, so mod_<id> has a home the
+// moment the module boots and is migrated here.
 func (m *Module) applyDevMigrations(ctx context.Context) error {
+	return m.ensureSchemaMigrated(ctx, migration.ScopeModule, "mod_"+m.config.ID)
+}
+
+// ensureDevAppSchema lazily creates + migrates the per-app schema app_<id> the
+// first time a request for that app arrives in dev. Idempotent and cached per
+// process: only the first request for a given schema pays the migration cost;
+// later requests return the recorded result without touching Postgres. A
+// per-schema sync.Once also serializes concurrent first-touch requests so the
+// migrations run exactly once.
+func (m *Module) ensureDevAppSchema(ctx context.Context, schema string) error {
+	v, _ := m.devProvision.LoadOrStore(schema, &devProvisionEntry{})
+	entry := v.(*devProvisionEntry)
+	entry.once.Do(func() { entry.err = m.provisionDevAppSchema(ctx, schema) })
+	return entry.err
+}
+
+// provisionDevAppSchema runs the per-app setup: app-scope migrations into
+// app_<id>, then the contributions table (when the module declares any slots),
+// since that store is per-app — handlers read it via Module.DB, which resolves
+// to the app schema. Without it, a host module's slot reads/writes would hit a
+// missing relation the moment dev moved off the single shared schema.
+func (m *Module) provisionDevAppSchema(ctx context.Context, schema string) error {
+	if err := m.ensureSchemaMigrated(ctx, migration.ScopeApp, schema); err != nil {
+		return err
+	}
+	if m.contribReg.Len() > 0 {
+		sctx := db.WithSchema(ctx, schema)
+		q, release, err := m.DB(sctx)
+		if err != nil {
+			return fmt.Errorf("dev provision %s: open db: %w", schema, err)
+		}
+		defer release()
+		if err := m.contribStorage.EnsureTable(sctx, q); err != nil {
+			return fmt.Errorf("dev provision %s: ensure contributions table: %w", schema, err)
+		}
+	}
+	return nil
+}
+
+// ensureSchemaMigrated creates the target schema and its per-schema migration
+// tracking table, then applies any not-yet-recorded migrations for the given
+// scope. Each schema owns its own schema_migrations table (keyed by
+// scope+version) so every app's app-scope history is independent and a second
+// app installing the same module re-runs the migrations into its own schema
+// instead of being skipped as "already applied".
+func (m *Module) ensureSchemaMigrated(ctx context.Context, scope migration.Scope, schema string) error {
 	pool, release, err := m.resolvePool(ctx)
 	if err != nil {
 		return fmt.Errorf("dev migrate: open pool: %w", err)
 	}
 	defer release()
 
-	modSchema := pgx.Identifier{"mod_" + m.config.ID}.Sanitize()
-	if _, err := pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+modSchema); err != nil {
-		return fmt.Errorf("dev migrate: create mod schema: %w", err)
+	schemaIdent := pgx.Identifier{schema}.Sanitize()
+	if _, err := pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+schemaIdent); err != nil {
+		return fmt.Errorf("dev migrate: create schema %s: %w", schema, err)
 	}
 
-	// The tracking table lives in the module's OWN schema and MUST be
-	// per-module. Every module on a developer's machine shares one dev
-	// Postgres, so the old shared __ms_local.schema_migrations (keyed only by
-	// scope+version) collided across modules: module B's "app/0001" was
-	// skipped because module A had already recorded "app/0001", so B's tables
-	// were never created. Keyed per mod_<id> schema, each module's version
-	// space is independent.
-	trackingTable := pgx.Identifier{"mod_" + m.config.ID, "schema_migrations"}.Sanitize()
+	trackingTable := pgx.Identifier{schema, "schema_migrations"}.Sanitize()
 	if _, err := pool.Exec(ctx, fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
 			scope      text NOT NULL,
@@ -78,21 +112,17 @@ func (m *Module) applyDevMigrations(ctx context.Context) error {
 			applied_at timestamptz NOT NULL DEFAULT now(),
 			PRIMARY KEY (scope, version)
 		)`, trackingTable)); err != nil {
-		return fmt.Errorf("dev migrate: create tracking table: %w", err)
+		return fmt.Errorf("dev migrate: create tracking table in %s: %w", schema, err)
 	}
 
-	for _, scope := range migration.AllScopes() {
-		if err := m.applyDevScope(ctx, pool, trackingTable, scope); err != nil {
-			return err
-		}
-	}
-	return nil
+	return m.applyDevScope(ctx, pool, trackingTable, schema, scope)
 }
 
-// applyDevScope filters the embedded sql/<scope>/ migrations down to those
-// not already recorded in the tracking table, then applies the remainder
-// via the same TxRunner the production install handler uses.
-func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, trackingTable string, scope migration.Scope) error {
+// applyDevScope filters the embedded sql/<scope>/ migrations down to those not
+// already recorded in the schema's tracking table, then applies the remainder
+// via the same TxRunner the production install handler uses, pinned to the
+// target schema.
+func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, trackingTable, schema string, scope migration.Scope) error {
 	all, err := migration.List(m.config.SQL, scope)
 	if err != nil {
 		return fmt.Errorf("dev migrate %s: list: %w", scope, err)
@@ -116,18 +146,11 @@ func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, tracking
 		return nil
 	}
 
-	// App-scope migrations carry no per-app tenant in dev, so m.Tx would run
-	// each with an empty schema and fall back to the connection's default
-	// search_path. That default is not guaranteed identical across the pooled
-	// connections used for consecutive migrations, so a migration referencing
-	// an earlier one's table can fail with "relation does not exist". Pin the
-	// whole app sequence to one schema (public) so every migration lands in the
-	// same place. Module scope uses m.ModuleTx, which sets mod_<id> itself.
-	migrateCtx := ctx
-	if scope == migration.ScopeApp {
-		migrateCtx = db.WithSchema(ctx, devAppSchema)
-	}
-
+	// Pin the whole sequence to the target schema so every migration lands in
+	// the same place. App scope runs via Module.Tx, which reads this schema from
+	// the context; module scope runs via Module.ModuleTx, which overlays
+	// mod_<id> itself (identical to schema here) — setting it is harmless.
+	migrateCtx := db.WithSchema(ctx, schema)
 	runTx := m.lifecycleTxRunner(scope)
 	ran, err := migration.Apply(migrateCtx, runTx, m.config.SQL, pending)
 	// Record whatever ran before the failure (if any) so retries skip them.
@@ -137,7 +160,7 @@ func (m *Module) applyDevScope(ctx context.Context, pool *pgxpool.Pool, tracking
 	if err != nil {
 		return fmt.Errorf("dev migrate %s: apply: %w", scope, err)
 	}
-	m.logger.Printf("dev: applied %d %s migration(s): %v", len(ran), scope, ran)
+	m.logger.Printf("dev: applied %d %s migration(s) to %s: %v", len(ran), scope, schema, ran)
 	return nil
 }
 

--- a/internal/core/dev_migrate_test.go
+++ b/internal/core/dev_migrate_test.go
@@ -2,8 +2,11 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"testing/fstest"
+
+	"github.com/jackc/pgx/v5"
 )
 
 func TestDevMigrateEnabled(t *testing.T) {
@@ -28,14 +31,36 @@ func TestDevMigrateEnabled(t *testing.T) {
 	}
 }
 
-// TestApplyDevMigrations_Integration verifies the full dev-migrate path
-// against a live Postgres. Skipped when no Postgres is reachable — matches
-// the integration-test convention in db/db_integration_test.go.
-//
-// The migration here uses the same `CREATE TABLE IF NOT EXISTS` shape the
-// CLI scaffold ships, so a re-run after a successful first run is a true
-// idempotency check (tracking table prevents Apply from running them again).
-func TestApplyDevMigrations_Integration(t *testing.T) {
+func TestDevAppSchemaName(t *testing.T) {
+	cases := []struct {
+		appID string
+		want  string
+		ok    bool
+	}{
+		{"f64152df-77ff-4552-b31a-78026ea49cb7", "app_f64152df_77ff_4552_b31a_78026ea49cb7", true},
+		{"63B23941-245C-43FA-A68E-979E4997FBFE", "app_63b23941_245c_43fa_a68e_979e4997fbfe", true},
+		{"local-dev-app", "app_local_dev_app", true},
+		{"bad space", "", false},
+		{"semi;colon", "", false},
+		{"", "app_", false}, // "app_" has no trailing chars → fails the +-quantifier pattern
+	}
+	for _, tc := range cases {
+		got, ok := devAppSchemaName(tc.appID)
+		if ok != tc.ok {
+			t.Errorf("devAppSchemaName(%q) ok = %v, want %v", tc.appID, ok, tc.ok)
+		}
+		if ok && got != tc.want {
+			t.Errorf("devAppSchemaName(%q) = %q, want %q", tc.appID, got, tc.want)
+		}
+	}
+}
+
+// TestDevAppSchema_PerAppIsolation_Integration is the regression guard for the
+// dev per-app isolation bug: every app must get its OWN app_<id> schema, so the
+// same module installed on two apps does not share rows. Runs against the live
+// dev Postgres on :5433 (matches db/db_integration_test.go conventions);
+// skipped in short mode or when Postgres is unreachable.
+func TestDevAppSchema_PerAppIsolation_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -44,52 +69,77 @@ func TestApplyDevMigrations_Integration(t *testing.T) {
 
 	sqlFS := fstest.MapFS{
 		"sql/app/0001_init.up.sql": &fstest.MapFile{
-			Data: []byte(`CREATE TABLE IF NOT EXISTS dev_migrate_test_items (id text PRIMARY KEY)`),
+			Data: []byte(`CREATE TABLE IF NOT EXISTS dev_iso_items (id text PRIMARY KEY)`),
 		},
 	}
 
-	m, err := New(Config{ID: "devmigtest", Name: "Dev Migrate Test", SQL: sqlFS})
+	m, err := New(Config{ID: "devisotest", Name: "Dev Iso Test", SQL: sqlFS})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 
 	ctx := context.Background()
-	if err := m.applyDevMigrations(ctx); err != nil {
+	pool, release, err := m.resolvePool(ctx)
+	if err != nil {
+		t.Skipf("skipping (no postgres on :5433): %v", err)
+	}
+	defer release()
+	if err := pool.Ping(ctx); err != nil {
 		t.Skipf("skipping (no postgres on :5433): %v", err)
 	}
 
-	// Second call should be a no-op (tracking table records the prior run).
-	// If Apply runs again on an idempotent migration the test still passes;
-	// if it ran on a non-idempotent migration it would fail — the point
-	// is to assert the no-op path is taken, which we observe by reading
-	// the tracking table.
-	if err := m.applyDevMigrations(ctx); err != nil {
-		t.Fatalf("second applyDevMigrations: %v", err)
+	schemaA, _ := devAppSchemaName("11111111-1111-1111-1111-111111111111")
+	schemaB, _ := devAppSchemaName("22222222-2222-2222-2222-222222222222")
+	ident := func(s string) string { return pgx.Identifier{s}.Sanitize() }
+
+	cleanup := func() {
+		for _, s := range []string{schemaA, schemaB} {
+			if _, err := pool.Exec(ctx, `DROP SCHEMA IF EXISTS `+ident(s)+` CASCADE`); err != nil {
+				t.Logf("cleanup %s: %v", s, err)
+			}
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// Lazily provision both apps, as the dev middleware does on first request.
+	if err := m.ensureDevAppSchema(ctx, schemaA); err != nil {
+		t.Fatalf("provision %s: %v", schemaA, err)
+	}
+	if err := m.ensureDevAppSchema(ctx, schemaB); err != nil {
+		t.Fatalf("provision %s: %v", schemaB, err)
 	}
 
-	pool, release, err := m.resolvePool(ctx)
-	if err != nil {
-		t.Fatalf("resolvePool: %v", err)
+	// Write a row through app A's schema; app B must NOT see it.
+	if _, err := pool.Exec(ctx, fmt.Sprintf(`INSERT INTO %s.dev_iso_items(id) VALUES('a1')`, ident(schemaA))); err != nil {
+		t.Fatalf("insert into %s: %v", schemaA, err)
 	}
-	defer release()
+	countIn := func(schema string) int {
+		var n int
+		if err := pool.QueryRow(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.dev_iso_items`, ident(schema))).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", schema, err)
+		}
+		return n
+	}
+	if got := countIn(schemaA); got != 1 {
+		t.Errorf("app A rows = %d, want 1", got)
+	}
+	if got := countIn(schemaB); got != 0 {
+		t.Errorf("app B rows = %d, want 0 — per-app isolation breach", got)
+	}
 
-	var count int
+	// Re-provisioning A is a cached no-op and the tracking table holds exactly
+	// one row for the applied migration.
+	if err := m.ensureDevAppSchema(ctx, schemaA); err != nil {
+		t.Fatalf("re-provision %s: %v", schemaA, err)
+	}
+	var trk int
 	if err := pool.QueryRow(ctx,
-		`SELECT count(*) FROM __ms_local.schema_migrations WHERE scope = 'app' AND version = '0001'`,
-	).Scan(&count); err != nil {
+		fmt.Sprintf(`SELECT count(*) FROM %s.schema_migrations WHERE scope = 'app' AND version = '0001'`, ident(schemaA)),
+	).Scan(&trk); err != nil {
 		t.Fatalf("read tracking row: %v", err)
 	}
-	if count != 1 {
-		t.Errorf("expected exactly 1 tracking row for app/0001, got %d", count)
-	}
-
-	// Cleanup so reruns are deterministic.
-	if _, err := pool.Exec(ctx, `DROP TABLE IF EXISTS dev_migrate_test_items`); err != nil {
-		t.Logf("cleanup table: %v", err)
-	}
-	if _, err := pool.Exec(ctx,
-		`DELETE FROM __ms_local.schema_migrations WHERE scope = 'app' AND version = '0001'`,
-	); err != nil {
-		t.Logf("cleanup tracking: %v", err)
+	if trk != 1 {
+		t.Errorf("expected exactly 1 tracking row for app/0001 in %s, got %d", schemaA, trk)
 	}
 }

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -116,6 +116,71 @@ type Module struct {
 	sqsClient      *msqs.Client         // nil in dev mode (MS_TASK_QUEUE_URL unset)
 	signingKey     []byte               // HMAC key for TaskMessage signing (MS_TASK_SIGNING_KEY)
 	meterClient    *meter.Client        // prod (MS_METER_LAMBDA_ARN set) or dev-mode stderr
+
+	// devMode is true under `mirrorstack dev` (HTTP serving + dev DB), false in
+	// Lambda/task-worker. It gates the dev-only per-app schema machinery:
+	// production injects the app schema via the Lambda shim, dev derives it from
+	// X-MS-App-ID here. Captured once at New().
+	devMode bool
+	// devProvision caches per-app schema provisioning (schema string ->
+	// *devProvisionEntry) so only the first dev request for an app runs its
+	// app-scope migrations. See Module.ensureDevAppSchema.
+	devProvision sync.Map
+}
+
+// devProvisionEntry guards one app schema's lazy provisioning. The sync.Once
+// serializes concurrent first-touch requests; err caches the outcome.
+type devProvisionEntry struct {
+	once sync.Once
+	err  error
+}
+
+// devAppSchemaPattern validates a derived dev app schema name. It matches the
+// runtime's production AppSchema pattern so dev and prod agree on the shape,
+// and guards the identifier before it reaches SQL (pgx.Identifier.Sanitize is
+// the second line of defense).
+var devAppSchemaPattern = regexp.MustCompile(`^app_[a-z0-9_]+$`)
+
+// devAppSchemaName derives the per-app Postgres schema from an app id, matching
+// the platform's ids.AppSchemaName convention (app_<uuid-with-underscores>).
+// Returns ok=false if the result is not a valid schema identifier.
+func devAppSchemaName(appID string) (string, bool) {
+	schema := "app_" + strings.ReplaceAll(strings.ToLower(appID), "-", "_")
+	if !devAppSchemaPattern.MatchString(schema) {
+		return "", false
+	}
+	return schema, true
+}
+
+// devAppSchemaMiddleware is the dev analog of the Lambda shim's per-request
+// AppSchema injection (see runtime.InjectResources). For requests carrying an
+// app identity (X-MS-App-ID, forwarded by dispatch) it derives app_<id>,
+// provisions it lazily on first touch, and injects it via db.WithSchema so
+// Module.DB/Module.Tx scope to that app's schema. Attached only in devMode; in
+// production the schema is already in context and the X-MS-* headers are
+// stripped, so this never runs there.
+func (m *Module) devAppSchemaMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appID := r.Header.Get(auth.HeaderAppID)
+		if appID == "" || db.SchemaFrom(r.Context()) != "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		schema, ok := devAppSchemaName(appID)
+		if !ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Provision off the request context: migrations must not be cancelled by
+		// a client disconnect, and the cached result must not memoize a
+		// cancellation error for every later request.
+		if err := m.ensureDevAppSchema(context.Background(), schema); err != nil {
+			m.logger.Printf("dev: provision app schema %s: %v", schema, err)
+			httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: "app schema provisioning failed"})
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(db.WithSchema(r.Context(), schema)))
+	})
 }
 
 // moduleIDPattern matches valid module IDs: lowercase letter, then lowercase alphanumerics/underscores, max 36 chars.
@@ -169,6 +234,16 @@ func New(cfg Config) (*Module, error) {
 	// cross-origin requests from random origins shouldn't be allowed.
 	if os.Getenv("MS_INTERNAL_SECRET") == "" {
 		m.router.Use(localDevCORS)
+	}
+
+	// Dev per-app schema injection: under `mirrorstack dev` the platform's
+	// Lambda shim is absent, so the SDK derives app_<id> from X-MS-App-ID and
+	// provisions it lazily (see devAppSchemaMiddleware). Attached before routes
+	// are mounted so it wraps every scope, including the system /__mirrorstack/*
+	// surfaces (e.g. /contrib) that also operate on per-app data.
+	m.devMode = m.devMigrateEnabled()
+	if m.devMode {
+		m.router.Use(m.devAppSchemaMiddleware)
 	}
 
 	// Eagerly initialize SQS client when queue URL is configured.
@@ -472,7 +547,12 @@ func (m *Module) Start() error {
 	// guard keeps modules that never use Provide from
 	// touching their DB for an empty feature. Production schema
 	// management lands via the lifecycle install hook in a follow-up.
-	if m.contribReg.Len() > 0 {
+	//
+	// Skipped in devMode: the store is per-app, so it is created per app schema
+	// during lazy provisioning (provisionDevAppSchema) rather than once in the
+	// connection's default schema here — otherwise it would land in the wrong
+	// (shared) place and every app's contributions would collide.
+	if !m.devMode && m.contribReg.Len() > 0 {
 		q, release, err := m.DB(context.Background())
 		if err != nil {
 			return fmt.Errorf("mirrorstack: contributions: open DB: %w", err)


### PR DESCRIPTION
## Problem

In `mirrorstack dev`, every app shared one module data store. oauth-core's users lived in `public.m<id>_users`, and **every app read/wrote that one table** — so `/apps/test/oauth-core` and `/apps/twkpa-edu/oauth-core` listed identical users. Platform tables are correctly isolated (`app_<uuid>` schemas in the platform DB); module tables were not. Isolation was broken in dev only — production is correct.

### Root cause (two dev-only gaps)

1. **Provisioning** — `dev_migrate.go` ran app-scope migrations once into `public` at startup (`devAppSchema = "public"`). No per-app schema was ever created in the module's dev Postgres.
2. **Request scoping** — production injects `app_<uuid>` per request from the Lambda payload (`runtime.InjectResources`). Dev had no equivalent: `X-MS-App-ID` reached the auth context but nothing called `db.WithSchema`, so `m.Tx`/`m.DB` fell back to the `public` search_path.

## Fix — make dev mirror prod

- **Defer app-scope migrations** from startup to lazy, **per-app** provisioning into `app_<id>` on first request. Module scope still migrates into `mod_<id>` at startup. Each schema tracks its own migrations (so a second app re-runs them into its own schema instead of being skipped as already-applied).
- **Dev request middleware** derives `app_<id>` from `X-MS-App-ID` and injects it via `db.WithSchema` — the dev analog of the Lambda shim. Attached only in dev (`devMode`); in production the schema is already in context and `X-MS-*` headers are stripped, so it never runs there.
- **Contributions table** is created per app schema during provisioning (it's a per-app store read via `Module.DB`), and the startup shared-schema creation is skipped in dev.

`app_<id>` naming matches the platform's `ids.AppSchemaName` convention, and is validated + `pgx.Identifier.Sanitize`d before reaching SQL.

## Verification

- `go build ./... && go vet ./...` green; `go test -short ./...` green (one pre-existing unrelated `refcache` singleflight flake).
- New **integration test** `TestDevAppSchema_PerAppIsolation_Integration` (runs against the dev Postgres on :5433): provisions two apps, writes a row through app A, asserts app B sees **zero** rows — the direct regression guard for this bug. Passes.
- New `TestDevAppSchemaName` unit test.

## Note on existing data

The fix isolates **going forward**. Rows already sitting in the shared `public.m<id>_*` tables become orphaned (each app now reads its own empty `app_<id>` schema). They can be dropped after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)