### PR TITLE
feat: resolve __MODULE_ID__ placeholder at query time, closing app-scope table-prefix ID drift

### DIFF
--- a/internal/core/db.go
+++ b/internal/core/db.go
@@ -31,7 +31,7 @@ func (m *Module) DB(ctx context.Context) (db.Querier, func(), error) {
 		releasePool()
 		return nil, nil, err
 	}
-	return m.devGuardFor(ctx, querier, db.CredentialFrom), func() {
+	return m.devGuardFor(ctx, m.withModuleID(querier), db.CredentialFrom), func() {
 		releaseConn()
 		releasePool()
 	}, nil
@@ -55,7 +55,7 @@ func (m *Module) Tx(ctx context.Context, fn func(q db.Querier) error) error {
 	}
 	defer releasePool()
 	return db.Tx(ctx, pool, func(q db.Querier) error {
-		return fn(m.devGuardFor(ctx, q, db.CredentialFrom))
+		return fn(m.devGuardFor(ctx, m.withModuleID(q), db.CredentialFrom))
 	})
 }
 

--- a/internal/core/db_placeholder.go
+++ b/internal/core/db_placeholder.go
@@ -1,0 +1,97 @@
+package core
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/mirrorstack-ai/app-module-sdk/db"
+)
+
+// This file closes the module-ID drift trap: a module's app-scope SQL
+// (migrations under sql/app/*.sql, and sqlc-generated queries compiled from
+// queries.sql) prefixes every table name with the module's catalog ID so it
+// doesn't collide with another installed module's tables in the same shared
+// app_<appID> schema. Historically that ID was baked in as literal text at
+// scaffold time — if the module is later deleted and re-registered under a
+// fresh catalog UUID, the runtime Config.ID no longer matches the ID baked
+// into the SQL/Go source, and every query targets a table that was never
+// created (or a migration creates tables under the wrong prefix entirely).
+//
+// The fix: module source (both raw .sql migrations and sqlc's queries.sql,
+// which sqlc compiles verbatim into Go string literals) uses a fixed
+// placeholder token, modulePlaceholderToken, instead of a real ID.
+// placeholderQuerier substitutes the token for the module's actual runtime
+// ID on every statement, right before it reaches the real connection —
+// wrapping every app-scope db.Querier this package hands out (migrations
+// via Module.Tx, and every sqlc-generated business query via Module.DB)
+// gives the resolved SQL to the driver with no other code needing to know
+// the placeholder exists. See withModuleID below for how this composes
+// with devGuardFor's cross-module check.
+//
+// Module-scope (mod_<id>) tables are NOT affected: that ID is a schema name
+// (mod_ + Config.ID), not a baked-in table-name prefix, so there is no
+// literal ID text in module-scope SQL to substitute. ModuleDB/ModuleTx
+// intentionally do not apply this wrapper.
+
+// modulePlaceholderToken is the fixed marker module authors' SQL sources use
+// in place of a real module ID. Chosen to be unambiguous inside SQL/Go
+// string literals and to never collide with a real platform-minted ID
+// (m<32 hex>), which contains no uppercase letters or underscores at the
+// start.
+const modulePlaceholderToken = "__MODULE_ID__"
+
+// placeholderQuerier wraps a db.Querier and rewrites modulePlaceholderToken
+// to the module's real runtime ID in every statement before delegating.
+// Config.ID is validated at module construction time against
+// moduleIDPattern (^[a-z][a-z0-9_]{0,35}$ — see module.go), which excludes
+// quotes, whitespace, and every other SQL metacharacter, so the substituted
+// value cannot break out of its position in the SQL text.
+type placeholderQuerier struct {
+	q  db.Querier
+	id string
+}
+
+func (p placeholderQuerier) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	return p.q.Exec(ctx, p.resolve(sql), args...)
+}
+
+func (p placeholderQuerier) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	return p.q.Query(ctx, p.resolve(sql), args...)
+}
+
+func (p placeholderQuerier) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	return p.q.QueryRow(ctx, p.resolve(sql), args...)
+}
+
+func (p placeholderQuerier) resolve(sql string) string {
+	if !strings.Contains(sql, modulePlaceholderToken) {
+		return sql
+	}
+	return strings.ReplaceAll(sql, modulePlaceholderToken, p.id)
+}
+
+// withModuleID wraps q so any occurrence of modulePlaceholderToken in a
+// statement's SQL text resolves to this module's real runtime ID. Applied to
+// every app-scope db.Querier this package hands out (Module.DB, Module.Tx),
+// innermost relative to devGuardFor — call sites compose it as
+// devGuardFor(ctx, withModuleID(q), ...), so devGuardFor's guardQuerier is
+// actually the OUTER layer and runs FIRST: it scans the raw statement text,
+// still containing the literal modulePlaceholderToken, before delegating to
+// this wrapper, which resolves the token last, right before the statement
+// reaches the real connection. That order is safe even though the guard
+// never sees a resolved own-table reference: the guard's cross-module
+// regexes (moduleTableRe, moduleSchemaRe) only match the platform-minted
+// m<32 hex> form, which modulePlaceholderToken can never satisfy (it has
+// uppercase letters and underscores outside the hex alphabet), so an
+// unresolved own-table reference is simply invisible to the guard rather
+// than misclassified — never a false accept or a false reject. A foreign
+// module's table reference is unaffected by any of this: it is always
+// literal real-ID text baked into the calling module's own SQL, not
+// something this wrapper ever touches, so the guard still catches it
+// exactly as before.
+func (m *Module) withModuleID(q db.Querier) db.Querier {
+	return placeholderQuerier{q: q, id: m.config.ID}
+}

--- a/internal/core/db_placeholder_test.go
+++ b/internal/core/db_placeholder_test.go
@@ -1,0 +1,124 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/mirrorstack-ai/app-module-sdk/db"
+)
+
+func TestPlaceholderQuerierResolvesToken(t *testing.T) {
+	const id = "m81b3ac7081c1409495700c761e23b59e"
+	stub := &stubQuerier{}
+	p := placeholderQuerier{q: stub, id: id}
+
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{"table name prefix", `SELECT * FROM __MODULE_ID___users WHERE id = $1`, `SELECT * FROM ` + id + `_users WHERE id = $1`},
+		{"multiple occurrences", `CREATE TABLE __MODULE_ID___a (id uuid); CREATE TABLE __MODULE_ID___b (id uuid)`, `CREATE TABLE ` + id + `_a (id uuid); CREATE TABLE ` + id + `_b (id uuid)`},
+		{"no placeholder", `SELECT 1`, `SELECT 1`},
+		{"schema qualified", `SELECT * FROM app_x.__MODULE_ID___sessions`, `SELECT * FROM app_x.` + id + `_sessions`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := p.resolve(tt.sql); got != tt.want {
+				t.Fatalf("resolve(%q) = %q, want %q", tt.sql, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlaceholderQuerierDelegatesResolvedSQL(t *testing.T) {
+	const id = "m81b3ac7081c1409495700c761e23b59e"
+	ctx := context.Background()
+
+	t.Run("Exec", func(t *testing.T) {
+		stub := &stubQuerier{}
+		p := placeholderQuerier{q: stub, id: id}
+		if _, err := p.Exec(ctx, `INSERT INTO __MODULE_ID___users (id) VALUES ($1)`); err != nil {
+			t.Fatalf("Exec err = %v, want nil", err)
+		}
+		if !stub.called {
+			t.Fatal("Exec never reached the underlying querier")
+		}
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		stub := &stubQuerier{}
+		p := placeholderQuerier{q: stub, id: id}
+		if _, err := p.Query(ctx, `SELECT * FROM __MODULE_ID___users`); err != nil {
+			t.Fatalf("Query err = %v, want nil", err)
+		}
+		if !stub.called {
+			t.Fatal("Query never reached the underlying querier")
+		}
+	})
+
+	t.Run("QueryRow", func(t *testing.T) {
+		stub := &stubQuerier{}
+		p := placeholderQuerier{q: stub, id: id}
+		_ = p.QueryRow(ctx, `SELECT 1 FROM __MODULE_ID___users`)
+		if !stub.called {
+			t.Fatal("QueryRow never reached the underlying querier")
+		}
+	})
+}
+
+// recordingQuerier is a db.Querier stub that captures the exact SQL text it
+// receives, so a test can tell resolved SQL (real module ID) apart from
+// unresolved SQL (literal modulePlaceholderToken).
+type recordingQuerier struct{ lastSQL string }
+
+func (r *recordingQuerier) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	r.lastSQL = sql
+	return pgconn.CommandTag{}, nil
+}
+
+func (r *recordingQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	r.lastSQL = sql
+	return nil, nil
+}
+
+func (r *recordingQuerier) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	r.lastSQL = sql
+	return errRow{}
+}
+
+// TestWithModuleIDIntegratesWithGuard confirms the actual composition order
+// of devGuardFor(ctx, withModuleID(q), ...): guardQuerier is the OUTER
+// layer and runs first, scanning the raw statement text — which still
+// contains the literal modulePlaceholderToken at that point — before
+// delegating to placeholderQuerier, which resolves the token last, right
+// before the statement reaches the real connection (see withModuleID's doc
+// comment in db_placeholder.go). A query against the module's OWN
+// placeholder table must therefore both (a) pass the guard while still
+// unresolved, and (b) still arrive at the underlying querier fully resolved
+// to the real module ID.
+func TestWithModuleIDIntegratesWithGuard(t *testing.T) {
+	const id = "m81b3ac7081c1409495700c761e23b59e"
+	m, err := New(Config{ID: id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := &recordingQuerier{}
+
+	// Dev context (no credential) => guard wraps the placeholder resolver.
+	q := m.devGuardFor(context.Background(), m.withModuleID(rec), db.CredentialFrom)
+	if _, err := q.Exec(context.Background(), `SELECT * FROM __MODULE_ID___users`); err != nil {
+		t.Fatalf("own placeholder table Exec err = %v, want nil", err)
+	}
+	if want := `SELECT * FROM ` + id + `_users`; rec.lastSQL != want {
+		t.Fatalf("underlying querier got SQL %q, want resolved %q", rec.lastSQL, want)
+	}
+	if strings.Contains(rec.lastSQL, modulePlaceholderToken) {
+		t.Fatalf("underlying querier still saw the unresolved placeholder token: %q", rec.lastSQL)
+	}
+}


### PR DESCRIPTION
## Summary
- App-scope tables share one Postgres schema per app across multiple installed modules, so each module's tables need a name prefix to avoid colliding with another module's tables in that schema. That prefix was the module's catalog ID, baked in as literal text in migrations AND compiled into sqlc-generated Go query strings. When a module gets deleted and re-registered under a fresh catalog UUID, migrations create tables under the OLD id-prefix while the runtime reports the NEW one — every query then targets a table that doesn't exist. `ms-app-modules#52` is a one-time patch for exactly this drift; the next re-registration reproduces the identical bug.
- Adds `db_placeholder.go`: a `db.Querier` wrapper (`placeholderQuerier`) that resolves a fixed `__MODULE_ID__` token to the module's runtime `Config.ID` in every `Exec`/`Query`/`QueryRow` call, wired into `Module.DB` and `Module.Tx` (the app-scope paths). Module-scope (`mod_<id>` schema) is untouched — it already uses the runtime ID as the SCHEMA name, not a baked-in table prefix.
- Since migrations, sqlc business queries, and the lifecycle install/upgrade/downgrade handlers all route through this same `db.Querier` chokepoint, wrapping it once covers every path — confirmed via full trace of `Module.DB`/`Tx`/`lifecycleTxRunner`/`system.InstallHandler` etc.
- Companion PRs: mirrorstack-cli (scaffold template now emits `__MODULE_ID__` for new modules) and ms-app-modules (the 3 existing modules converted, and `#52` fully superseded).

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` — all packages pass, including new `db_placeholder_test.go` (substitution correctness, delegation across all 3 Querier methods, guard-ordering integration)
- [x] **Live end-to-end verified this session**: real `POST /apps/{id}/installs` against real prod, fresh local Postgres (no pre-existing schema/migration history), confirms tables materialize as `m5dcba905ba6c4242a9c3696f9efc92e9_users` etc. — the runtime ID correctly resolved, zero literal `__MODULE_ID__` leakage anywhere in the database