### PR TITLE
feat: fail Start when a declared UI has no bundle to serve

### DIFF
--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -577,6 +577,37 @@ func RequirePermission(name string) func(http.Handler) http.Handler {
 //   - Task worker (MS_TASK_WORKER_MODE=true): polls SQS for background tasks
 //   - Otherwise: HTTP server on :PORT (default 8080) for local development
 //
+// checkUIServable rejects the one combination that is always a mistake:
+// RegisterUI declared a surface, but Config.WebDir is empty so ms.Start never
+// mounts a directory behind GET /__mirrorstack/web/*.
+//
+// Nothing else catches it. The manifest still advertises the page, the module
+// still builds, its bundle still builds, and CI still passes — the platform
+// dynamically imports /__mirrorstack/web/index.js, gets a 404, and the admin
+// sees "Couldn't load module bundle". The failure is entirely in the wiring
+// between a declaration and the runtime meant to serve it, so it only ever
+// shows up in a browser.
+//
+// A module with no UI is fine, and a module with WebDir and no UI is fine too
+// (it may serve assets a contribution renders). Only declared-but-unservable
+// is contradictory, and it is worth failing the process for: the module is
+// advertising a surface it cannot deliver.
+func (m *Module) checkUIServable() error {
+	if m.config.WebDir != "" {
+		return nil
+	}
+	ui := m.registry.UI()
+	if ui == nil || (len(ui.DefaultPages) == 0 && len(ui.Components) == 0) {
+		return nil
+	}
+	return fmt.Errorf(
+		"mirrorstack: RegisterUI declared %d page(s) and %d component(s) but Config.WebDir is empty — "+
+			"the bundle route GET /__mirrorstack/web/* is not mounted, so the platform will 404 when it "+
+			"imports the bundle. Set WebDir (conventionally \"web/dist\") in ms.Init, or drop the RegisterUI call",
+		len(ui.DefaultPages), len(ui.Components),
+	)
+}
+
 // Lambda wins if both env vars are set (they are mutually exclusive in
 // production but this ordering is a safety net).
 func (m *Module) Start() error {
@@ -591,6 +622,10 @@ func (m *Module) Start() error {
 
 	if runtime.IsTaskWorker() {
 		return m.startTaskWorker()
+	}
+
+	if err := m.checkUIServable(); err != nil {
+		return err
 	}
 
 	if m.devMode {

--- a/internal/core/webdir_guard_test.go
+++ b/internal/core/webdir_guard_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // checkUIServable exists because of a real outage-shaped bug: a module declared
@@ -34,6 +35,38 @@ func TestCheckUIServable_DeclaredPagesWithoutWebDir(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q does not mention %q", err, want)
 		}
+	}
+}
+
+// The guard is worthless if Start stops calling it, and every other test here
+// calls checkUIServable directly — they would all stay green if the call site
+// were deleted. This one exercises Start itself.
+//
+// Start is run on a goroutine with a deadline rather than called inline: when
+// the guard IS wired it returns the error immediately, but an unwired Start
+// falls through to ListenAndServe and never returns. Waiting inline would turn
+// the regression into a ten-minute package timeout instead of a failure that
+// names itself.
+func TestStart_RefusesDeclaredUIWithoutWebDir(t *testing.T) {
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{{Route: "/", Title: "Settings", Export: "mountSettings"}},
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- m.Start() }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Start() = nil; want the checkUIServable error")
+		}
+		if !strings.Contains(err.Error(), "WebDir") {
+			t.Errorf("Start() = %v; want the WebDir guard error", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start() did not return — it got past the UI guard and reached the listener, " +
+			"so checkUIServable is no longer wired into Start")
 	}
 }
 

--- a/internal/core/webdir_guard_test.go
+++ b/internal/core/webdir_guard_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+// checkUIServable exists because of a real outage-shaped bug: a module declared
+// a settings page, its manifest advertised it, Go built, the bundle built, CI
+// passed and an adversarial review passed — and the page still failed in the
+// browser with "Couldn't load module bundle", because Config.WebDir was empty
+// so GET /__mirrorstack/web/* had no directory behind it.
+//
+// These tests pin the exact combination that is contradictory, and — just as
+// importantly — the three that are not, so the guard can never start rejecting
+// a legitimate module.
+
+func TestCheckUIServable_DeclaredPagesWithoutWebDir(t *testing.T) {
+	t.Parallel()
+
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		DefaultPages: []UIPage{{Route: "/", Title: "Settings", Export: "mountSettings"}},
+	})
+
+	err := m.checkUIServable()
+	if err == nil {
+		t.Fatal("checkUIServable() = nil; want an error — a declared page with no WebDir 404s at runtime")
+	}
+	// The message has to name the fix, not just the symptom: this fires on a
+	// developer's first run of a new surface, and "WebDir" is the one word
+	// that turns it into a one-line change.
+	for _, want := range []string{"WebDir", "web/dist", "__mirrorstack/web"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func TestCheckUIServable_DeclaredComponentsWithoutWebDir(t *testing.T) {
+	t.Parallel()
+
+	// Components are served from the same bundle as pages, so a
+	// components-only surface is just as unservable.
+	m, _ := New(Config{ID: "demo"})
+	m.RegisterUI(ModuleUI{
+		Components: []UIComponent{{Name: "Card", Export: "Card"}},
+	})
+
+	if err := m.checkUIServable(); err == nil {
+		t.Fatal("checkUIServable() = nil for components-only UI with no WebDir; want an error")
+	}
+}
+
+func TestCheckUIServable_Allowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		webDir string
+		ui     *ModuleUI
+	}{
+		{
+			// The overwhelmingly common case: a headless module.
+			name: "no UI and no WebDir",
+		},
+		{
+			name:   "UI declared with WebDir",
+			webDir: "web/dist",
+			ui: &ModuleUI{
+				DefaultPages: []UIPage{{Route: "/", Title: "Settings", Export: "mountSettings"}},
+			},
+		},
+		{
+			// WebDir without RegisterUI is legitimate — the module may serve
+			// assets that another module's contributed surface renders.
+			name:   "WebDir with no UI",
+			webDir: "web/dist",
+		},
+		{
+			// RegisterUI called with nothing in it declares no surface, so
+			// there is nothing to fail to serve.
+			name: "empty UI with no WebDir",
+			ui:   &ModuleUI{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m, _ := New(Config{ID: "demo", WebDir: tt.webDir})
+			if tt.ui != nil {
+				m.RegisterUI(*tt.ui)
+			}
+			if err := m.checkUIServable(); err != nil {
+				t.Errorf("checkUIServable() = %v; want nil", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`RegisterUI` declaring pages while `Config.WebDir` is empty is **always** a mistake, and nothing catches it today.

## The bug this comes from

ms-app-modules#94 shipped a settings page for `users-roles` with `WebDir` unset. `WebDir` is what makes `Start` mount `GET /__mirrorstack/web/*` (`internal/core/module.go:784`) — declaring a `UIPage` does not imply it. So the manifest advertised the page, the platform dutifully imported the bundle, and the browser got:

> Couldn't load module bundle: Failed to fetch dynamically imported module: `…/_m/users-roles/__mirrorstack/web/index.js`

| check | result |
|---|---|
| manifest `ui.defaultPages` | correct |
| `go build` / `vet` / `test` | pass |
| `pnpm typecheck` / `build` | pass, 389 kB emitted |
| CI, 10 jobs | green |
| Codex adversarial review | APPROVE, no findings |

Everything static passed. The failure lives entirely in the wiring between a declaration and the runtime meant to serve it, so it can only ever appear in a browser. **Third bug of that shape in one day** — the SDK's own comment at `module.go:782` already said *"When WebDir is empty, every request 404s."*

## The guard

`checkUIServable()` runs at `Start`, **after** the Lambda and task-worker early returns — a deployed module legitimately serves its bundle from CDN, so this belongs to the local/dev path where the tunnel runs.

The message names the fix, not the symptom, because it fires on a developer's first run of a new surface:

```
mirrorstack: RegisterUI declared 1 page(s) and 0 component(s) but Config.WebDir is empty —
the bundle route GET /__mirrorstack/web/* is not mounted, so the platform will 404 when it
imports the bundle. Set WebDir (conventionally "web/dist") in ms.Init, or drop the RegisterUI call
```

## Only the contradictory case fails

| WebDir | RegisterUI | result |
|---|---|---|
| — | — | ok — the common headless module |
| `web/dist` | pages | ok |
| `web/dist` | — | ok — may serve assets another module's contributed surface renders |
| — | empty `ModuleUI{}` | ok — declares no surface |
| **—** | **pages or components** | **error** |

Each allowed row is pinned by a test, so the guard cannot start rejecting valid modules.

## Verification

- **Mutation-tested**: forcing `checkUIServable` to return `nil` makes both failure tests fail — they detect the real bug rather than passing by construction.
- Full suite: **18 packages, 0 failures**.
- `gofmt`, `go vet` clean.