### PR TITLE
fix(transport): send the tunnel session secret on the meter + Notify ingress

### DIFF
--- a/internal/core/dispatch_transport.go
+++ b/internal/core/dispatch_transport.go
@@ -47,6 +47,12 @@ func dispatchBase() string {
 	return strings.TrimRight(base, "/")
 }
 
+// moduleSessionSecret returns the dev-tunnel credential that binds this module
+// process to the same live session dispatch registered for it. This is the
+// outbound session-identity seam already used by dependency_db.go and the
+// CLI's module-log ingest, not the inbound MS_PLATFORM_TOKEN hierarchy.
+func moduleSessionSecret() string { return os.Getenv("MS_INTERNAL_SECRET") }
+
 // appIDFromContext reads the current app id from the request context — the
 // same identity the SDK injects for handlers. An empty app id is an error
 // (no panic): every dispatch surface needs an app scope. op names the caller
@@ -58,12 +64,17 @@ func appIDFromContext(ctx context.Context, op string) (string, error) {
 	return "", fmt.Errorf("mirrorstack: %s requires an app-scoped context (no AppID in auth identity)", op)
 }
 
-// postDispatchJSON marshals payload and POSTs it to url with the module->
-// dispatch header set (Content-Type + X-MS-App-ID — no token; the dispatch
-// authenticates the sender by transport, never by envelope assertion). A
-// non-2xx response is returned as an error prefixed with op ("ms.Emit",
-// "ms.Notify"), body truncated to ~2 KB.
-func postDispatchJSON(ctx context.Context, op, url, appID string, payload any) error {
+// postDispatchJSON marshals payload and POSTs it to url with the base module->
+// dispatch headers (Content-Type + X-MS-App-ID) plus whatever extraHeaders the
+// CALLER opts into. Credentials are per-surface, not blanket: only the routes
+// dispatch actually gates on a secret pass one, so a surface can never acquire
+// the session credential by accident. An empty value is skipped rather than
+// written as a blank header — dispatch reads a blank as "no credential", and a
+// blank header is indistinguishable on the wire from an authentication bug.
+// Whatever is sent, dispatch still re-derives sender identity itself and never
+// trusts an envelope assertion. A non-2xx response is returned as an error
+// prefixed with op ("ms.Emit", "ms.Notify"), body truncated to ~2 KB.
+func postDispatchJSON(ctx context.Context, op, url, appID string, payload any, extraHeaders map[string]string) error {
 	buf, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -74,6 +85,11 @@ func postDispatchJSON(ctx context.Context, op, url, appID string, payload any) e
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-MS-App-ID", appID)
+	for name, value := range extraHeaders {
+		if value != "" {
+			req.Header.Set(name, value)
+		}
+	}
 
 	resp, err := callHTTP.Do(req)
 	if err != nil {

--- a/internal/core/emit.go
+++ b/internal/core/emit.go
@@ -68,7 +68,7 @@ func (m *Module) Emit(ctx context.Context, name string, payload any) error {
 		SentAt:         time.Now().UTC().Format(time.RFC3339Nano),
 		Payload:        payload,
 	}
-	return postDispatchJSON(ctx, "ms.Emit", resolveEventBusURL(appID, name), appID, env)
+	return postDispatchJSON(ctx, "ms.Emit", resolveEventBusURL(appID, name), appID, env, nil)
 }
 
 // Emit publishes an event on the default module created by Init(). Panics

--- a/internal/core/notify.go
+++ b/internal/core/notify.go
@@ -116,7 +116,9 @@ func (m *Module) Notify(ctx context.Context, n Notification) error {
 		Link:           n.Link,
 		Audience:       audience,
 	}
-	return postDispatchJSON(ctx, "ms.Notify", resolveNotifyURL(appID), appID, env)
+	return postDispatchJSON(ctx, "ms.Notify", resolveNotifyURL(appID), appID, env, map[string]string{
+		"X-MS-Service-Secret": moduleSessionSecret(),
+	})
 }
 
 // hasMessage reports whether a resolved locale map carries at least one

--- a/internal/core/notify_test.go
+++ b/internal/core/notify_test.go
@@ -179,6 +179,58 @@ func TestNotify_PostsFromContextAppID(t *testing.T) {
 	}
 }
 
+// Dispatch's notification ingress is mounted outside all auth middleware and
+// now gates on X-MS-Service-Secret matching the module's live tunnel session.
+// If this header stops going out, ms.Notify silently 403s for every module
+// under `mirrorstack dev --tunnel`.
+func TestNotify_SendsModuleSessionSecret(t *testing.T) {
+	var gotSecret string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSecret = r.Header.Get("X-MS-Service-Secret")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	t.Setenv("MS_INTERNAL_SECRET", "session-secret-1")
+
+	m, _ := New(Config{ID: "billing"})
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+	if err := m.Notify(ctx, Notification{Title: Text("Hello")}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if gotSecret != "session-secret-1" {
+		t.Errorf("X-MS-Service-Secret = %q, want session-secret-1", gotSecret)
+	}
+}
+
+// A deployed (non-tunnel) module has no session secret. That must stay a
+// best-effort POST that dispatch rejects, never a client-side hard error or a
+// blank header — notification delivery may not break a module's request path.
+func TestNotify_WithoutModuleSessionSecretStillPosts(t *testing.T) {
+	var hits int
+	var gotSecretValues []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotSecretValues = r.Header.Values("X-MS-Service-Secret")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	t.Setenv("MS_INTERNAL_SECRET", "")
+
+	m, _ := New(Config{ID: "billing"})
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+	if err := m.Notify(ctx, Notification{Title: Text("Hello")}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("dispatch hit %d times, want 1", hits)
+	}
+	if len(gotSecretValues) != 0 {
+		t.Errorf("X-MS-Service-Secret values = %q, want no header", gotSecretValues)
+	}
+}
+
 func TestNotify_ValidationErrorsWithoutHTTP(t *testing.T) {
 	var hit bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/meter/meter.go
+++ b/meter/meter.go
@@ -471,6 +471,18 @@ func (c *Client) dispatch(ctx context.Context, appID string, event Event) error 
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-MS-App-ID", appID)
+	// The usage ingress is billable: dispatch requires this header to
+	// constant-time-match the module's live tunnel-session secret, or an
+	// unauthenticated caller could forge usage events for any app with a
+	// tunnel-live module. MS_INTERNAL_SECRET is the CLI-exported per-session
+	// value dispatch stored at register time — read here rather than through
+	// internal/core's moduleSessionSecret because meter is a separate package
+	// and this does not warrant a new exported API. Best-effort, not fatal: a
+	// deployed module legitimately has no tunnel session, and metering must
+	// never break a module's request path.
+	if secret := os.Getenv("MS_INTERNAL_SECRET"); secret != "" {
+		req.Header.Set("X-MS-Service-Secret", secret)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/meter/meter_test.go
+++ b/meter/meter_test.go
@@ -22,13 +22,14 @@ type capture struct {
 	path   string
 	appID  string
 	ct     string
+	secret []string
 	body   []byte
 }
 
 func (c *capture) get() capture {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return capture{hits: c.hits, method: c.method, path: c.path, appID: c.appID, ct: c.ct, body: c.body}
+	return capture{hits: c.hits, method: c.method, path: c.path, appID: c.appID, ct: c.ct, secret: c.secret, body: c.body}
 }
 
 // newDispatchStub starts an httptest server standing in for the dispatch usage
@@ -44,6 +45,7 @@ func newDispatchStub(t *testing.T, status int) (*Client, *capture) {
 		cap.path = r.URL.Path
 		cap.appID = r.Header.Get("X-MS-App-ID")
 		cap.ct = r.Header.Get("Content-Type")
+		cap.secret = r.Header.Values("X-MS-Service-Secret")
 		cap.body, _ = io.ReadAll(r.Body)
 		cap.mu.Unlock()
 		if status == 0 {
@@ -179,6 +181,42 @@ func TestRecord_PostsEventToUsageIngress(t *testing.T) {
 	}
 	if got.RecordedAtHint.IsZero() {
 		t.Error("recordedAtHint should be set")
+	}
+}
+
+// The usage ingress is the billable one: dispatch requires this header to match
+// the module's live tunnel session, so dropping it makes every ms.Record under
+// `mirrorstack dev --tunnel` 403 and silently stop metering.
+func TestRecord_SendsModuleSessionSecret(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "session-secret-1")
+	c, cap := newDispatchStub(t, http.StatusAccepted)
+	declareCounter(t, c, "transcode.minutes")
+
+	if err := c.Record(appCtx("a-456"), "transcode.minutes", 1); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if got := cap.get().secret; len(got) != 1 || got[0] != "session-secret-1" {
+		t.Errorf("X-MS-Service-Secret values = %q, want [session-secret-1]", got)
+	}
+}
+
+// A deployed module has no tunnel session secret. Metering is non-fatal by
+// contract, so an unset secret must still POST (and let dispatch reject) rather
+// than error early or put a blank header on the wire.
+func TestRecord_WithoutModuleSessionSecretStillPosts(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	c, cap := newDispatchStub(t, http.StatusAccepted)
+	declareCounter(t, c, "transcode.minutes")
+
+	if err := c.Record(appCtx("a-456"), "transcode.minutes", 1); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	got := cap.get()
+	if got.hits != 1 {
+		t.Errorf("usage ingress hit %d times, want 1", got.hits)
+	}
+	if len(got.secret) != 0 {
+		t.Errorf("X-MS-Service-Secret values = %q, want no header", got.secret)
 	}
 }
 


### PR DESCRIPTION
## Why

Dispatch's `POST /apps/{appID}/usage` and `POST /apps/{appID}/notifications` are mounted **outside all auth middleware** and used to gate the sender on **session existence only** — so an unauthenticated internet caller could POST forged **billable** usage events for any app with a tunnel-live module.

mirrorstack-ai/api-platform#438 closes that: dispatch now requires `X-MS-Service-Secret` to constant-time-match the module's live tunnel-session `InternalSecret`. This SDK never sent that header on either surface — the meter sent only `Content-Type` and `X-MS-App-ID`.

## 🔗 Must land with mirrorstack-ai/api-platform#438

Without #438 this header is inert. Without **this** PR, `ms.Record` and `ms.Notify` 403 for every module under `mirrorstack dev --tunnel`. Merge them together.

## What changed

Both transports now send `MS_INTERNAL_SECRET` as `X-MS-Service-Secret` — the seam `internal/core/dependency_db.go` (read-exposed) and the CLI's module-log ingest **already** ride, rather than a new invention. It is the per-session value the CLI mints in `--tunnel` mode, injects into the module process env, *and* sends on the WS `register` frame — so it is the same value on both ends by construction. No new env var; the inbound `MS_PLATFORM_TOKEN` hierarchy is untouched.

- `postDispatchJSON` is shared by `ms.Emit` and `ms.Notify`, so the credential is **caller-opted-in** (explicit `extraHeaders`) rather than blanket-applied. A surface can never acquire the session secret by accident. `ms.Emit` and `ms.Call` are unchanged.
- `meter` is a separate package, so it reads the env var locally rather than exporting new API just for this.
- Empty values are skipped, never written as a blank header.

## Unset secret stays best-effort

No header, no early error, request still sent. A deployed module legitimately has no tunnel session today, and metering must never break a module's request path — dispatch is the fail-closed enforcement point. This is deliberately **unlike** `dependency_db.go`, which hard-errors because a cross-module read must not silently return nothing.

The deployed-module signing seam is core-v2#338 step 7, not this PR.

## Tests

Four new tests asserting on the header the fake dispatch **actually received** — secret present, and the unset-secret path still POSTing with no header at all.

Verified by mutation: removing the header from both transports turns `TestRecord_SendsModuleSessionSecret` and `TestNotify_SendsModuleSessionSecret` red; restored, `go build ./... && go vet ./... && go test ./...` is green. No pre-existing test removed or weakened. No new dependencies, no exported API change, no version/CHANGELOG bump.

Part of mirrorstack-ai/mirrorstack-core-v2#337

🤖 Generated with [Claude Code](https://claude.com/claude-code)