### PR TITLE
fix: surface the dispatch-base fallback instead of failing mute

### DIFF
--- a/internal/core/call.go
+++ b/internal/core/call.go
@@ -84,7 +84,7 @@ func (m *Module) Call(ctx context.Context, targetModuleID, method, path string, 
 
 	resp, err := callHTTP.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("ms.Call %s %s: %w", method, u, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/core/call_test.go
+++ b/internal/core/call_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,23 @@ import (
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 )
+
+func TestDispatchBaseFallsBackWhenUnset(t *testing.T) {
+	t.Setenv("MS_DISPATCH_URL", "")
+
+	if got := dispatchBase(); got != devDispatchFallback {
+		t.Errorf("dispatchBase() = %q, want %q", got, devDispatchFallback)
+	}
+}
+
+func TestDispatchBaseTrimsTrailingSlash(t *testing.T) {
+	t.Setenv("MS_DISPATCH_URL", "https://api.mirrorstack.ai/dispatch/")
+
+	const want = "https://api.mirrorstack.ai/dispatch"
+	if got := dispatchBase(); got != want {
+		t.Errorf("dispatchBase() = %q, want %q", got, want)
+	}
+}
 
 func TestResolveCallURL_Building(t *testing.T) {
 	cases := []struct {
@@ -123,6 +141,34 @@ func TestCall_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
 	if !strings.Contains(msg, "/module/m0123/internal/users") {
 		t.Errorf("error %q missing request path", msg)
 	}
+}
+
+func TestCall_TransportErrorIncludesResolvedHost(t *testing.T) {
+	const dispatchURL = "http://unreachable-dispatch.example:8083"
+	t.Setenv("MS_DISPATCH_URL", dispatchURL)
+
+	previousClient := callHTTP
+	callHTTP = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		}),
+	}
+	t.Cleanup(func() { callHTTP = previousClient })
+
+	m, _ := New(Config{ID: "demo"})
+	err := m.CallGet(context.Background(), "m0123", "/internal/users", nil)
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if !strings.Contains(err.Error(), dispatchURL) {
+		t.Errorf("error %q missing resolved dispatch host %q", err, dispatchURL)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestCallGet_NoBodyNoContentType(t *testing.T) {

--- a/internal/core/dispatch_transport.go
+++ b/internal/core/dispatch_transport.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 )
@@ -20,12 +22,26 @@ import (
 // transport lands here (and in the per-surface resolvers' path logic) instead
 // of being swapped in N copies.
 
+// dispatchFallbackWarn keeps the unset-MS_DISPATCH_URL warning to one line per
+// process, so a module that makes many calls does not spam its log.
+var dispatchFallbackWarn sync.Once
+
 // dispatchBase resolves the platform-dispatch base URL: MS_DISPATCH_URL (the
 // container->dispatch base) with the host.docker.internal dev fallback when
 // unset.
 func dispatchBase() string {
 	base := os.Getenv("MS_DISPATCH_URL")
 	if base == "" {
+		// The fallback is only correct when a FULL local platform stack is
+		// running (its dispatch listens on :8083). A dev-tunnel session runs no
+		// local platform, so taking this branch means every ms.Call/Emit/Notify
+		// will fail with a bare connection error the caller can only report as a
+		// 502. Say so once, loudly, instead of failing mute.
+		dispatchFallbackWarn.Do(func() {
+			slog.Warn("MS_DISPATCH_URL is unset; falling back to the local dev dispatch. "+
+				"Inter-module calls, events and notifications will fail unless a local platform stack is running on this address.",
+				"fallback", devDispatchFallback)
+		})
 		base = devDispatchFallback
 	}
 	return strings.TrimRight(base, "/")


### PR DESCRIPTION
## Symptom

A tunnel-against-prod dev session returned a bare `502` from every module route that makes an outbound platform call. The module's own error text said only `authorize-url failed: <connection error>` — with no indication of *where* the request had been aimed.

## Root cause

`dispatchBase()` falls back to `devDispatchFallback` (`http://host.docker.internal:8083`) whenever `MS_DISPATCH_URL` is unset. That address is only correct when a **full local platform stack** is running. A `mirrorstack dev --tunnel` session runs no local platform, so the fallback is a dead port — and it was taken silently.

This is not OAuth-specific: `Call`, `Emit` and `Notify` all share `dispatchBase()`.

## Change

- Warn once (`sync.Once`) when the fallback is taken, naming the address and saying inter-module calls/events/notifications will fail.
- Wrap the transport error in `Call` with the method and resolved URL, so the dead host names itself.

**The fallback value is deliberately unchanged.** Repointing it at production would make a genuinely-local platform stack silently talk to prod — the opposite of what we want.

## Tests

- `TestDispatchBaseFallsBackWhenUnset`, `TestDispatchBaseTrimsTrailingSlash`
- `TestCall_TransportErrorIncludesResolvedHost` — asserts the resolved dispatch host appears in the error

`go build ./...` clean; `go test ./internal/core/...` passes.

## Context

The env-plumbing fix that stops the fallback being taken at all lives in mirrorstack-cli. This PR only makes the condition diagnosable — the two are independent and each stands alone.

Refs mirrorstack-ai/mirrorstack-core-v2#220