### PR TITLE
fix(mcp): inline tool schemas so inputSchema is type:object

### DIFF
--- a/internal/core/mcp.go
+++ b/internal/core/mcp.go
@@ -104,7 +104,12 @@ func MCPResource[Out any](name, description string, handler func(ctx context.Con
 
 func deriveSchema[T any]() (json.RawMessage, error) {
 	var zero T
-	return json.Marshal(jsonschema.Reflect(zero))
+	// DoNotReference inlines the struct schema so the top level is a concrete
+	// {"type":"object",...} rather than invopop's default {"$ref":"#/$defs/..."}.
+	// The MCP spec requires inputSchema/outputSchema to be an object schema with
+	// type:"object"; a top-level $ref makes clients reject the whole tools/list.
+	r := &jsonschema.Reflector{DoNotReference: true}
+	return json.Marshal(r.Reflect(zero))
 }
 
 // wrapMCPToolHandler adapts a typed handler into the type-erased registry form.


### PR DESCRIPTION
## Problem
`deriveSchema` (used by `MCPTool`/`MCPResource`) marshalled `jsonschema.Reflect(zero)`, whose default output is a top-level `{"$ref":"#/$defs/<Type>"}` with the actual object schema under `$defs`.

The MCP spec requires a tool's `inputSchema`/`outputSchema` to be an object schema with `type: "object"`. A top-level `$ref` makes MCP clients (e.g. Claude Code) reject the **entire** `tools/list` with `Invalid input: expected "object"` — so one module's tools break every module's tools for that account.

## Fix
Use `&jsonschema.Reflector{DoNotReference: true}` so the struct schema inlines as a concrete `{"type":"object","properties":{...}}`. Nested types still inline correctly.

## Impact
Any module declaring `ms.MCPTool`/`ms.MCPResource` now emits spec-valid schemas; existing catalogs re-sync to valid schemas on next install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)