### PR TITLE
security: contain web asset file access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/system/web.go
+++ b/system/web.go
@@ -1,8 +1,10 @@
 package system
 
 import (
+	"io/fs"
 	"net/http"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"strings"
 )
@@ -21,8 +23,8 @@ import (
 // If rootDir is empty, every request 404s — the module declared no web
 // surface.
 //
-// Path traversal is blocked by validating the cleaned filesystem path is
-// rooted under rootDir; symlinks that escape the dir are rejected.
+// Path traversal is blocked by os.Root, which rejects paths and symlinks that
+// escape rootDir while opening the file.
 func WebHandler(rootDir string) http.HandlerFunc {
 	if rootDir == "" {
 		return func(w http.ResponseWriter, _ *http.Request) {
@@ -37,15 +39,6 @@ func WebHandler(rootDir string) http.HandlerFunc {
 		return func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "web dir invalid", http.StatusInternalServerError)
 		}
-	}
-	// Resolve symlinks at construction so per-request EvalSymlinks
-	// results can be prefix-compared. Without this, macOS's tempdir
-	// (/var → /private/var symlink) breaks the prefix check for every
-	// served file. If the dir doesn't exist yet, fall back to abs — the
-	// handler will 404 anyway when files aren't found.
-	root := abs
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		root = resolved
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		setCORS(w)
@@ -66,11 +59,12 @@ func WebHandler(rootDir string) http.HandlerFunc {
 			http.NotFound(w, r)
 			return
 		}
-		full := filepath.Join(root, rel)
-		// Defense-in-depth: refuse anything that escapes rootDir even
-		// after filepath.Clean (e.g. via symlink). EvalSymlinks resolves
-		// links so we compare the real on-disk path.
-		real, err := filepath.EvalSymlinks(full)
+		if !fs.ValidPath(rel) {
+			http.NotFound(w, r)
+			return
+		}
+
+		root, err := os.OpenRoot(abs)
 		if err != nil {
 			if os.IsNotExist(err) {
 				http.NotFound(w, r)
@@ -79,21 +73,25 @@ func WebHandler(rootDir string) http.HandlerFunc {
 			http.Error(w, "io error", http.StatusInternalServerError)
 			return
 		}
-		if !strings.HasPrefix(real, root+string(filepath.Separator)) && real != root {
-			http.NotFound(w, r) // pretend it doesn't exist rather than confirm escape attempt
+		defer root.Close()
+
+		file, err := root.Open(rel)
+		if err != nil {
+			// Do not reveal whether a path is missing, inaccessible, or
+			// rejected because it escapes the configured web root.
+			http.NotFound(w, r)
 			return
 		}
-		fi, err := os.Stat(real)
+		defer file.Close()
+
+		fi, err := file.Stat()
 		if err != nil || fi.IsDir() {
 			http.NotFound(w, r)
 			return
 		}
 
-		// Material content-type for the two file kinds we ship today —
-		// the JS bundle and its sourcemap. http.ServeFile would also work
-		// but adds Last-Modified / ETag handling we don't need yet.
-		w.Header().Set("Content-Type", contentTypeFor(real))
-		http.ServeFile(w, r, real)
+		w.Header().Set("Content-Type", contentTypeFor(rel))
+		http.ServeContent(w, r, pathpkg.Base(rel), fi.ModTime(), file)
 	}
 }
 
@@ -108,7 +106,7 @@ func setCORS(w http.ResponseWriter) {
 }
 
 func contentTypeFor(path string) string {
-	switch filepath.Ext(path) {
+	switch pathpkg.Ext(path) {
 	case ".js", ".mjs":
 		return "application/javascript; charset=utf-8"
 	case ".map":

--- a/system/web_test.go
+++ b/system/web_test.go
@@ -80,6 +80,30 @@ func TestWebHandler_PathTraversal_Blocked(t *testing.T) {
 	}
 }
 
+func TestWebHandler_SymlinkEscape_Blocked(t *testing.T) {
+	parent := t.TempDir()
+	writeFile(t, parent, "secret.txt", "should-not-be-readable")
+	dir := filepath.Join(parent, "dist")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink("../secret.txt", filepath.Join(dir, "leak.js")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	h := WebHandler(dir)
+	req := httptest.NewRequest(http.MethodGet, "/__mirrorstack/web/leak.js", nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("symlink escape succeeded: body=%s", rec.Body)
+	}
+	if got := rec.Body.String(); got == "should-not-be-readable" {
+		t.Error("secret leaked through symlink")
+	}
+}
+
 func TestWebHandler_MissingFile_Returns404(t *testing.T) {
 	dir := t.TempDir()
 	h := WebHandler(dir)


### PR DESCRIPTION
## Summary

- replace string-based path and symlink checks with Go 1.26 os.Root containment
- serve web assets from an already-open file handle to remove the check/use race
- reject invalid relative paths before filesystem access
- add a regression test for symlinks escaping the configured web root
- restrict the CI GITHUB_TOKEN to contents read

## Security impact

Addresses CodeQL alerts 2 and 3 for uncontrolled paths in system/web.go and alert 1 for missing workflow permissions.

The current implementation validates a resolved path and later reopens it by name. The new implementation opens files through os.Root, which rejects traversal and symlinks escaping the root during the open operation.

## Validation

- gofmt
- go vet ./...
- go test -race ./...
- actionlint v1.7.12
- git diff --check

This PR is not auto-merged.
