### PR TITLE
ci: pin Actions dependencies to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
         ports:
           - 9324:9324
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
       - run: go vet ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- upgrade referenced GitHub Actions to their latest stable releases
- pin every action to a full 40-character commit SHA
- retain exact version comments for reviewability and future Dependabot updates

## Why

This removes mutable-tag supply-chain risk and prepares the organization to enforce full-SHA action references globally.

## Validation

- workflow YAML syntax parsed successfully
- no mutable `uses:` references remain
- GitHub Script v9 breaking-pattern scan passed where applicable

This PR is intentionally unmerged.