### PR TITLE
ci: dispatch commit-bound core pointer updates

### DIFF
--- a/.github/workflows/notify-core-pointer.yml
+++ b/.github/workflows/notify-core-pointer.yml
@@ -1,0 +1,45 @@
+name: Notify core pointer
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: notify-core-pointer-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint core-only workflow dispatcher token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.POINTER_DISPATCH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.POINTER_DISPATCH_APP_PRIVATE_KEY }}
+          owner: mirrorstack-ai
+          repositories: mirrorstack-core-v2
+
+      - name: Dispatch commit-bound pointer update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMPONENT: app-module-sdk
+          COMPONENT_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          gh workflow run pointer-bumps.yml \
+            --repo mirrorstack-ai/mirrorstack-core-v2 \
+            --ref main \
+            -f component="$COMPONENT" \
+            -f component_sha="$COMPONENT_SHA" \
+            -f dry_run=false
+          echo "Dispatched $COMPONENT@$COMPONENT_SHA to mirrorstack-core-v2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude guidance
+
+## Core manifest pointer automation
+
+After a PR merges to protected `main`, a successful terminal `CI` run triggers
+`.github/workflows/notify-core-pointer.yml`. The workflow sends the exact
+`app-module-sdk` main SHA to `mirrorstack-ai/mirrorstack-core-v2`, where
+`mirrorstack-core-bot` opens or updates the commit-bound pointer PR.
+
+Claude must not manually edit or push the core gitlink during the normal flow.
+The automation only opens/updates a reviewable PR; it never reviews, merges,
+promotes, or deploys. If the PR is missing, inspect the terminal CI/CD run and
+`Notify core pointer` run first; core's scheduled scan remains the fallback.


### PR DESCRIPTION
## Summary

- dispatch the exact successful main SHA to mirrorstack-core-v2 after the terminal CI workflow
- mint a repository-scoped token from the mirrorstack-pointer-dispatcher GitHub App
- document the automatic pointer PR flow in CLAUDE.md
- retain the scheduled core scan as a fallback

The automation only opens or updates a reviewable pointer PR. It does not review, merge, promote, or deploy.

## Validation

- actionlint v1.7.12
- git diff --cached --check