### PR TITLE
fix(system): opt in to local-network access so tunnelled bundles load

### DIFF
--- a/system/web.go
+++ b/system/web.go
@@ -41,7 +41,7 @@ func WebHandler(rootDir string) http.HandlerFunc {
 		}
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		setCORS(w)
+		setCORS(w, r)
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -95,7 +95,7 @@ func WebHandler(rootDir string) http.HandlerFunc {
 	}
 }
 
-func setCORS(w http.ResponseWriter) {
+func setCORS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "*")
@@ -103,6 +103,24 @@ func setCORS(w http.ResponseWriter) {
 	// fresh fetch when the module restarts. Short max-age keeps the dev
 	// loop responsive while still letting browsers reuse within a render.
 	w.Header().Set("Cache-Control", "no-cache")
+
+	// Under `mirrorstack dev --tunnel` the page is a PUBLIC https origin
+	// (apps.mirrorstack.ai) while this bundle is served from http://localhost.
+	// Chrome treats that as a local-network request and blocks it unless the
+	// target opts in on the preflight — the request never reaches this process,
+	// so the settings page renders blank with nothing in the module's log.
+	// Echo the opt-in only when asked for, and answer both spellings: Chrome
+	// <138 sends the Private Network Access header, 138+ the Local Network
+	// Access one. Opting in is safe here because the namespace is read-only
+	// public static assets with no credentials — see the type comment.
+	if r != nil {
+		if r.Header.Get("Access-Control-Request-Private-Network") == "true" {
+			w.Header().Set("Access-Control-Allow-Private-Network", "true")
+		}
+		if r.Header.Get("Access-Control-Request-Local-Network-Access") == "true" {
+			w.Header().Set("Access-Control-Allow-Local-Network-Access", "true")
+		}
+	}
 }
 
 func contentTypeFor(path string) string {

--- a/system/web_test.go
+++ b/system/web_test.go
@@ -147,6 +147,54 @@ func TestWebHandler_Options_PreflightSucceeds(t *testing.T) {
 	}
 }
 
+// Under `dev --tunnel` the page is a public https origin while the bundle is
+// served from http://localhost, so Chrome sends a local-network preflight and
+// blocks the load unless this handler opts in. The block happens in the
+// browser, so a regression here shows up only as a blank settings page with
+// nothing in the module's log — hence covering both spellings explicitly.
+func TestWebHandler_LocalNetworkPreflight_OptsIn(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "index.js", "ok")
+	h := WebHandler(dir)
+
+	for _, tt := range []struct{ name, reqHeader, wantHeader string }{
+		{"chrome 138+", "Access-Control-Request-Local-Network-Access", "Access-Control-Allow-Local-Network-Access"},
+		{"chrome <138", "Access-Control-Request-Private-Network", "Access-Control-Allow-Private-Network"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodOptions, "/__mirrorstack/web/index.js", nil)
+			req.Header.Set("Origin", "https://apps.mirrorstack.ai")
+			req.Header.Set(tt.reqHeader, "true")
+			rec := httptest.NewRecorder()
+			h(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204", rec.Code)
+			}
+			if got := rec.Header().Get(tt.wantHeader); got != "true" {
+				t.Errorf("%s = %q, want \"true\" — the browser drops the bundle without it", tt.wantHeader, got)
+			}
+		})
+	}
+}
+
+// The opt-in is echoed only when asked for, so an ordinary fetch does not
+// advertise local-network access it was never requested to grant.
+func TestWebHandler_NoLocalNetworkRequest_NoOptIn(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "index.js", "ok")
+	h := WebHandler(dir)
+
+	req := httptest.NewRequest(http.MethodOptions, "/__mirrorstack/web/index.js", nil)
+	req.Header.Set("Origin", "https://apps.mirrorstack.ai")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	for _, header := range []string{"Access-Control-Allow-Local-Network-Access", "Access-Control-Allow-Private-Network"} {
+		if got := rec.Header().Get(header); got != "" {
+			t.Errorf("%s = %q on an unrequested preflight, want empty", header, got)
+		}
+	}
+}
+
 func TestWebHandler_BadMethod_405(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "index.js", "ok")


### PR DESCRIPTION
## Symptom

Every module settings page renders as an **empty frame** under `mirrorstack dev --tunnel`. No console error, no entry in the module's request log, and the exact same URL returns `200` to `curl`.

## Cause

The settings page is served from a **public https origin** (`apps.mirrorstack.ai`) while the module bundle is fetched from **`http://localhost:9080`**. Chrome classes that as a local-network request and blocks it unless the target opts in on the preflight.

`system.WebHandler` set CORS but never the opt-in header, so **Chrome dropped the request before it left the browser** — which is why nothing appeared server-side and why `curl` was misleading.

## Evidence (Chrome 150, against a live tunnel)

| | requests reaching the module |
|---|---|
| top-level navigation to the bundle URL | ✅ `GET … 200` |
| same URL as a subresource from `apps.mirrorstack.ai`, before this change | ❌ **nothing arrives** |
| same, after this change | ✅ `OPTIONS … 204` preflight arrives and is answered |

## The fix

Echo the opt-in on the preflight, **only when the request asks for it** — so an ordinary fetch does not advertise access it never requested. Both spellings are answered because the header was renamed mid-flight: Chrome 138+ sends `Access-Control-Request-Local-Network-Access`, earlier versions `Access-Control-Request-Private-Network`.

Opting in is safe for this namespace specifically: `/__mirrorstack/web/*` is read-only public static assets carrying no credentials — which is already why its CORS is permissive.

## Tests

Two added, covering both spellings plus the negative case (no opt-in echoed when unrequested). Worth noting the gap this closes: the failure is entirely browser-side, so **no server-side test could have caught it** — the handler was returning a correct 200 the whole time. The regression signal is a blank page, which is exactly the kind of silent failure that hides.

## Not fixed here

With the server opted in, Chrome still holds the request pending the user's **local-network permission** for the site. That is a browser-level grant, not something the SDK can supply. Anyone running a tunnel needs to allow it once for `apps.mirrorstack.ai` (Chrome → Site settings → Local network access).