### PR TITLE
feat(mcp): per-tool permission option for MCP tools

### DIFF
--- a/internal/core/mcp.go
+++ b/internal/core/mcp.go
@@ -11,13 +11,34 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/system"
 )
 
+// MCPToolOption configures an MCPTool declaration. The variadic seam carries
+// future per-tool knobs (e.g. risk tier) without breaking existing callers.
+type MCPToolOption func(*mcpToolConfig)
+
+type mcpToolConfig struct {
+	permission string // SHORT permission name; slug-qualified at registration
+}
+
+// ToolPermission gates the tool on a module permission, looked up by SHORT
+// name and slug-qualified exactly like RegisterPermission. The platform lists
+// and invokes the tool only for callers whose effective permissions include
+// it.
+//
+// Safe-by-default: if the name was never RegisterPermission'd, it is
+// registered lazily as ADMIN-ONLY (a dev warning is logged) so a typo locks
+// the tool down rather than opening it — same rule as RequirePermission.
+func ToolPermission(name string) MCPToolOption {
+	return func(c *mcpToolConfig) { c.permission = name }
+}
+
 // MCPTool registers an agent-callable tool on the default module. Input and
 // output JSON Schemas are derived from the In and Out type parameters via
 // reflection; struct fields use their `json:"..."` tags. The handler receives
 // parsed typed args and returns a typed result.
 //
 // Name must satisfy registry.ValidateName (no path separators, whitespace, or
-// null bytes). First-wins: a duplicate registration is a no-op.
+// null bytes). First-wins: a duplicate registration is a no-op (including its
+// options).
 //
 // The tool is served at POST /__mirrorstack/mcp/tools/call under Internal
 // scope. The platform aggregates tools from all installed modules into a
@@ -34,8 +55,10 @@ import (
 // derived at registration via reflection and validated against incoming JSON
 // at call time (NOT statically against the wire format).
 //
+// Optional MCPToolOptions scope the tool, e.g. ms.ToolPermission("users.read").
+//
 // Panics before Init or on schema derivation failure.
-func MCPTool[In, Out any](name, description string, handler func(ctx context.Context, args In) (Out, error)) {
+func MCPTool[In, Out any](name, description string, handler func(ctx context.Context, args In) (Out, error), opts ...MCPToolOption) {
 	m := mustDefault("MCPTool")
 	inputSchema, err := deriveSchema[In]()
 	if err != nil {
@@ -45,13 +68,21 @@ func MCPTool[In, Out any](name, description string, handler func(ctx context.Con
 	if err != nil {
 		panic("mirrorstack: MCPTool(" + name + ") output schema derivation failed: " + err.Error())
 	}
-	m.registry.AddMCPTool(registry.MCPToolDecl{
+	var cfg mcpToolConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	decl := registry.MCPToolDecl{
 		Name:         name,
 		Description:  description,
 		InputSchema:  inputSchema,
 		OutputSchema: outputSchema,
 		Handler:      wrapMCPToolHandler(handler),
-	})
+	}
+	if cfg.permission != "" {
+		decl.Permission, _ = m.ensurePermissionDeclared("MCPTool", cfg.permission)
+	}
+	m.registry.AddMCPTool(decl)
 }
 
 // MCPResource registers an agent-readable resource on the default module. The

--- a/internal/core/mcp_test.go
+++ b/internal/core/mcp_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/mirrorstack-ai/app-module-sdk/roles"
 	"github.com/mirrorstack-ai/app-module-sdk/system"
 )
 
@@ -113,6 +115,143 @@ func TestMCPResource_RegistersAndReadsViaRoute(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"healthy":true`) {
 		t.Errorf("body = %s, want content with healthy:true", rec.Body.String())
+	}
+}
+
+// newSluggedTestModule is newTestModuleWithSecret with a slug, for tests that
+// exercise permission qualification ("<slug>.<name>").
+func newSluggedTestModule(t *testing.T, id, slug string) *Module {
+	t.Helper()
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	m, err := New(Config{ID: id, Slug: slug})
+	if err != nil {
+		t.Fatalf("New(%q): %v", id, err)
+	}
+	return m
+}
+
+func TestMCPTool_ToolPermissionQualifiesAndProjects(t *testing.T) {
+	resetDefault(t)
+	m := newSluggedTestModule(t, "demo", "demo")
+	defaultModule = m
+
+	RegisterPermission("users.read", PermissionOpts{DefaultRole: roles.Viewer()})
+	MCPTool("list-users", "List users", func(ctx context.Context, a greetArgs) (greetResult, error) {
+		return greetResult{}, nil
+	}, ToolPermission("users.read"))
+
+	tool, ok := m.registry.MCPTool("list-users")
+	if !ok {
+		t.Fatal("tool not registered")
+	}
+	if tool.Permission != "demo.users.read" {
+		t.Errorf("decl.Permission = %q, want %q (slug-qualified)", tool.Permission, "demo.users.read")
+	}
+
+	// Manifest projection carries the qualified name.
+	payload := fetchManifest(t, m)
+	if len(payload.MCP.Tools) != 1 || payload.MCP.Tools[0].Permission != "demo.users.read" {
+		t.Errorf("manifest.mcp.tools = %+v, want permission demo.users.read", payload.MCP.Tools)
+	}
+	// The declared role set survives — ToolPermission must not clobber the
+	// RegisterPermission'd roles with the lazy admin-only fallback.
+	var declaredRoles []string
+	for _, p := range payload.Permissions {
+		if p.Name == "demo.users.read" {
+			declaredRoles = p.Roles
+		}
+	}
+	if !slices.Contains(declaredRoles, roles.Viewer().Key) {
+		t.Errorf("manifest.permissions[demo.users.read].roles = %v, want viewer preserved", declaredRoles)
+	}
+
+	// tools/list wire stays in lockstep with the manifest.
+	req := httptest.NewRequest("GET", "/__mirrorstack/mcp/tools/list", nil)
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), `"permission":"demo.users.read"`) {
+		t.Errorf("tools/list body = %s, want permission field", rec.Body.String())
+	}
+}
+
+func TestMCPTool_NoPermissionOmitsField(t *testing.T) {
+	resetDefault(t)
+	m := newTestModuleWithSecret(t, "demo")
+	defaultModule = m
+
+	MCPTool("greet", "Say hi", func(ctx context.Context, a greetArgs) (greetResult, error) {
+		return greetResult{}, nil
+	})
+
+	// omitempty: the tool entry must not carry a "permission" key at all.
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	var raw struct {
+		MCP struct {
+			Tools []map[string]json.RawMessage `json:"tools"`
+		} `json:"mcp"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw manifest: %v", err)
+	}
+	if len(raw.MCP.Tools) != 1 {
+		t.Fatalf("mcp.tools = %+v, want 1 entry", raw.MCP.Tools)
+	}
+	if _, present := raw.MCP.Tools[0]["permission"]; present {
+		t.Errorf("tool entry carries a permission key without ToolPermission: %v", raw.MCP.Tools[0])
+	}
+}
+
+func TestMCPTool_UndeclaredPermissionRegistersAdminOnly(t *testing.T) {
+	resetDefault(t)
+	m := newSluggedTestModule(t, "demo", "demo")
+	defaultModule = m
+
+	// No RegisterPermission — a typo'd name must fail CLOSED (admin-only),
+	// never open, and still land in manifest.permissions so the platform's
+	// roles projection resolves.
+	MCPTool("nuke", "Dangerous", func(ctx context.Context, a greetArgs) (greetResult, error) {
+		return greetResult{}, nil
+	}, ToolPermission("ghost.perm"))
+
+	tool, _ := m.registry.MCPTool("nuke")
+	if tool.Permission != "demo.ghost.perm" {
+		t.Errorf("decl.Permission = %q, want %q", tool.Permission, "demo.ghost.perm")
+	}
+	payload := fetchManifest(t, m)
+	found := false
+	for _, p := range payload.Permissions {
+		if p.Name == "demo.ghost.perm" {
+			found = true
+			if len(p.Roles) != 1 || p.Roles[0] != roles.Admin().Key {
+				t.Errorf("lazy permission roles = %v, want [admin]", p.Roles)
+			}
+			if p.DefaultRole != roles.Admin().Key {
+				t.Errorf("lazy permission default role = %q, want admin", p.DefaultRole)
+			}
+		}
+	}
+	if !found {
+		t.Error("manifest.permissions missing demo.ghost.perm (lazy registration did not fire)")
+	}
+}
+
+func TestMCPTool_DuplicateKeepsFirstPermission(t *testing.T) {
+	resetDefault(t)
+	m := newSluggedTestModule(t, "demo", "demo")
+	defaultModule = m
+
+	RegisterPermission("a", PermissionOpts{DefaultRole: roles.Viewer()})
+	RegisterPermission("b", PermissionOpts{DefaultRole: roles.Viewer()})
+	handler := func(ctx context.Context, a greetArgs) (greetResult, error) {
+		return greetResult{}, nil
+	}
+	MCPTool("greet", "first", handler, ToolPermission("a"))
+	MCPTool("greet", "second", handler, ToolPermission("b"))
+
+	tool, _ := m.registry.MCPTool("greet")
+	if tool.Permission != "demo.a" {
+		t.Errorf("decl.Permission = %q, want first-wins demo.a", tool.Permission)
 	}
 }
 

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -451,14 +451,23 @@ func (m *Module) RegisterPermission(name string, opts PermissionOpts) {
 // lazily as ADMIN-ONLY (an isDev warning is logged) so a forgotten declaration
 // locks the route down rather than opening it.
 func (m *Module) RequirePermission(name string) func(http.Handler) http.Handler {
+	_, declared := m.ensurePermissionDeclared("RequirePermission", name)
+	// Runtime: admin always passes, plus the declared roles.
+	return auth.RequireRoles(append([]string{roles.Admin().Key}, declared...)...)
+}
+
+// ensurePermissionDeclared slug-qualifies name and returns the qualified name
+// plus the declared role set. Lazy admin-only registration: a surface gated on
+// an undeclared permission must NOT silently open, so a missing
+// RegisterPermission registers the name admin-only (a dev warning names the
+// calling surface so the author notices). Shared by RequirePermission and
+// MCPTool's ToolPermission option.
+func (m *Module) ensurePermissionDeclared(caller, name string) (string, []string) {
 	qualified := qualifyPermissionName(m.config.Slug, name)
 	declared, ok := m.registry.PermissionRoles(qualified)
 	if !ok {
-		// Lazy admin-only registration: a route gated on an undeclared
-		// permission must NOT silently open. Warn in dev so the author
-		// notices the missing RegisterPermission.
 		if !runtime.IsLambda() {
-			m.logger.Printf("RequirePermission(%q): no RegisterPermission found — defaulting to admin-only. Declare it via ms.RegisterPermission.", name)
+			m.logger.Printf("%s(%q): no RegisterPermission found — defaulting to admin-only. Declare it via ms.RegisterPermission.", caller, name)
 		}
 		m.registry.AddPermissionWithMeta(registry.Permission{
 			Name:        qualified,
@@ -467,8 +476,7 @@ func (m *Module) RequirePermission(name string) func(http.Handler) http.Handler 
 		})
 		declared = []string{roles.Admin().Key}
 	}
-	// Runtime: admin always passes, plus the declared roles.
-	return auth.RequireRoles(append([]string{roles.Admin().Key}, declared...)...)
+	return qualified, declared
 }
 
 // qualifyPermissionName prepends "<slug>." to name. No-op if name is

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -136,7 +136,11 @@ type MCPToolDecl struct {
 	Description  string          `json:"description"`
 	InputSchema  json.RawMessage `json:"inputSchema"`
 	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
-	Handler      MCPToolHandler  `json:"-"`
+	// Permission is the slug-qualified module permission gating the tool
+	// (ms.ToolPermission). Empty means none declared — the platform falls
+	// back to its membership floor.
+	Permission string         `json:"permission,omitempty"`
+	Handler    MCPToolHandler `json:"-"`
 }
 
 // MCPResourceDecl is a registered MCP resource.

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -310,10 +310,23 @@ func RegisterUI(ui ModuleUI) { core.RegisterUI(ui) }
 
 // --- Agent surface (MCP) ---
 
+// MCPToolOption configures an MCPTool declaration (e.g. ToolPermission).
+type MCPToolOption = core.MCPToolOption
+
+// ToolPermission gates an MCP tool on a module permission (SHORT name,
+// slug-qualified exactly like RegisterPermission). The platform lists and
+// invokes the tool only for callers whose effective permissions include it.
+// An undeclared name registers lazily as admin-only (fail closed).
+//
+//	ms.RegisterPermission("users.read", ms.PermissionOpts{DefaultRole: roles.Viewer()})
+//	ms.MCPTool("list-users", "List users", listUsers, ms.ToolPermission("users.read"))
+func ToolPermission(name string) MCPToolOption { return core.ToolPermission(name) }
+
 // MCPTool registers an agent-callable tool on the default module with JSON
-// Schema derived from the type parameters via reflection.
-func MCPTool[In, Out any](name, description string, handler func(ctx context.Context, args In) (Out, error)) {
-	core.MCPTool[In, Out](name, description, handler)
+// Schema derived from the type parameters via reflection. Optional
+// MCPToolOptions scope the tool, e.g. ms.ToolPermission("users.read").
+func MCPTool[In, Out any](name, description string, handler func(ctx context.Context, args In) (Out, error), opts ...MCPToolOption) {
+	core.MCPTool[In, Out](name, description, handler, opts...)
 }
 
 // MCPResource registers an agent-readable resource on the default module.

--- a/system/mcp.go
+++ b/system/mcp.go
@@ -27,6 +27,7 @@ func toolEntries(decls []registry.MCPToolDecl) []MCPToolEntry {
 		out[i] = MCPToolEntry{
 			Name: t.Name, Description: t.Description,
 			InputSchema: t.InputSchema, OutputSchema: t.OutputSchema,
+			Permission: t.Permission,
 		}
 	}
 	return out
@@ -128,6 +129,9 @@ type MCPToolEntry struct {
 	Description  string          `json:"description"`
 	InputSchema  json.RawMessage `json:"inputSchema"`
 	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
+	// Permission mirrors MCPToolDecl.Permission: the slug-qualified module
+	// permission required to see and call the tool; absent when none declared.
+	Permission string `json:"permission,omitempty"`
 }
 
 // MCPResourceEntry is the JSON wire shape for a resource.

--- a/system/mcp_test.go
+++ b/system/mcp_test.go
@@ -50,6 +50,42 @@ func TestMCPToolsList_EmitsRegisteredTools(t *testing.T) {
 	}
 }
 
+func TestMCPToolsList_CarriesPermission(t *testing.T) {
+	t.Parallel()
+
+	reg := newMCPReg(t)
+	reg.AddMCPTool(registry.MCPToolDecl{
+		Name: "gated", Description: "Needs a permission",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Permission:  "demo.users.read",
+	})
+	reg.AddMCPTool(registry.MCPToolDecl{
+		Name: "open", Description: "No permission",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	})
+
+	req := httptest.NewRequest("GET", "/tools/list", nil)
+	rec := httptest.NewRecorder()
+	MCPToolsListHandler(reg).ServeHTTP(rec, req)
+
+	var body struct {
+		Tools []map[string]json.RawMessage `json:"tools"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Tools) != 2 {
+		t.Fatalf("len(tools) = %d, want 2", len(body.Tools))
+	}
+	if got := string(body.Tools[0]["permission"]); got != `"demo.users.read"` {
+		t.Errorf("gated tool permission = %s, want \"demo.users.read\"", got)
+	}
+	// omitempty: a tool without a declared permission must not carry the key.
+	if _, present := body.Tools[1]["permission"]; present {
+		t.Errorf("open tool carries a permission key: %v", body.Tools[1])
+	}
+}
+
 func TestMCPToolsCall_InvokesHandler(t *testing.T) {
 	t.Parallel()
 
@@ -247,6 +283,7 @@ func TestManifest_IncludesMCP(t *testing.T) {
 	reg.AddMCPTool(registry.MCPToolDecl{
 		Name: "greet", Description: "Say hi",
 		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Permission:  "demo.users.read",
 	})
 	reg.AddMCPResource(registry.MCPResourceDecl{
 		Name: "status", Description: "Status",
@@ -262,6 +299,9 @@ func TestManifest_IncludesMCP(t *testing.T) {
 	}
 	if len(got.MCP.Tools) != 1 || got.MCP.Tools[0].Name != "greet" {
 		t.Errorf("manifest.mcp.tools = %+v", got.MCP.Tools)
+	}
+	if got.MCP.Tools[0].Permission != "demo.users.read" {
+		t.Errorf("manifest.mcp.tools[0].permission = %q, want demo.users.read", got.MCP.Tools[0].Permission)
 	}
 	if len(got.MCP.Resources) != 1 || got.MCP.Resources[0].Name != "status" {
 		t.Errorf("manifest.mcp.resources = %+v", got.MCP.Resources)
@@ -312,7 +352,7 @@ func TestMCPToolsCall_200HasCorrectContentType(t *testing.T) {
 // Guard: the handler struct in mcp.go must be reachable from the wire-facing
 // MCPToolEntry shape (tests above rely on json roundtrip). Keep the _ = trick
 // to surface unused-field refactors early.
-var _ = MCPToolEntry{Name: "", Description: "", InputSchema: nil, OutputSchema: nil}
+var _ = MCPToolEntry{Name: "", Description: "", InputSchema: nil, OutputSchema: nil, Permission: ""}
 var _ = MCPResourceEntry{Name: "", Description: "", Schema: nil}
 
 // Ensure handler interface matches registry decl at build time.


### PR DESCRIPTION
## Why

MCP M2 requires modules to gate individual MCP tools on a module permission so the platform can project tool access into permission_roles. The SDK previously had no way to attach a permission to an MCP tool declaration — this adds that seam, per docs-temp/mcp-m0-m2/design.md §4.1.

## What

- `internal/registry/registry.go`: `MCPToolDecl` gains `Permission string` (json `permission,omitempty`).
- `system/mcp.go`: `MCPToolEntry` gains the same field; `toolEntries` copies it, so the manifest (`buildManifestMCP`) and `GET /__mirrorstack/mcp/tools/list` stay in lockstep automatically.
- `internal/core/mcp.go`: new `MCPToolOption` variadic seam + `ToolPermission(name)`; `MCPTool` signature gains `opts ...MCPToolOption` (source-compatible). When set, the short name is slug-qualified and resolved via the shared helper.
- `internal/core/module.go`: extracted `Module.ensurePermissionDeclared(caller, name)` from `RequirePermission` (identical behavior/warning format) and shared it with `MCPTool` — undeclared/typo'd names lazily register ADMIN-ONLY (fail closed) so `manifest.permissions[]` always contains every tool permission.
- `mirrorstack.go`: re-exports `MCPToolOption` (alias) and `ToolPermission`; `MCPTool` wrapper threads opts through.

Backward compatible: modules without the option compile unchanged and emit byte-identical manifests.

## Tests

- core: option qualifies + projects to decl/manifest/tools-list while preserving RegisterPermission'd roles; omitted option emits no `permission` key (raw-JSON omitempty check); lazy admin-only registration fires (roles=[admin], defaultRole=admin); first-wins duplicate keeps the first permission.
- system: tools/list carries permission and omits it when empty; manifest round-trip carries it; wire-shape guard updated.
- Verification: `go build ./...` + `go vet ./...` + `go test ./internal/core/... ./internal/registry/... ./system/...` all green.

## Review

0 findings triaged: 0 applied, 0 skipped.

Design doc: docs-temp/mcp-m0-m2/design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)