### PR TITLE
fix: recheck refcache inside singleflight

### DIFF
--- a/internal/refcache/refcache.go
+++ b/internal/refcache/refcache.go
@@ -79,13 +79,25 @@ func (c *Cache[T]) Get(key string, factory func() (T, error)) (T, func(), error)
 	}
 	c.mu.Unlock()
 
-	// Slow path: singleflight ensures only one factory call runs per key.
-	// The leader's closure inserts the entry with refCount=1 (pinning it
-	// against immediate eviction). Followers receive the broadcast value and
-	// bump refcount by one each. Total refcount after N callers = N.
-	var iAmLeader bool
+	// Slow path: singleflight coalesces overlapping factory calls. Recheck the
+	// cache inside the closure because a caller can miss the fast path, get
+	// descheduled, and enter Do after an earlier call has already completed.
+	// The closure caller claims one reference; followers that share its result
+	// each claim another below. Total refcount after N callers = N.
+	var closureClaimedRef bool
 	result, err, _ := c.sf.Do(key, func() (any, error) {
-		iAmLeader = true
+		closureClaimedRef = true
+
+		c.mu.Lock()
+		if e, ok := c.items[key]; ok {
+			e.lastUsed = time.Now()
+			e.refCount++
+			value := e.value
+			c.mu.Unlock()
+			return value, nil
+		}
+		c.mu.Unlock()
+
 		value, err := factory()
 		if err != nil {
 			return nil, err
@@ -112,8 +124,9 @@ func (c *Cache[T]) Get(key string, factory func() (T, error)) (T, func(), error)
 	}
 	value := result.(T)
 
-	if iAmLeader {
-		// Factory closure already inserted with refCount=1 on our behalf.
+	if closureClaimedRef {
+		// The closure either incremented an existing entry or inserted a new
+		// one with refCount=1 on this caller's behalf.
 		return value, c.releaseFunc(key), nil
 	}
 

--- a/internal/refcache/refcache_test.go
+++ b/internal/refcache/refcache_test.go
@@ -183,11 +183,11 @@ func TestEviction_AllPinned_ReturnsLimitError(t *testing.T) {
 // same missing key coalesce via singleflight: exactly ONE factory call runs,
 // all callers receive the same value, and each caller gets its own refcount.
 //
-// Determinism: each caller increments a counter on entry to Get and spins
-// until all N have entered. Because the fast-path miss happens before the
-// caller's entry-counter increment, we know all N goroutines have passed
-// the cache-empty check by the time the barrier releases. They then all
-// invoke sf.Do, which serializes them — only the leader's factory runs.
+// Each caller increments a counter immediately before Get, and the factory
+// stays open until all N callers have started. A scheduler may still delay a
+// caller between its fast-path miss and sf.Do; the cache's in-closure recheck
+// must make that late caller reuse the newly cached entry instead of running
+// another factory.
 //
 // A 2-second deadline prevents infinite spin if the timing assumption breaks.
 func TestSlowPath_SingleflightCoalesces(t *testing.T) {


### PR DESCRIPTION
## Summary

- recheck the cache inside the singleflight closure after a fast-path miss
- reuse and pin an entry created while a caller was descheduled
- prevent redundant factories and non-canonical resources under contention
- correct the concurrency-test explanation to cover late arrivals

## Failure observed

The post-merge race-enabled integration suite failed TestSlowPath_SingleflightCoalesces: eight callers received eight resources and the factory ran eight times. A caller could miss the fast path, arrive after the previous singleflight call completed, and become a new leader without checking the populated cache.

## Validation

- go vet ./...
- go test -race ./...
- go test -race ./internal/refcache -run TestSlowPath_SingleflightCoalesces -count=100
- git diff --cached --check