### PR TITLE
fix(db): make Resources.DB sslmode configurable (dev-sim TLS)

### DIFF
--- a/db/pool_cache.go
+++ b/db/pool_cache.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -72,9 +73,16 @@ func configurePoolDefaults(cfg *pgxpool.Config) {
 func createPool(ctx context.Context, cred Credential) (*pgxpool.Pool, error) {
 	// DSN intentionally excludes the password — any wrapped ParseConfig error
 	// would otherwise echo the full connection string into CloudWatch.
+	// sslmode defaults to require (prod: the RDS Proxy endpoint mandates TLS);
+	// a local dev-sim Postgres has no TLS, so the dev runner sets
+	// MS_MODULE_DB_SSLMODE=disable. Unset always resolves to the secure default.
+	sslmode := os.Getenv("MS_MODULE_DB_SSLMODE")
+	if sslmode == "" {
+		sslmode = "require"
+	}
 	connStr := fmt.Sprintf(
-		"host=%s port=%d dbname=%s user=%s sslmode=require",
-		cred.Host, cred.Port, cred.Database, cred.Username,
+		"host=%s port=%d dbname=%s user=%s sslmode=%s",
+		cred.Host, cred.Port, cred.Database, cred.Username, sslmode,
 	)
 	cfg, err := pgxpool.ParseConfig(connStr)
 	if err != nil {


### PR DESCRIPTION
## Problem
The Resources.DB pool (`db/pool_cache.go` `createPool`) hardcoded `sslmode=require`. That's correct for prod (the RDS Proxy endpoint mandates TLS), but a local dev-sim Postgres has no TLS, so every deployed-module DB connection failed with `tls error: server refused TLS connection`.

## Fix
Read `MS_MODULE_DB_SSLMODE`, defaulting to `require`. The dev runner sets `MS_MODULE_DB_SSLMODE=disable`. Unset always resolves to the secure default — prod behaviour is unchanged.

Surfaced while bringing the local stack onto merged main (the decision-13 Resources.DB vend path). Pairs with a compose change setting the env on the dev runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)