### PR TITLE
fix(core): send the service secret on Emit so events are accepted

### DIFF
--- a/internal/core/emit.go
+++ b/internal/core/emit.go
@@ -68,7 +68,15 @@ func (m *Module) Emit(ctx context.Context, name string, payload any) error {
 		SentAt:         time.Now().UTC().Format(time.RFC3339Nano),
 		Payload:        payload,
 	}
-	return postDispatchJSON(ctx, "ms.Emit", resolveEventBusURL(appID, name), appID, env, nil)
+	// The event bus rejects a sender with no X-MS-Service-Secret before it looks
+	// anything up, so passing nil headers here meant every Emit came back
+	// 403 unknown_sender ("event sender is not a live module") — a message that
+	// points at tunnel liveness rather than at the missing credential it
+	// actually describes. ms.Notify and the dependency read proxy send the same
+	// secret; Emit was the one caller that did not.
+	return postDispatchJSON(ctx, "ms.Emit", resolveEventBusURL(appID, name), appID, env, map[string]string{
+		"X-MS-Service-Secret": moduleSessionSecret(),
+	})
 }
 
 // Emit publishes an event on the default module created by Init(). Panics

--- a/internal/core/emit_test.go
+++ b/internal/core/emit_test.go
@@ -115,6 +115,33 @@ func TestEmit_PostsEnvelopeFromContextAppID(t *testing.T) {
 	}
 }
 
+// The event bus rejects a sender carrying no X-MS-Service-Secret before it
+// looks anything up, so omitting it made every Emit fail 403 unknown_sender —
+// silently, because Emit is best-effort. Nothing else caught it: the envelope
+// was correct, the URL was correct, and the module's own log was the only place
+// the failure appeared. Assert the credential, not just the payload.
+func TestEmit_SendsServiceSecretHeader(t *testing.T) {
+	var gotSecret string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSecret = r.Header.Get("X-MS-Service-Secret")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"delivered":0}`))
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	t.Setenv("MS_INTERNAL_SECRET", "sess-secret-xyz")
+
+	m, _ := New(Config{ID: "billing"})
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+	if err := m.Emit(ctx, "payment.captured", map[string]any{"amount": 100}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	if gotSecret != "sess-secret-xyz" {
+		t.Errorf("X-MS-Service-Secret = %q, want the session secret — the event bus 403s without it", gotSecret)
+	}
+}
+
 func TestEmit_EmptyAppContextErrorsWithoutHTTP(t *testing.T) {
 	var hit bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`ms.Emit` has **never worked**. Every event the platform has ever emitted was rejected.

## Cause

The event bus rejects a sender carrying no `X-MS-Service-Secret` **before it looks anything up**:

```go
// api-platform internal/dispatch/handler/event_router.go
headerLogIngestSecret = "X-MS-Service-Secret"
if r.Header.Get(headerLogIngestSecret) == "" {
    httputil.Error(w, http.StatusForbidden, "unknown_sender", "event sender is not a live module")
}
```

`Emit` passed `nil` headers. `ms.Notify` (`notify.go:124`) and the dependency read proxy (`dependency_db.go:447`) both send the same secret from the same helper — `Emit` was the one caller that did not.

## Why it stayed hidden

- The error message says *"not a live module"*, which points at **tunnel liveness** rather than at the missing credential it actually describes. It read as an infrastructure problem for a long time.
- Delivery is deliberately best-effort, so the failure never propagates to the caller — sign-in succeeds, the event is simply lost.
- The only trace is one line in the **emitting module's own stdout**, where nobody is looking.

Evidence: across five separate dev-tunnel sessions today, every `emit` log line was a failure and not one was a success — including sessions verified live and serving `200` through dispatch at the same moment.

## Impact

Every cross-module event. Concretely, `oauth-core` emits `user.created` / `session.started`, and `users-roles` subscribes to grant a default role on sign-in ([ms-app-modules#103](https://github.com/mirrorstack-ai/ms-app-modules/pull/103)) — that feature could never have fired.

The subscriber side is confirmed correct: POSTing the event straight to the module's `/__mirrorstack/events/session.started` returns `200` and the grant lands.

## Test

`TestEmit_SendsServiceSecretHeader` asserts the credential rather than just the payload. The existing tests all passed throughout — they checked the envelope, the URL and the app-id header, none of which were wrong.