### PR TITLE
refactor(sdk): simplify dev per-app schema follow-ups

### DIFF
--- a/internal/core/dev_migrate.go
+++ b/internal/core/dev_migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -50,6 +51,13 @@ func (m *Module) applyDevMigrations(ctx context.Context) error {
 	return m.ensureSchemaMigrated(ctx, migration.ScopeModule, "mod_"+m.config.ID)
 }
 
+// devProvisionEntry guards one app schema's lazy provisioning. The sync.Once
+// serializes concurrent first-touch requests; err caches the outcome.
+type devProvisionEntry struct {
+	once sync.Once
+	err  error
+}
+
 // ensureDevAppSchema lazily creates + migrates the per-app schema app_<id> the
 // first time a request for that app arrives in dev. Idempotent and cached per
 // process: only the first request for a given schema pays the migration cost;
@@ -57,6 +65,9 @@ func (m *Module) applyDevMigrations(ctx context.Context) error {
 // per-schema sync.Once also serializes concurrent first-touch requests so the
 // migrations run exactly once.
 func (m *Module) ensureDevAppSchema(ctx context.Context, schema string) error {
+	// The loaded bool is intentionally discarded: LoadOrStore returns the
+	// canonical entry whether we created it or won the race for an existing
+	// one, and sync.Once makes provisioning run exactly once regardless.
 	v, _ := m.devProvision.LoadOrStore(schema, &devProvisionEntry{})
 	entry := v.(*devProvisionEntry)
 	entry.once.Do(func() { entry.err = m.provisionDevAppSchema(ctx, schema) })

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -128,25 +128,15 @@ type Module struct {
 	devProvision sync.Map
 }
 
-// devProvisionEntry guards one app schema's lazy provisioning. The sync.Once
-// serializes concurrent first-touch requests; err caches the outcome.
-type devProvisionEntry struct {
-	once sync.Once
-	err  error
-}
-
-// devAppSchemaPattern validates a derived dev app schema name. It matches the
-// runtime's production AppSchema pattern so dev and prod agree on the shape,
-// and guards the identifier before it reaches SQL (pgx.Identifier.Sanitize is
-// the second line of defense).
-var devAppSchemaPattern = regexp.MustCompile(`^app_[a-z0-9_]+$`)
-
 // devAppSchemaName derives the per-app Postgres schema from an app id, matching
 // the platform's ids.AppSchemaName convention (app_<uuid-with-underscores>).
-// Returns ok=false if the result is not a valid schema identifier.
+// It validates against the same pattern the production Lambda shim uses
+// (runtime.AppSchemaPattern) so dev and prod agree on the shape;
+// pgx.Identifier.Sanitize is the second line of defense before SQL. Returns
+// ok=false if the result is not a valid schema identifier.
 func devAppSchemaName(appID string) (string, bool) {
 	schema := "app_" + strings.ReplaceAll(strings.ToLower(appID), "-", "_")
-	if !devAppSchemaPattern.MatchString(schema) {
+	if !runtime.AppSchemaPattern.MatchString(schema) {
 		return "", false
 	}
 	return schema, true
@@ -536,7 +526,7 @@ func (m *Module) Start() error {
 		return m.startTaskWorker()
 	}
 
-	if m.devMigrateEnabled() {
+	if m.devMode {
 		if err := m.applyDevMigrations(context.Background()); err != nil {
 			return err
 		}

--- a/internal/runtime/inject.go
+++ b/internal/runtime/inject.go
@@ -37,7 +37,7 @@ var validRoles = map[string]bool{
 // Returns an error if AppSchema is non-empty and does not match the expected
 // pattern, or if AppRole is not a recognized platform role.
 func InjectResources(ctx context.Context, p InjectParams) (context.Context, error) {
-	if p.AppSchema != "" && !schemaPattern.MatchString(p.AppSchema) {
+	if p.AppSchema != "" && !AppSchemaPattern.MatchString(p.AppSchema) {
 		return ctx, fmt.Errorf("mirrorstack: invalid app schema format %q", p.AppSchema)
 	}
 	if !validRoles[p.AppRole] {

--- a/internal/runtime/lambda.go
+++ b/internal/runtime/lambda.go
@@ -15,7 +15,11 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 )
 
-var schemaPattern = regexp.MustCompile(`^app_[a-z0-9_]+$`)
+// AppSchemaPattern validates a per-app Postgres schema name (app_<uuid> with
+// hyphens replaced by underscores). Exported so the dev runtime, which derives
+// the schema from X-MS-App-ID instead of receiving it in the Lambda payload,
+// validates it identically — keeping dev and prod from drifting on the shape.
+var AppSchemaPattern = regexp.MustCompile(`^app_[a-z0-9_]+$`)
 
 // Resources holds per-invocation credentials for all platform services.
 type Resources struct {


### PR DESCRIPTION
Post-merge `/simplify` cleanups on top of #113. **No behavior change.**

- **Reuse:** export `runtime.AppSchemaPattern` and validate the dev-derived app schema against it, replacing a byte-identical local regex in `internal/core`. Prevents dev and prod schema-name validation from silently drifting.
- **Altitude/efficiency:** use the cached `m.devMode` at the `Start()` migration gate instead of re-calling `devMigrateEnabled()` (which re-reads env + `runtime.IsLambda`/`IsTaskWorker` each time).
- **Tidy:** move `devProvisionEntry` next to its only consumers in `dev_migrate.go`; document the intentionally-discarded `LoadOrStore` bool.

### Rejected from the simplify pass
The efficiency agent suggested skipping `CREATE SCHEMA` when a module has no app migrations. **Not applied** — it would break modules that declare contribution slots but ship no app migrations: `provisionDevAppSchema` creates the contributions table inside `app_<id>`, which must exist first.

### Verification
`go build`, `go vet`, `go test -short ./...` green (one pre-existing unrelated `refcache` singleflight flake). The `TestDevAppSchema_PerAppIsolation_Integration` regression guard still passes against the dev Postgres on :5433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)