### PR TITLE
fix(contributions): create the per-app store on the deployed plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,6 @@ All notable changes to the MirrorStack Module SDK.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-- **A module's contribution store is now created on the deployed plane.** `<moduleID>_contributions` was only ever created under `mirrorstack dev`: the one non-dev call site sat *below* `Start()`'s `runtime.IsLambda()` early return, so a deployed module never ran it — and even off-Lambda it created the table in the connection's default schema, which is the wrong place for a per-app table. Every deployed host of a contribution slot therefore answered `ms.StoredContributions` with `relation "m..._contributions" does not exist`, and every consumer of that call reported "no contributions" — indistinguishable, to an operator, from nobody having contributed. For oauth-core's `auth-provider` slot that is sign-in.
-
-  Provisioning moves to the platform's per-(app, module) lifecycle window: `system.InstallHandler` and `system.UpgradeHandler` now run an SDK-owned `Provisioner` before the author's migrations, inside the install context the platform already sends (`schema` + `credential`). That is the only place on the deployed plane where the SDK holds an app schema together with a role allowed to create tables in it, and it is per-app by construction — a cold-start hook could not be, because one Lambda container serves many apps. A schema-less (dev-tunnel) body stays a no-op; the dev plane keeps creating the store in `provisionDevAppSchema` exactly as before.
-
-  `EnsureTable` is now concurrency-safe: the CREATEs ride a `pg_advisory_xact_lock` keyed on `current_schema()` in the same argument-less `Exec` (one implicit transaction — split into two statements the lock would be released before the DDL it guards), with `42P07`/`23505` tolerated as "the relation exists" for the racers the lock cannot cover. Without it, eight concurrent installs of one app fail with a `pg_type_typname_nsp_index` unique violation.
-
-- **An app installed before this ships heals itself on first use.** The platform sends no lifecycle call at all to an install already at its target migration counter, so the hook alone would never reach existing installs. `ms.StoredContributions` and the `/__mirrorstack/contrib` routes now create the store and retry once when — and only when — Postgres answers `42P01`. Any other failure, a missing `CREATE` grant included, still surfaces.
-
-- **`Module.StoredContributions` reads its OWN pool.** It called the package-level `DB(ctx)`, which resolves through the module created by `ms.Init`, so a non-default `*Module` read another module's connection.
-
-### Changed
-- `system.InstallHandler` and `system.UpgradeHandler` take a fourth argument, `Provisioner` (nil for none). `DowngradeHandler` deliberately does not: reverting an author's migrations is not a reason to re-create SDK infrastructure. Modules do not call these — `ms.Init` mounts them.
-
-### Upgrade notes
-- **A deployed module must be rebuilt against this SDK for its store to be created.** Nothing on the platform side changes.
-- **The contribution PUSH still has no deployed transport.** `pushContribution` and the manifest read behind it resolve only a live dev-tunnel session (`WSSessionModuleEndpoints`), so on the deployed plane the platform never asks a host to register anything — silently, before the store is even reached. This release makes the store exist and reads return empty instead of erroring; filling it deployed is a platform change.
-
 ## [v0.3.2] - 2026-08-02
 
 **No wire change. Nothing about what this SDK sends is different from v0.3.1** — this release documents and test-pins a contract that already holds, so that the platform can start authenticating *deployed* modules without any module rebuild.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the MirrorStack Module SDK.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A module's contribution store is now created on the deployed plane.** `<moduleID>_contributions` was only ever created under `mirrorstack dev`: the one non-dev call site sat *below* `Start()`'s `runtime.IsLambda()` early return, so a deployed module never ran it — and even off-Lambda it created the table in the connection's default schema, which is the wrong place for a per-app table. Every deployed host of a contribution slot therefore answered `ms.StoredContributions` with `relation "m..._contributions" does not exist`, and every consumer of that call reported "no contributions" — indistinguishable, to an operator, from nobody having contributed. For oauth-core's `auth-provider` slot that is sign-in.
+
+  Provisioning moves to the platform's per-(app, module) lifecycle window: `system.InstallHandler` and `system.UpgradeHandler` now run an SDK-owned `Provisioner` before the author's migrations, inside the install context the platform already sends (`schema` + `credential`). That is the only place on the deployed plane where the SDK holds an app schema together with a role allowed to create tables in it, and it is per-app by construction — a cold-start hook could not be, because one Lambda container serves many apps. A schema-less (dev-tunnel) body stays a no-op; the dev plane keeps creating the store in `provisionDevAppSchema` exactly as before.
+
+  `EnsureTable` is now concurrency-safe: the CREATEs ride a `pg_advisory_xact_lock` keyed on `current_schema()` in the same argument-less `Exec` (one implicit transaction — split into two statements the lock would be released before the DDL it guards), with `42P07`/`23505` tolerated as "the relation exists" for the racers the lock cannot cover. Without it, eight concurrent installs of one app fail with a `pg_type_typname_nsp_index` unique violation.
+
+- **An app installed before this ships heals itself on first use.** The platform sends no lifecycle call at all to an install already at its target migration counter, so the hook alone would never reach existing installs. `ms.StoredContributions` and the `/__mirrorstack/contrib` routes now create the store and retry once when — and only when — Postgres answers `42P01`. Any other failure, a missing `CREATE` grant included, still surfaces.
+
+- **`Module.StoredContributions` reads its OWN pool.** It called the package-level `DB(ctx)`, which resolves through the module created by `ms.Init`, so a non-default `*Module` read another module's connection.
+
+### Changed
+- `system.InstallHandler` and `system.UpgradeHandler` take a fourth argument, `Provisioner` (nil for none). `DowngradeHandler` deliberately does not: reverting an author's migrations is not a reason to re-create SDK infrastructure. Modules do not call these — `ms.Init` mounts them.
+
+### Upgrade notes
+- **A deployed module must be rebuilt against this SDK for its store to be created.** Nothing on the platform side changes.
+- **The contribution PUSH still has no deployed transport.** `pushContribution` and the manifest read behind it resolve only a live dev-tunnel session (`WSSessionModuleEndpoints`), so on the deployed plane the platform never asks a host to register anything — silently, before the store is even reached. This release makes the store exist and reads return empty instead of erroring; filling it deployed is a platform change.
+
 ## [v0.3.2] - 2026-08-02
 
 **No wire change. Nothing about what this SDK sends is different from v0.3.1** — this release documents and test-pins a contract that already holds, so that the platform can start authenticating *deployed* modules without any module rebuild.

--- a/internal/contributions/handlers.go
+++ b/internal/contributions/handlers.go
@@ -86,7 +86,9 @@ func (h *Handlers) register(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
-	if err := h.storage.Upsert(r.Context(), q, slotKey, id, body); err != nil {
+	if err := h.storage.WithTable(r.Context(), q, func() error {
+		return h.storage.Upsert(r.Context(), q, slotKey, id, body)
+	}); err != nil {
 		httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: err.Error()})
 		return
 	}
@@ -111,7 +113,9 @@ func (h *Handlers) unregister(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
-	if err := h.storage.Delete(r.Context(), q, slotKey, id); err != nil {
+	if err := h.storage.WithTable(r.Context(), q, func() error {
+		return h.storage.Delete(r.Context(), q, slotKey, id)
+	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			httputil.JSON(w, http.StatusNotFound, httputil.ErrorResponse{Error: "contribution not found"})
 			return
@@ -139,8 +143,12 @@ func (h *Handlers) list(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
-	out, err := h.storage.List(r.Context(), q, slotKey)
-	if err != nil {
+	var out []Contribution
+	if err := h.storage.WithTable(r.Context(), q, func() error {
+		var listErr error
+		out, listErr = h.storage.List(r.Context(), q, slotKey)
+		return listErr
+	}); err != nil {
 		httputil.JSON(w, http.StatusInternalServerError, httputil.ErrorResponse{Error: err.Error()})
 		return
 	}

--- a/internal/contributions/storage.go
+++ b/internal/contributions/storage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/pgerr"
 )
 
 // listLimit caps the row count returned by Storage.List so a slot
@@ -35,14 +36,45 @@ func NewStorage(modulePrefix string) *Storage {
 // contributions table name. Exposed for test diagnostics.
 func (s *Storage) TableName() string { return s.table }
 
-// EnsureTable runs CREATE TABLE IF NOT EXISTS. Dev fallback; prod
-// schema management lives in the lifecycle install hook.
+// EnsureTable creates the store in whatever schema q's search_path resolves to.
+// The store is per-APP (one table per module per app schema), so every caller
+// must already be scoped to one app — there is no once-per-process shortcut: a
+// deployed module's container serves many apps.
+//
+// Callers: the lifecycle install/upgrade hook (the platform's per-(app, module)
+// window, which is what provisions a deployed install) and WithTable's retry
+// (which heals an install that predates that hook). Both are idempotent.
+//
+// CONCURRENCY. CREATE TABLE IF NOT EXISTS is idempotent but NOT atomic — the
+// existence check and the catalog insert race, so two cold containers
+// provisioning the same app at the same instant can both pass the check and
+// then collide in pg_class. Two things prevent that, deliberately both:
+//
+//   - The advisory lock serializes provisioning per SCHEMA. Keyed on the
+//     resolved schema rather than on the module because the store is per-app:
+//     two apps must not queue behind each other, two cold starts for the SAME
+//     app must. It is the xact-scoped variant so it is released by the implicit
+//     transaction that ends this Exec, never leaked onto a pooled connection.
+//   - pgerr.RelationAlreadyExists is the backstop for what the lock cannot
+//     cover — a psql session, or any future non-SDK writer — at the cost of one
+//     error-code comparison.
+//
+// The three statements MUST stay in one argument-less Exec: pgx sends that over
+// the simple protocol, which Postgres runs as a single implicit transaction, and
+// that is the only thing making pg_advisory_xact_lock outlive its own statement
+// and still cover the CREATEs.
 func (s *Storage) EnsureTable(ctx context.Context, q db.Querier) error {
 	// Index name strips the surrounding quotes from the sanitized
 	// table name so it stays a bare identifier (Postgres errors on
 	// quoted index names that contain double-quotes).
-	idx := s.tableUnquoted() + "_slot_registered_idx"
+	bare := s.tableUnquoted()
+	idx := bare + "_slot_registered_idx"
+	// bare is <modulePrefix>_contributions, and modulePrefix is validated
+	// against moduleIDPattern in core.New(), so it cannot close the lock key's
+	// string literal.
 	stmt := fmt.Sprintf(`
+		SELECT pg_advisory_xact_lock(hashtext(current_schema() || '.%[3]s'));
+
 		CREATE TABLE IF NOT EXISTS %[1]s (
 		    slot            text NOT NULL,
 		    contribution_id text NOT NULL,
@@ -53,10 +85,38 @@ func (s *Storage) EnsureTable(ctx context.Context, q db.Querier) error {
 
 		CREATE INDEX IF NOT EXISTS %[2]s
 		    ON %[1]s (slot, registered_at DESC);`,
-		s.table, idx,
+		s.table, idx, bare,
 	)
-	_, err := q.Exec(ctx, stmt)
-	return err
+	if _, err := q.Exec(ctx, stmt); err != nil && !pgerr.RelationAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// WithTable runs op and, when op failed because the store does not exist in this
+// app's schema, creates it and runs op once more.
+//
+// This is the heal path for an install that predates the lifecycle provisioning
+// hook: the platform only opens an install/upgrade window when a migration
+// watermark moves, so an app already installed at the current version gets no
+// further lifecycle call and would otherwise never acquire the table. 42P01 is
+// the only error it acts on — the one code that means "never provisioned for
+// this app" rather than "this query is wrong" — so a provisioned store pays
+// nothing and a permission failure still surfaces to the caller.
+//
+// q MUST NOT be inside a caller-owned transaction: the failed statement aborts
+// it, so neither the CREATE nor the retry could run. Both call sites (the
+// /contrib handlers and Module.StoredContributions) hold a plain pooled
+// connection for exactly that reason.
+func (s *Storage) WithTable(ctx context.Context, q db.Querier, op func() error) error {
+	err := op()
+	if !pgerr.UndefinedTable(err) {
+		return err
+	}
+	if ensureErr := s.EnsureTable(ctx, q); ensureErr != nil {
+		return fmt.Errorf("contributions: provision %s: %w", s.table, ensureErr)
+	}
+	return op()
 }
 
 // tableUnquoted returns the table name without the pgx-Sanitize

--- a/internal/contributions/storage_test.go
+++ b/internal/contributions/storage_test.go
@@ -1,0 +1,156 @@
+package contributions
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeQuerier records every statement and returns a scripted error, so the
+// provisioning contract can be pinned without a database.
+type fakeQuerier struct {
+	stmts []string
+	err   error
+}
+
+func (f *fakeQuerier) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	f.stmts = append(f.stmts, sql)
+	return pgconn.CommandTag{}, f.err
+}
+
+func (f *fakeQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	f.stmts = append(f.stmts, sql)
+	return nil, f.err
+}
+
+func (f *fakeQuerier) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	f.stmts = append(f.stmts, sql)
+	return nil
+}
+
+func pgError(code string) error { return &pgconn.PgError{Code: code} }
+
+// TestEnsureTable_SingleExec pins the property the advisory lock depends on:
+// pgx only sends an argument-less Exec over the simple protocol, and only then
+// does Postgres wrap the whole string in ONE implicit transaction. Split into
+// separate Execs, pg_advisory_xact_lock would be released before the CREATE it
+// is supposed to guard, silently.
+func TestEnsureTable_SingleExec(t *testing.T) {
+	s := NewStorage("m9f1c4b2a7d8e4f0ab1c2d3e4f5061728")
+	q := &fakeQuerier{}
+
+	if err := s.EnsureTable(context.Background(), q); err != nil {
+		t.Fatalf("EnsureTable: %v", err)
+	}
+	if len(q.stmts) != 1 {
+		t.Fatalf("EnsureTable issued %d statements, want 1 — the lock and the CREATEs must share one implicit transaction", len(q.stmts))
+	}
+	stmt := q.stmts[0]
+	for _, want := range []string{
+		"pg_advisory_xact_lock(hashtext(current_schema()",
+		"CREATE TABLE IF NOT EXISTS",
+		"CREATE INDEX IF NOT EXISTS",
+	} {
+		if !strings.Contains(stmt, want) {
+			t.Errorf("statement is missing %q:\n%s", want, stmt)
+		}
+	}
+	// Unqualified: the table lands in whatever app schema search_path resolves
+	// to, which is what makes one binary serve many apps.
+	if strings.Contains(stmt, "app_") {
+		t.Errorf("statement hard-codes a schema:\n%s", stmt)
+	}
+}
+
+func TestEnsureTable_ToleratesLostCreateRace(t *testing.T) {
+	for _, code := range []string{"42P07", "23505"} {
+		t.Run(code, func(t *testing.T) {
+			s := NewStorage("mtolerate")
+			if err := s.EnsureTable(context.Background(), &fakeQuerier{err: pgError(code)}); err != nil {
+				t.Errorf("EnsureTable with %s = %v, want nil — the relation exists, which is the whole postcondition", code, err)
+			}
+		})
+	}
+	s := NewStorage("mtolerate")
+	if err := s.EnsureTable(context.Background(), &fakeQuerier{err: pgError("42501")}); err == nil {
+		t.Error("EnsureTable swallowed 42501 — a missing CREATE grant must surface")
+	}
+}
+
+func TestWithTable(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no failure: no provisioning", func(t *testing.T) {
+		s := NewStorage("mheal")
+		q := &fakeQuerier{}
+		calls := 0
+		if err := s.WithTable(ctx, q, func() error { calls++; return nil }); err != nil {
+			t.Fatalf("WithTable: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("op ran %d times, want 1", calls)
+		}
+		if len(q.stmts) != 0 {
+			t.Errorf("provisioned %d statements on a healthy store, want 0", len(q.stmts))
+		}
+	})
+
+	t.Run("42P01: provision then retry once", func(t *testing.T) {
+		s := NewStorage("mheal")
+		q := &fakeQuerier{}
+		calls := 0
+		err := s.WithTable(ctx, q, func() error {
+			calls++
+			if calls == 1 {
+				return pgError("42P01")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("WithTable: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("op ran %d times, want 2 (fail, then retry after provisioning)", calls)
+		}
+		if len(q.stmts) != 1 || !strings.Contains(q.stmts[0], "CREATE TABLE IF NOT EXISTS") {
+			t.Errorf("expected exactly one provisioning statement, got %v", q.stmts)
+		}
+	})
+
+	t.Run("still 42P01 after provisioning: no second retry", func(t *testing.T) {
+		s := NewStorage("mheal")
+		calls := 0
+		err := s.WithTable(ctx, &fakeQuerier{}, func() error { calls++; return pgError("42P01") })
+		if err == nil {
+			t.Fatal("WithTable = nil, want the persisting error")
+		}
+		if calls != 2 {
+			t.Errorf("op ran %d times, want 2 — the retry is once, not a loop", calls)
+		}
+	})
+
+	t.Run("other errors pass through untouched", func(t *testing.T) {
+		s := NewStorage("mheal")
+		q := &fakeQuerier{}
+		want := pgError("42501")
+		if err := s.WithTable(ctx, q, func() error { return want }); !errors.Is(err, want) {
+			t.Errorf("WithTable = %v, want the original error", err)
+		}
+		if len(q.stmts) != 0 {
+			t.Errorf("provisioned on a non-missing-table error: %v", q.stmts)
+		}
+	})
+
+	t.Run("provisioning failure names the store", func(t *testing.T) {
+		s := NewStorage("mheal")
+		q := &fakeQuerier{err: pgError("42501")}
+		err := s.WithTable(ctx, q, func() error { return pgError("42P01") })
+		if err == nil || !strings.Contains(err.Error(), "provision") {
+			t.Errorf("WithTable = %v, want a provisioning failure", err)
+		}
+	})
+}

--- a/internal/contributions/types.go
+++ b/internal/contributions/types.go
@@ -14,9 +14,13 @@
 //	    PRIMARY KEY (slot, contribution_id)
 //	)
 //
-// The host names the table prefix once (Config.ID) and the SDK creates
-// the table on Start if any slot has been declared. Production schema
-// management is handled by the lifecycle install hook in a follow-up.
+// The host names the table prefix once (Config.ID); the table itself is
+// per-APP, because the rows are (one app's copy of) the contributions
+// registered into that app's installs. So it is created per (app, module) by
+// the platform's lifecycle install/upgrade hook — see core.Module's
+// lifecycleProvisioner — never once per process: one deployed container serves
+// many apps and many schemas. Storage.WithTable heals an install that predates
+// that hook on first use.
 package contributions
 
 import (

--- a/internal/core/contrib_provision_test.go
+++ b/internal/core/contrib_provision_test.go
@@ -1,0 +1,389 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
+)
+
+// contribTestPayload is the shape a host declares for its slot; the register
+// route validates against it with DisallowUnknownFields.
+type contribTestPayload struct {
+	Label string `json:"label"`
+}
+
+// unreachableDSN is a DSN whose connect fails immediately (nothing listens on
+// port 1), so "did this code path touch Postgres at all?" becomes a testable
+// question without needing a database.
+const unreachableDSN = "postgres://u:p@127.0.0.1:1/none?sslmode=disable"
+
+func TestLifecycleProvisioner_AppScopeOnly(t *testing.T) {
+	resetDefault(t)
+	m := newTestModuleWithSecret(t, "provscope")
+
+	if p := m.lifecycleProvisioner(migration.ScopeModule); p != nil {
+		t.Error("module scope got a provisioner — the contributions store is per-APP, mod_<id> is shared across apps")
+	}
+	if p := m.lifecycleProvisioner(migration.ScopeApp); p == nil {
+		t.Error("app scope got no provisioner")
+	}
+}
+
+// TestLifecycleProvisioner_ReadsSlotsPerCall guards the ordering trap that would
+// disable this whole mechanism silently: the provisioner is built when ms.Init
+// mounts the routes, but ms.Provide runs afterwards. If the slot count were read
+// at mount time it would be zero for every real module.
+//
+// The DB is deliberately unreachable, so "returned nil" proves the hook did not
+// try to provision and a connect error proves it did.
+func TestLifecycleProvisioner_ReadsSlotsPerCall(t *testing.T) {
+	resetDefault(t)
+	t.Setenv(devMigrateEnvVar, "")
+	t.Setenv("DATABASE_URL", unreachableDSN)
+	m := newTestModuleWithSecret(t, "provslots")
+
+	// Captured exactly as mountSystemRoutes captures it: before any Provide.
+	provision := m.lifecycleProvisioner(migration.ScopeApp)
+	ctx := db.WithSchema(context.Background(), "app_11111111_1111_1111_1111_111111111111")
+
+	if err := provision(ctx); err != nil {
+		t.Fatalf("no slots declared: want a no-op, got %v", err)
+	}
+
+	m.ProvideSlot(NewContributionSlot[contribTestPayload]("auth-provider"))
+	if err := provision(ctx); err == nil {
+		t.Error("after ms.Provide the hook must reach the DB (unreachable here), got nil")
+	}
+}
+
+// TestLifecycleProvisioner_SkipsBareTunnelBody covers the dev-tunnel payload
+// shape (no schema, no credential): provisioning there would create a PER-APP
+// table in the connection's default schema, shared by every app. The dev plane
+// creates it per app schema in provisionDevAppSchema instead.
+func TestLifecycleProvisioner_SkipsBareTunnelBody(t *testing.T) {
+	resetDefault(t)
+	t.Setenv(devMigrateEnvVar, "")
+	t.Setenv("DATABASE_URL", unreachableDSN)
+	m := newTestModuleWithSecret(t, "provbare")
+	m.ProvideSlot(NewContributionSlot[contribTestPayload]("auth-provider"))
+
+	if err := m.lifecycleProvisioner(migration.ScopeApp)(context.Background()); err != nil {
+		t.Fatalf("schema-less lifecycle body: want a no-op, got %v", err)
+	}
+}
+
+// TestContributionStore_DeployedPlane_Integration is the end-to-end proof that
+// the store exists on the DEPLOYED path — the plane where Start() returns into
+// lambda.Start and nothing below it ever runs.
+//
+// Deployed-plane fidelity: MS_LOCAL_DB_URL is unset (so devMode is false and the
+// dev per-app middleware is NOT mounted), the app schema arrives the way the
+// platform sends it — in the lifecycle body, and in the request context the way
+// the Lambda shim injects it — and every call goes through the real mounted
+// routes. The one substitution is the DB credential: the connection is the local
+// superuser rather than a minted r_<app>_<mod> role, because only the platform
+// can mint those. system's TestInstallHandler_ProvisionRunsInLifecycleContext
+// covers the credential half of the same body.
+//
+// Runs against the dev Postgres on :5433 (matches dev_migrate_test.go);
+// skipped in short mode or when Postgres is unreachable.
+func TestContributionStore_DeployedPlane_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	resetDefault(t)
+	t.Setenv(devMigrateEnvVar, "")
+	t.Setenv("DATABASE_URL", "postgres://mirrorstack:mirrorstack@localhost:5433/mirrorstack?sslmode=disable")
+
+	// A platform-minted module id (m + 32 hex) so the physical table name — and
+	// the dev cross-module guard's view of it — is the production shape.
+	const moduleID = "m9f1c4b2a7d8e4f0ab1c2d3e4f5061728"
+	m := newTestModuleWithSecret(t, moduleID)
+	if m.devMode {
+		t.Fatal("devMode is true — this test must exercise the non-dev plane")
+	}
+	// Declared AFTER New, exactly as a module's main.go does it.
+	m.ProvideSlot(NewContributionSlot[contribTestPayload]("auth-provider"))
+
+	ctx := context.Background()
+	pool, release, err := m.resolvePool(ctx)
+	if err != nil {
+		t.Skipf("skipping (no postgres on :5433): %v", err)
+	}
+	defer release()
+	if err := pool.Ping(ctx); err != nil {
+		t.Skipf("skipping (no postgres on :5433): %v", err)
+	}
+
+	appInstalled := "aaaaaaaa-1111-1111-1111-111111111111"  // gets the install hook
+	appLegacy := "bbbbbbbb-2222-2222-2222-222222222222"     // installed before the hook existed
+	appConcurrent := "cccccccc-3333-3333-3333-333333333333" // two cold starts at once
+	schemas := map[string]string{}
+	ident := func(s string) string { return pgx.Identifier{s}.Sanitize() }
+	for _, id := range []string{appInstalled, appLegacy, appConcurrent} {
+		s, ok := runtimeAppSchema(t, id)
+		if !ok {
+			t.Fatalf("derive schema for %s", id)
+		}
+		schemas[id] = s
+	}
+	cleanup := func() {
+		for _, s := range schemas {
+			if _, err := pool.Exec(ctx, `DROP SCHEMA IF EXISTS `+ident(s)+` CASCADE`); err != nil {
+				t.Logf("cleanup %s: %v", s, err)
+			}
+		}
+		if _, err := pool.Exec(ctx, `DROP TABLE IF EXISTS public.`+ident(moduleID+"_contributions")); err != nil {
+			t.Logf("cleanup public leak check: %v", err)
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+	// The platform owns the app schema; it exists before any lifecycle call.
+	for _, s := range schemas {
+		if _, err := pool.Exec(ctx, `CREATE SCHEMA `+ident(s)); err != nil {
+			t.Fatalf("create schema %s: %v", s, err)
+		}
+	}
+
+	table := moduleID + "_contributions"
+	tableIn := func(schema string) bool {
+		var exists bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM information_schema.tables
+				WHERE table_schema = $1 AND table_name = $2 AND table_type = 'BASE TABLE'
+			)`, schema, table).Scan(&exists); err != nil {
+			t.Fatalf("table lookup in %s: %v", schema, err)
+		}
+		return exists
+	}
+
+	// --- Phase 1: the platform's deployed install POST creates the store -----
+	if code, body := postInstall(t, m, appInstalled, schemas[appInstalled]); code != http.StatusOK {
+		t.Fatalf("install status = %d, body = %s", code, body)
+	}
+	if !tableIn(schemas[appInstalled]) {
+		t.Fatalf("%s.%s missing after install — the deployed plane still has no contribution store", schemas[appInstalled], table)
+	}
+	if tableIn("public") {
+		t.Errorf("public.%s exists — a PER-APP table landed in the default schema", table)
+	}
+	if tableIn(schemas[appLegacy]) {
+		t.Errorf("installing app %s also created the store in %s — the store is not app-scoped", appInstalled, schemas[appLegacy])
+	}
+	var idxCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM pg_indexes WHERE schemaname = $1 AND indexname = $2`,
+		schemas[appInstalled], table+"_slot_registered_idx").Scan(&idxCount); err != nil {
+		t.Fatalf("index lookup: %v", err)
+	}
+	if idxCount != 1 {
+		t.Errorf("slot/registered_at index count = %d, want 1 — the statement after the advisory lock did not run", idxCount)
+	}
+
+	// Re-running install is idempotent (the platform re-POSTs install on a dev
+	// refresh and on a retry after a partial failure).
+	if code, body := postInstall(t, m, appInstalled, schemas[appInstalled]); code != http.StatusOK {
+		t.Fatalf("second install status = %d, body = %s", code, body)
+	}
+
+	// --- Phase 2: the store is usable and app-scoped through the real routes -
+	contributor := "dddddddd-4444-4444-4444-444444444444"
+	if code, body := postContribution(t, m, schemas[appInstalled], contributor, `{"label":"Google"}`); code != http.StatusOK {
+		t.Fatalf("register status = %d, body = %s", code, body)
+	}
+	if got := listContributions(t, m, schemas[appInstalled]); len(got) != 1 || got[0] != contributor {
+		t.Errorf("app %s contributions = %v, want [%s]", appInstalled, got, contributor)
+	}
+
+	// --- Phase 3: a read heals an install that predates the hook -------------
+	// This app never received an install/upgrade call carrying the hook, which is
+	// every app already installed when this ships: the platform sends no
+	// lifecycle call at all once the migration watermark is at target.
+	stored, err := m.StoredContributions(db.WithSchema(ctx, schemas[appLegacy]), "auth-provider")
+	if err != nil {
+		t.Fatalf("StoredContributions on an unprovisioned app: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Errorf("stored = %v, want empty for an app nobody contributed to", stored)
+	}
+	if !tableIn(schemas[appLegacy]) {
+		t.Errorf("%s.%s missing — the read did not heal the unprovisioned app", schemas[appLegacy], table)
+	}
+	// Healed, and still isolated: app A's row is not visible here.
+	if got := listContributions(t, m, schemas[appLegacy]); len(got) != 0 {
+		t.Errorf("app %s contributions = %v, want none — rows leaked across app schemas", appLegacy, got)
+	}
+
+	// --- Phase 4: concurrent provisioning of ONE app does not fight ----------
+	// Two cold containers serving the same app race on CREATE TABLE IF NOT
+	// EXISTS, which is idempotent but not atomic. All of them must succeed.
+	const racers = 8
+	var wg sync.WaitGroup
+	codes := make([]int, racers)
+	bodies := make([]string, racers)
+	for i := range racers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			codes[i], bodies[i] = postInstall(t, m, appConcurrent, schemas[appConcurrent])
+		}()
+	}
+	wg.Wait()
+	for i, code := range codes {
+		if code != http.StatusOK {
+			t.Errorf("concurrent install %d status = %d, body = %s", i, code, bodies[i])
+		}
+	}
+	if !tableIn(schemas[appConcurrent]) {
+		t.Errorf("%s.%s missing after %d concurrent installs", schemas[appConcurrent], table, racers)
+	}
+}
+
+// TestContributionStore_DevPlaneUnchanged_Integration is the "do not disturb
+// dev" guard for the two dev-facing halves of this change: the per-app store is
+// still created by the dev middleware's lazy provisioning, and the dev tunnel's
+// bare install body (no schema, no credential — what the platform sends over a
+// tunnel with a service token) still creates nothing, rather than dropping a
+// per-app table into the shared default schema.
+func TestContributionStore_DevPlaneUnchanged_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	resetDefault(t)
+	t.Setenv(devMigrateEnvVar, "postgres://mirrorstack:mirrorstack@localhost:5433/mirrorstack?sslmode=disable")
+
+	const moduleID = "m3a2b1c09876543210fedcba987654321"
+	m := newTestModuleWithSecret(t, moduleID)
+	if !m.devMode {
+		t.Fatal("devMode is false — this test must exercise the dev plane")
+	}
+	m.ProvideSlot(NewContributionSlot[contribTestPayload]("auth-provider"))
+
+	ctx := context.Background()
+	pool, release, err := m.resolvePool(ctx)
+	if err != nil {
+		t.Skipf("skipping (no postgres on :5433): %v", err)
+	}
+	defer release()
+	if err := pool.Ping(ctx); err != nil {
+		t.Skipf("skipping (no postgres on :5433): %v", err)
+	}
+
+	schema, _ := devAppSchemaName("eeeeeeee-5555-5555-5555-555555555555")
+	table := moduleID + "_contributions"
+	ident := func(s string) string { return pgx.Identifier{s}.Sanitize() }
+	cleanup := func() {
+		if _, err := pool.Exec(ctx, `DROP SCHEMA IF EXISTS `+ident(schema)+` CASCADE`); err != nil {
+			t.Logf("cleanup %s: %v", schema, err)
+		}
+		if _, err := pool.Exec(ctx, `DROP TABLE IF EXISTS public.`+ident(table)); err != nil {
+			t.Logf("cleanup public leak check: %v", err)
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	if err := m.ensureDevAppSchema(ctx, schema); err != nil {
+		t.Fatalf("dev provision %s: %v", schema, err)
+	}
+	inSchema := func(s string) bool {
+		var exists bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM information_schema.tables
+				WHERE table_schema = $1 AND table_name = $2
+			)`, s, table).Scan(&exists); err != nil {
+			t.Fatalf("table lookup in %s: %v", s, err)
+		}
+		return exists
+	}
+	if !inSchema(schema) {
+		t.Errorf("%s.%s missing — dev lazy provisioning regressed", schema, table)
+	}
+
+	// The tunnel install shape: appId only.
+	req := httptest.NewRequest("POST", "/__mirrorstack/platform/lifecycle/app/install",
+		strings.NewReader(`{"appId":"eeeeeeee-5555-5555-5555-555555555555"}`))
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bare-body install status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if inSchema("public") {
+		t.Errorf("public.%s exists — a schema-less lifecycle call created a per-app table in the shared schema", table)
+	}
+}
+
+// runtimeAppSchema derives app_<id> the way both the platform and the dev
+// middleware do.
+func runtimeAppSchema(t *testing.T, appID string) (string, bool) {
+	t.Helper()
+	return devAppSchemaName(appID)
+}
+
+// postInstall drives the real platform lifecycle route with the body shape the
+// platform's DEPLOYED transport sends (appId + schema; the credential half is
+// covered in system/lifecycle_test.go).
+func postInstall(t *testing.T, m *Module, appID, schema string) (int, string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"appId":%q,"schema":%q}`, appID, schema)
+	req := httptest.NewRequest("POST", "/__mirrorstack/platform/lifecycle/app/install", strings.NewReader(body))
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+// postContribution registers one contribution through the mounted /contrib
+// route, with the app schema in the request context the way the Lambda shim
+// injects it on the deployed plane.
+func postContribution(t *testing.T, m *Module, schema, contributorID, payload string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/__mirrorstack/contrib/auth-provider/"+contributorID, strings.NewReader(payload))
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	req = req.WithContext(db.WithSchema(req.Context(), schema))
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+	return rec.Code, rec.Body.String()
+}
+
+// listContributions reads the slot through the mounted route and returns the
+// contribution ids.
+func listContributions(t *testing.T, m *Module, schema string) []string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/__mirrorstack/contrib/auth-provider", nil)
+	req.Header.Set("X-MS-Internal-Secret", "secret")
+	req = req.WithContext(db.WithSchema(req.Context(), schema))
+	rec := httptest.NewRecorder()
+	m.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Contributions []struct {
+			ID string `json:"id"`
+		} `json:"contributions"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	ids := make([]string, 0, len(resp.Contributions))
+	for _, c := range resp.Contributions {
+		ids = append(ids, c.ID)
+	}
+	return ids
+}

--- a/internal/core/contrib_provision_test.go
+++ b/internal/core/contrib_provision_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -26,6 +27,32 @@ type contribTestPayload struct {
 // port 1), so "did this code path touch Postgres at all?" becomes a testable
 // question without needing a database.
 const unreachableDSN = "postgres://u:p@127.0.0.1:1/none?sslmode=disable"
+
+const contributionDefaultDevDSN = "postgres://mirrorstack:mirrorstack@localhost:5433/mirrorstack?sslmode=disable"
+
+// contributionIntegrationDSN uses the same DATABASE_URL contract as the CI
+// integration job. Developers without one configured retain the historical
+// localhost:5433 fallback.
+func contributionIntegrationDSN() (dsn string, required bool) {
+	if dsn := strings.TrimSpace(os.Getenv("DATABASE_URL")); dsn != "" {
+		return dsn, true
+	}
+	return contributionDefaultDevDSN, false
+}
+
+// requireContributionPostgres only skips when a developer has not configured a
+// database. A supplied DATABASE_URL is an explicit integration-test contract,
+// so a connection failure must fail CI instead of silently reducing coverage.
+func requireContributionPostgres(t *testing.T, required bool, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if required {
+		t.Fatalf("configured DATABASE_URL is unavailable: %v", err)
+	}
+	t.Skipf("skipping (no DATABASE_URL and default Postgres is unavailable): %v", err)
+}
 
 func TestLifecycleProvisioner_AppScopeOnly(t *testing.T) {
 	resetDefault(t)
@@ -95,15 +122,17 @@ func TestLifecycleProvisioner_SkipsBareTunnelBody(t *testing.T) {
 // can mint those. system's TestInstallHandler_ProvisionRunsInLifecycleContext
 // covers the credential half of the same body.
 //
-// Runs against the dev Postgres on :5433 (matches dev_migrate_test.go);
-// skipped in short mode or when Postgres is unreachable.
+// Runs against DATABASE_URL when configured (including CI), otherwise the dev
+// Postgres on :5433. The fallback may skip when unavailable; a configured
+// database must be reachable.
 func TestContributionStore_DeployedPlane_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 	resetDefault(t)
 	t.Setenv(devMigrateEnvVar, "")
-	t.Setenv("DATABASE_URL", "postgres://mirrorstack:mirrorstack@localhost:5433/mirrorstack?sslmode=disable")
+	dsn, databaseRequired := contributionIntegrationDSN()
+	t.Setenv("DATABASE_URL", dsn)
 
 	// A platform-minted module id (m + 32 hex) so the physical table name — and
 	// the dev cross-module guard's view of it — is the production shape.
@@ -117,13 +146,9 @@ func TestContributionStore_DeployedPlane_Integration(t *testing.T) {
 
 	ctx := context.Background()
 	pool, release, err := m.resolvePool(ctx)
-	if err != nil {
-		t.Skipf("skipping (no postgres on :5433): %v", err)
-	}
+	requireContributionPostgres(t, databaseRequired, err)
 	defer release()
-	if err := pool.Ping(ctx); err != nil {
-		t.Skipf("skipping (no postgres on :5433): %v", err)
-	}
+	requireContributionPostgres(t, databaseRequired, pool.Ping(ctx))
 
 	appInstalled := "aaaaaaaa-1111-1111-1111-111111111111"  // gets the install hook
 	appLegacy := "bbbbbbbb-2222-2222-2222-222222222222"     // installed before the hook existed
@@ -262,7 +287,8 @@ func TestContributionStore_DevPlaneUnchanged_Integration(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 	resetDefault(t)
-	t.Setenv(devMigrateEnvVar, "postgres://mirrorstack:mirrorstack@localhost:5433/mirrorstack?sslmode=disable")
+	dsn, databaseRequired := contributionIntegrationDSN()
+	t.Setenv(devMigrateEnvVar, dsn)
 
 	const moduleID = "m3a2b1c09876543210fedcba987654321"
 	m := newTestModuleWithSecret(t, moduleID)
@@ -273,13 +299,9 @@ func TestContributionStore_DevPlaneUnchanged_Integration(t *testing.T) {
 
 	ctx := context.Background()
 	pool, release, err := m.resolvePool(ctx)
-	if err != nil {
-		t.Skipf("skipping (no postgres on :5433): %v", err)
-	}
+	requireContributionPostgres(t, databaseRequired, err)
 	defer release()
-	if err := pool.Ping(ctx); err != nil {
-		t.Skipf("skipping (no postgres on :5433): %v", err)
-	}
+	requireContributionPostgres(t, databaseRequired, pool.Ping(ctx))
 
 	schema, _ := devAppSchemaName("eeeeeeee-5555-5555-5555-555555555555")
 	table := moduleID + "_contributions"

--- a/internal/core/db.go
+++ b/internal/core/db.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
+	"github.com/mirrorstack-ai/app-module-sdk/system"
 )
 
 // DB returns a scoped database connection.
@@ -220,6 +221,43 @@ func (m *Module) lifecycleTxRunner(scope migration.Scope) migration.TxRunner {
 		return m.Tx
 	default:
 		panic("mirrorstack: lifecycleTxRunner: unhandled scope " + string(scope))
+	}
+}
+
+// lifecycleProvisioner returns the SDK-owned per-app setup the install/upgrade
+// handlers run for the given scope, or nil when there is nothing to provision.
+//
+// Today that is the contributions store: <Config.ID>_contributions holds one
+// app's registered contributions, so it lives in the APP schema and has to be
+// created once per (app, module). The platform's install/upgrade call is the
+// only deployed-plane window that carries both an app schema and a credential
+// allowed to create tables in it — a cold-start hook could not do this, because
+// one Lambda container serves many apps and would only ever provision the first
+// one it happened to see. Module scope has no store of its own (mod_<id> is
+// shared across apps, contributions are not), hence app scope only.
+func (m *Module) lifecycleProvisioner(scope migration.Scope) system.Provisioner {
+	if scope != migration.ScopeApp {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		// The slot count is read per CALL, never when the route is mounted:
+		// ms.Provide runs after ms.Init, which is what mounts the lifecycle
+		// routes, so a mount-time check would see zero slots for every module
+		// that declares any — and silently provision nothing, forever.
+		if m.contribReg.Len() == 0 {
+			return nil
+		}
+		// No schema in the lifecycle body means the tunnel payload shape, where
+		// the module runs against its own dev DB and the per-app store is
+		// created by ensureDevAppSchema instead. Creating it here would land a
+		// per-app table in the connection's default schema — the wrong place,
+		// and shared across every app.
+		if db.SchemaFrom(ctx) == "" {
+			return nil
+		}
+		return m.Tx(ctx, func(q db.Querier) error {
+			return m.contribStorage.EnsureTable(ctx, q)
+		})
 	}
 }
 

--- a/internal/core/dependency_local_test.go
+++ b/internal/core/dependency_local_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
@@ -741,32 +739,6 @@ func TestEnsureDevDirectoryPublished_OneShotSelfHeal(t *testing.T) {
 	m2.ensureDevDirectoryPublished(context.Background())
 	if *publishes2 != 0 {
 		t.Errorf("publish called %d times for an already-published module, want 0", *publishes2)
-	}
-}
-
-// TestIsRelationAlreadyExists covers the two SQLSTATEs a concurrent
-// CREATE TABLE IF NOT EXISTS can raise. Both mean the relation exists, which is
-// the entire postcondition ensureDevDirectory owes its caller.
-func TestIsRelationAlreadyExists(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"42P07 duplicate_table", &pgconn.PgError{Code: "42P07"}, true},
-		{"23505 catalog unique violation", &pgconn.PgError{Code: "23505"}, true},
-		{"wrapped 23505", fmt.Errorf("dev directory: %w", &pgconn.PgError{Code: "23505"}), true},
-		{"42501 insufficient_privilege is NOT a race", &pgconn.PgError{Code: "42501"}, false},
-		{"08006 connection failure is NOT a race", &pgconn.PgError{Code: "08006"}, false},
-		{"non-pg error", errors.New("boom"), false},
-		{"nil", nil, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isRelationAlreadyExists(tc.err); got != tc.want {
-				t.Errorf("isRelationAlreadyExists(%v) = %v, want %v", tc.err, got, tc.want)
-			}
-		})
 	}
 }
 

--- a/internal/core/dev_directory.go
+++ b/internal/core/dev_directory.go
@@ -13,7 +13,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/pgerr"
 )
 
 // The DEV-PLANE ANALOGUE of the platform's module_version_exposed_tables
@@ -277,7 +278,7 @@ func (m *Module) ensureDevDirectory(ctx context.Context) error {
 			exposes    jsonb NOT NULL DEFAULT '[]'::jsonb,
 			updated_at timestamptz NOT NULL DEFAULT now()
 		)`); err != nil {
-		if isRelationAlreadyExists(err) {
+		if pgerr.RelationAlreadyExists(err) {
 			// The tx is already aborted, so there is nothing to commit; the
 			// deferred Rollback cleans up. The postcondition holds regardless.
 			return nil
@@ -288,20 +289,6 @@ func (m *Module) ensureDevDirectory(ctx context.Context) error {
 		return fmt.Errorf("dev directory: commit: %w", err)
 	}
 	return nil
-}
-
-// isRelationAlreadyExists reports whether err is Postgres telling us the
-// relation we tried to create is already there. 42P07 is the direct
-// duplicate_table verdict; 23505 is the same race observed one layer down, as a
-// unique violation on the pg_class/pg_type catalog index, and is what
-// CREATE TABLE IF NOT EXISTS actually raises when two backends interleave
-// between the existence check and the insert.
-func isRelationAlreadyExists(err error) bool {
-	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) {
-		return false
-	}
-	return pgErr.Code == "42P07" || pgErr.Code == "23505"
 }
 
 // registerInDevDirectory upserts THIS module's row and reclaims its slug.

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -634,27 +634,14 @@ func (m *Module) Start() error {
 		}
 	}
 
-	// Auto-create the contributions table when any slot is declared.
-	// CREATE TABLE IF NOT EXISTS is safe to call on every Start; the
-	// guard keeps modules that never use Provide from
-	// touching their DB for an empty feature. Production schema
-	// management lands via the lifecycle install hook in a follow-up.
-	//
-	// Skipped in devMode: the store is per-app, so it is created per app schema
-	// during lazy provisioning (provisionDevAppSchema) rather than once in the
-	// connection's default schema here — otherwise it would land in the wrong
-	// (shared) place and every app's contributions would collide.
-	if !m.devMode && m.contribReg.Len() > 0 {
-		q, release, err := m.DB(context.Background())
-		if err != nil {
-			return fmt.Errorf("mirrorstack: contributions: open DB: %w", err)
-		}
-		if err := m.contribStorage.EnsureTable(context.Background(), q); err != nil {
-			release()
-			return fmt.Errorf("mirrorstack: contributions: ensure table: %w", err)
-		}
-		release()
-	}
+	// The contributions store is deliberately NOT created here. It is per-app
+	// and Start has no app, so creating it on the way to ListenAndServe put it
+	// in the connection's default schema, where no request ever looks for it —
+	// and Lambda returns above this line anyway, which is how a deployed host
+	// ended up with no store at all. Provisioning is the per-(app, module)
+	// lifecycle hook's job (lifecycleProvisioner, db.go); dev additionally
+	// creates it per app schema in provisionDevAppSchema, which is what serves
+	// the tunnel's schema-less install body.
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -868,9 +855,14 @@ func (m *Module) mountSystemRoutes() {
 				// them independently.
 				for _, scope := range migration.AllScopes() {
 					runTx := m.lifecycleTxRunner(scope)
+					// SDK-owned per-app setup (the contributions store) rides
+					// install + upgrade, not downgrade: reverting an author's
+					// migrations is not a reason to drop SDK infrastructure, and
+					// re-creating it there would be the only DDL a downgrade did.
+					provision := m.lifecycleProvisioner(scope)
 					r.Route("/"+string(scope), func(r chi.Router) {
-						r.With(smallBody).Post("/install", system.InstallHandler(m.config.SQL, scope, runTx))
-						r.With(smallBody).Post("/upgrade", system.UpgradeHandler(m.config.SQL, scope, runTx))
+						r.With(smallBody).Post("/install", system.InstallHandler(m.config.SQL, scope, runTx, provision))
+						r.With(smallBody).Post("/upgrade", system.UpgradeHandler(m.config.SQL, scope, runTx, provision))
 						r.With(smallBody).Post("/downgrade", system.DowngradeHandler(m.config.SQL, scope, runTx))
 						r.With(smallBody).Post("/uninstall", system.UninstallHandler()) // no scope — no-op for both
 
@@ -1013,13 +1005,28 @@ func Contributions() []contributions.SlotInfo {
 // entry's ID is the contributing module's id (the registration key), which a
 // host can use to address that module. Use this on the HOST side to consume
 // contributions (e.g. oauth-core listing its registered auth providers).
+//
+// A host installed before the SDK provisioned this store on install has no
+// table for the app yet; the first read creates it (see Storage.WithTable) and
+// returns empty, instead of failing the host with a missing-relation error it
+// has no way to act on.
 func (m *Module) StoredContributions(ctx context.Context, slot string) ([]contributions.Contribution, error) {
-	q, release, err := DB(ctx)
+	// m.DB, not the package-level DB: that one resolves through the DEFAULT
+	// module, so a non-default *Module would read another module's pool.
+	q, release, err := m.DB(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
-	return m.contribStorage.List(ctx, q, slot)
+	var out []contributions.Contribution
+	if err := m.contribStorage.WithTable(ctx, q, func() error {
+		var listErr error
+		out, listErr = m.contribStorage.List(ctx, q, slot)
+		return listErr
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // StoredContributions reads stored contributions for a slot on the default

--- a/internal/pgerr/pgerr.go
+++ b/internal/pgerr/pgerr.go
@@ -1,0 +1,47 @@
+// Package pgerr classifies the Postgres error codes the SDK's own
+// infrastructure DDL has to interpret rather than propagate. It exists because
+// both internal/core (the dev dependency directory) and internal/contributions
+// (the per-app contribution store) create tables lazily and must read the same
+// two verdicts out of a driver error the same way.
+package pgerr
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// RelationAlreadyExists reports whether err is Postgres telling us the relation
+// we tried to create is already there. 42P07 is the direct duplicate_table
+// verdict; 23505 is the same race observed one layer down, as a unique
+// violation on the pg_class/pg_type catalog index, and is what
+// CREATE TABLE IF NOT EXISTS actually raises when two backends interleave
+// between the existence check and the insert.
+//
+// Both outcomes mean THE RELATION EXISTS, which is the whole postcondition a
+// create-if-absent helper owes its caller, so callers treat both as success.
+func RelationAlreadyExists(err error) bool {
+	return hasCode(err, "42P07", "23505")
+}
+
+// UndefinedTable reports whether err is Postgres 42P01 — the statement named a
+// relation that does not exist. For a table the SDK provisions per app, this is
+// the one error that means "never provisioned for this app" rather than "the
+// query is wrong", so a caller can create the table and retry instead of
+// failing a request it has no other way to satisfy.
+func UndefinedTable(err error) bool {
+	return hasCode(err, "42P01")
+}
+
+func hasCode(err error, codes ...string) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	for _, c := range codes {
+		if pgErr.Code == c {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pgerr/pgerr_test.go
+++ b/internal/pgerr/pgerr_test.go
@@ -1,0 +1,58 @@
+package pgerr
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestRelationAlreadyExists covers the two SQLSTATEs a concurrent
+// CREATE TABLE IF NOT EXISTS can raise. Both mean the relation exists, which is
+// the entire postcondition a create-if-absent helper owes its caller.
+func TestRelationAlreadyExists(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"42P07 duplicate_table", &pgconn.PgError{Code: "42P07"}, true},
+		{"23505 catalog unique violation", &pgconn.PgError{Code: "23505"}, true},
+		{"wrapped 23505", fmt.Errorf("dev directory: %w", &pgconn.PgError{Code: "23505"}), true},
+		{"42501 insufficient_privilege is NOT a race", &pgconn.PgError{Code: "42501"}, false},
+		{"08006 connection failure is NOT a race", &pgconn.PgError{Code: "08006"}, false},
+		{"42P01 undefined_table is the opposite verdict", &pgconn.PgError{Code: "42P01"}, false},
+		{"non-pg error", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RelationAlreadyExists(tc.err); got != tc.want {
+				t.Errorf("RelationAlreadyExists(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUndefinedTable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"42P01 undefined_table", &pgconn.PgError{Code: "42P01"}, true},
+		{"wrapped 42P01", fmt.Errorf("list contributions: %w", &pgconn.PgError{Code: "42P01"}), true},
+		{"42703 undefined_column is a different bug", &pgconn.PgError{Code: "42703"}, false},
+		{"42501 insufficient_privilege must not be healed", &pgconn.PgError{Code: "42501"}, false},
+		{"non-pg error", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UndefinedTable(tc.err); got != tc.want {
+				t.Errorf("UndefinedTable(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/system/lifecycle.go
+++ b/system/lifecycle.go
@@ -94,8 +94,21 @@ type UninstallResult struct {
 	Status string `json:"status"`
 }
 
-// InstallHandler returns an http.HandlerFunc that applies all migrations
-// from sqlFS in numeric ascending order.
+// Provisioner is SDK-owned per-app setup the install and upgrade handlers run
+// BEFORE the author's migrations, inside the already-injected lifecycle context
+// (schema + credential). Nil means this scope has nothing to provision.
+//
+// It exists because some per-app state belongs to the SDK rather than to the
+// module author's sql/app set — today the contributions store — and this is the
+// only window on the deployed plane where the SDK holds an app schema together
+// with a credential allowed to create tables in it. A failure fails the
+// lifecycle call: reporting install success over a module whose declared
+// contribution slots have no store is the silent half-install this hook exists
+// to remove.
+type Provisioner func(ctx context.Context) error
+
+// InstallHandler returns an http.HandlerFunc that runs provision (when
+// non-nil), then applies all migrations from sqlFS in numeric ascending order.
 //
 // The SDK does NOT track which migrations were previously applied — it is a
 // stateless executor. The platform decides when install is appropriate (a
@@ -103,10 +116,13 @@ type UninstallResult struct {
 // calls install at most once per (scope, target). Calling install twice
 // will re-run every migration and likely fail with "relation already exists"
 // — platform-side saga logic is responsible for preventing that.
-func InstallHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner) http.HandlerFunc {
+func InstallHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner, provision Provisioner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, ok := injectInstallContext(w, r)
 		if !ok {
+			return
+		}
+		if !runProvision(w, ctx, provision) {
 			return
 		}
 		migrations, err := migration.List(sqlFS, scope)
@@ -124,6 +140,25 @@ func InstallHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner
 		}
 		httputil.JSON(w, http.StatusOK, LifecycleResult{Applied: applied})
 	}
+}
+
+// runProvision runs the SDK-owned setup step, if any. Returns ok=false after
+// writing a 500 when it fails; callers must return without touching w again.
+//
+// The failure is reported in the LifecycleError shape with an empty Applied
+// list, which is the truth (no migration ran) and is what the platform's
+// partial-apply parser expects — it leaves the install watermark at 0 so a
+// retry re-runs the whole install rather than resuming past a store that was
+// never created.
+func runProvision(w http.ResponseWriter, ctx context.Context, provision Provisioner) bool {
+	if provision == nil {
+		return true
+	}
+	if err := provision(ctx); err != nil {
+		httputil.JSON(w, http.StatusInternalServerError, LifecycleError{Error: "provision: " + err.Error()})
+		return false
+	}
+	return true
 }
 
 // injectInstallContext reads an optional InstallRequest body and folds its
@@ -195,7 +230,12 @@ func writeBodyDecodeError(w http.ResponseWriter, err error) {
 // path), the migrations run under that per-(app, module) credential with
 // search_path = schema — identical to InstallHandler. A bare {from, to}
 // body keeps the dev-tunnel env-pool behavior.
-func UpgradeHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner) http.HandlerFunc {
+//
+// provision runs here as well as on install, and BEFORE the (From, To] window
+// is even resolved: upgrade is the only lifecycle call an already-installed app
+// ever receives, so it is the only place SDK-owned per-app state can converge
+// for an install that predates it. An empty window must still provision.
+func UpgradeHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner, provision Provisioner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		req, ok := decodeUpgradeRequest(w, r)
 		if !ok {
@@ -203,6 +243,9 @@ func UpgradeHandler(sqlFS fs.FS, scope migration.Scope, runTx migration.TxRunner
 		}
 		ctx, ok := injectLifecycleContext(w, r.Context(), req.InstallRequest)
 		if !ok {
+			return
+		}
+		if !runProvision(w, ctx, provision) {
 			return
 		}
 

--- a/system/lifecycle_test.go
+++ b/system/lifecycle_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +38,7 @@ func noopTxRunner(t *testing.T) migration.TxRunner {
 func TestInstallHandler_EmptyFS(t *testing.T) {
 	t.Parallel()
 
-	h := InstallHandler(nil, migration.ScopeApp, noopTxRunner(t))
+	h := InstallHandler(nil, migration.ScopeApp, noopTxRunner(t), nil)
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", nil))
@@ -71,7 +72,7 @@ func TestUpgradeHandler_RequiresFromTo(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t))
+			h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t), nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", strings.NewReader(tc.body)))
 
@@ -100,7 +101,7 @@ func TestUpgradeHandler_RejectsSemver(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t))
+			h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t), nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", strings.NewReader(tc.body)))
 
@@ -121,7 +122,7 @@ func TestUpgradeHandler_UnknownTarget(t *testing.T) {
 	// doesn't exist in the (empty) migrations list. The handler must
 	// translate the runner's error into a 400 (caller asked for something
 	// the module doesn't have).
-	h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t))
+	h := UpgradeHandler(nil, migration.ScopeApp, noopTxRunner(t), nil)
 	body := strings.NewReader(`{"from": "0000", "to": "0001"}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
@@ -140,7 +141,7 @@ func TestUpgradeHandler_NoOp(t *testing.T) {
 	fsys := fstest.MapFS{
 		"sql/app/0008_a.up.sql": &fstest.MapFile{Data: []byte("")},
 	}
-	h := UpgradeHandler(fsys, migration.ScopeApp, noopTxRunner(t))
+	h := UpgradeHandler(fsys, migration.ScopeApp, noopTxRunner(t), nil)
 	body := strings.NewReader(`{"from": "0008", "to": "0008"}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
@@ -206,7 +207,7 @@ func TestUpgradeHandler_ModuleScope(t *testing.T) {
 	fsys := fstest.MapFS{
 		"sql/module/0008_a.up.sql": &fstest.MapFile{Data: []byte("")},
 	}
-	h := UpgradeHandler(fsys, migration.ScopeModule, noopTxRunner(t))
+	h := UpgradeHandler(fsys, migration.ScopeModule, noopTxRunner(t), nil)
 	body := strings.NewReader(`{"from": "0008", "to": "0008"}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
@@ -221,7 +222,7 @@ func TestInstallHandler_BadFS_500(t *testing.T) {
 
 	// fs.FS that returns an error on every Open. fs.ReadDir wraps and
 	// surfaces the error — the handler should respond 500.
-	h := InstallHandler(errFS{}, migration.ScopeApp, noopTxRunner(t))
+	h := InstallHandler(errFS{}, migration.ScopeApp, noopTxRunner(t), nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", nil))
 
@@ -267,7 +268,7 @@ func TestInstallHandler_BodyInjectsCredentialAndSchema(t *testing.T) {
 	t.Setenv("MS_LOCAL_DB_URL", "postgres://envuser:envpw@db.platform.local:6543/platform_apps?sslmode=disable")
 
 	var captured context.Context
-	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured), nil)
 
 	body := strings.NewReader(`{
 		"appId":  "6c8d1234-abcd-ef01-2345-6789abcdef00",
@@ -310,7 +311,7 @@ func TestInstallHandler_EmptyBodyFallsThrough(t *testing.T) {
 	// leave ctx without injected schema or credential so resolvePoolFor
 	// falls back to the dev pool.
 	var captured context.Context
-	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured), nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", nil))
 
@@ -328,7 +329,7 @@ func TestInstallHandler_EmptyBodyFallsThrough(t *testing.T) {
 func TestInstallHandler_MalformedBody_400(t *testing.T) {
 	t.Parallel()
 
-	h := InstallHandler(nil, migration.ScopeApp, noopTxRunner(t))
+	h := InstallHandler(nil, migration.ScopeApp, noopTxRunner(t), nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", strings.NewReader(`{not json`)))
 
@@ -347,7 +348,7 @@ func TestUpgradeHandler_BodyInjectsCredentialAndSchema(t *testing.T) {
 	t.Setenv("MS_LOCAL_DB_URL", "postgres://envuser:envpw@db.platform.local:6543/platform_apps?sslmode=disable")
 
 	var captured context.Context
-	h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured), nil)
 
 	body := strings.NewReader(`{
 		"from":   "0000",
@@ -390,7 +391,7 @@ func TestUpgradeHandler_FromToOnlyKeepsDevPath(t *testing.T) {
 	// and leave ctx without schema or credential so resolvePoolFor falls
 	// back to the dev pool — pre-existing behavior, unchanged.
 	var captured context.Context
-	h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured), nil)
 	body := strings.NewReader(`{"from": "0000", "to": "0001"}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
@@ -426,7 +427,7 @@ func TestUpgradeHandler_MalformedCredential_400(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, noopTxRunner(t))
+			h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, noopTxRunner(t), nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", strings.NewReader(tc.body)))
 
@@ -443,7 +444,7 @@ func TestUpgradeHandler_EmptyCredentialObjectFallsThrough(t *testing.T) {
 	// `"credential": {}` (shape compat) must behave like no credential at
 	// all — same rule injectInstallContext applies on install.
 	var captured context.Context
-	h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured), nil)
 	body := strings.NewReader(`{"from": "0000", "to": "0001", "credential": {}}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade", body))
@@ -497,7 +498,7 @@ func TestInstallHandler_PartialBodyOmitsMissingFields(t *testing.T) {
 	t.Parallel()
 
 	var captured context.Context
-	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured))
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured), nil)
 	body := strings.NewReader(`{"schema": "app_only"}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", body))
@@ -510,5 +511,101 @@ func TestInstallHandler_PartialBodyOmitsMissingFields(t *testing.T) {
 	}
 	if db.CredentialFrom(captured) != nil {
 		t.Error("CredentialFrom should be nil when body omits credential")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Provisioner — SDK-owned per-app setup on install + upgrade.
+// ---------------------------------------------------------------------------
+
+// TestInstallHandler_ProvisionRunsInLifecycleContext is the wiring guard for the
+// deployed plane: the hook must see the schema + credential the platform sent,
+// because that is the only thing that puts the SDK's per-app DDL in the right
+// app's schema under a role allowed to run it.
+func TestInstallHandler_ProvisionRunsInLifecycleContext(t *testing.T) {
+	// Not t.Parallel: t.Setenv on MS_LOCAL_DB_URL would race the env base read.
+	t.Setenv("MS_LOCAL_DB_URL", "postgres://envuser:envpw@db.platform.local:6543/platform_apps?sslmode=disable")
+
+	calls := 0
+	var provisionCtx context.Context
+	provision := func(ctx context.Context) error {
+		calls++
+		provisionCtx = ctx
+		return nil
+	}
+
+	var captured context.Context
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, capturingTxRunner(t, &captured), provision)
+	body := strings.NewReader(`{
+		"appId":  "6c8d1234-abcd-ef01-2345-6789abcdef00",
+		"schema": "app_6c8d1234_abcd_ef01_2345_6789abcdef00",
+		"credential": {"username": "r_6c8d1234_oauth-core", "token": "secret-token"}
+	}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", body))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("provisioner called %d times, want exactly 1", calls)
+	}
+	if got := db.SchemaFrom(provisionCtx); got != "app_6c8d1234_abcd_ef01_2345_6789abcdef00" {
+		t.Errorf("provision ctx SchemaFrom = %q, want app_6c8d1234_...", got)
+	}
+	if cred := db.CredentialFrom(provisionCtx); cred == nil || cred.Username != "r_6c8d1234_oauth-core" {
+		t.Errorf("provision ctx CredentialFrom = %+v, want the per-install role", cred)
+	}
+}
+
+// TestInstallHandler_ProvisionFailureFailsInstall pins both the disposition and
+// the ORDER: a provisioning failure must 500 with an empty Applied list, and the
+// migration runner must never run (noopTxRunner fails the test if it does, and
+// the FS here HAS a migration to apply).
+func TestInstallHandler_ProvisionFailureFailsInstall(t *testing.T) {
+	t.Parallel()
+
+	provision := func(context.Context) error { return errors.New("no CREATE on schema") }
+	h := InstallHandler(oneMigrationFS(), migration.ScopeApp, noopTxRunner(t), provision)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/install", strings.NewReader(`{"schema": "app_x"}`)))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+	var got LifecycleError
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Applied) != 0 {
+		t.Errorf("applied = %v, want empty — nothing ran", got.Applied)
+	}
+	if !strings.Contains(got.Error, "no CREATE on schema") {
+		t.Errorf("error = %q, want the provisioner's cause", got.Error)
+	}
+}
+
+// TestUpgradeHandler_ProvisionRunsOnEmptyWindow is the convergence guard for
+// installs that predate the hook. An app already at the target version yields an
+// EMPTY migration slice, and the hook still has to run — otherwise the lifecycle
+// would never create the store for an app installed before this shipped.
+func TestUpgradeHandler_ProvisionRunsOnEmptyWindow(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	provision := func(context.Context) error { calls++; return nil }
+	// from == to → Slice is empty → noopTxRunner must not be called.
+	h := UpgradeHandler(oneMigrationFS(), migration.ScopeApp, noopTxRunner(t), provision)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/upgrade",
+		strings.NewReader(`{"from": "0001", "to": "0001", "schema": "app_x"}`)))
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if calls != 1 {
+		t.Errorf("provisioner called %d times on an empty upgrade window, want 1", calls)
 	}
 }


### PR DESCRIPTION
A module that hosts a contribution slot has **no contribution store at all** once deployed, so every push into it 500s and every read errors — and both are swallowed, leaving the host rendering a confident empty section. Indistinguishable, to an operator, from "nobody contributed anything".

`Start()` returns early under `runtime.IsLambda()`, and the `EnsureTable` bootstrap sits *below* that early return **and** is gated `if !m.devMode`. The only other call site is `provisionDevAppSchema`, also dev-only. `types.go` said outright that production schema management was "a follow-up"; it was never built.

This matters most for `auth-provider` — the slot oauth-google uses to register itself with oauth-core. **Sign-in.**

## The seam

Per-app lifecycle provisioning, the only place on the deployed plane where the SDK holds an app schema *and* a credential permitted to DDL in it (`GRANT USAGE, CREATE ON SCHEMA … TO r_<app8>_<mod>`, and the runtime identity is that same role).

- a new `system.Provisioner` runs **before** the author's migrations in `InstallHandler`/`UpgradeHandler`. Failure returns the `LifecycleError` shape with an empty `Applied`, so the platform's partial-apply parser leaves the watermark at 0 and a retry re-runs everything.
- `EnsureTable` is now a single argument-less `Exec` carrying `pg_advisory_xact_lock(hashtext(current_schema() || '.<table>'))` + `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`. pgx uses the simple protocol when there are no bind args, which Postgres runs as one implicit transaction — that is the only thing making the xact lock outlive its own statement. Keyed on `current_schema()`, so two apps don't queue behind each other but two cold starts for one app do. `42P07`/`23505` tolerated as a backstop.
- the dev tunnel is untouched: the tunnel install body carries no schema or credential, so the provisioner's `SchemaFrom(ctx) == ""` guard skips it.

Also removed the dead `Start()` bootstrap (it created a per-app table in `public` on the one plane it ran) and fixed `Module.StoredContributions` calling the package-level `DB(ctx)` — the default module's pool — instead of `m.DB(ctx)`.

## Two findings that changed the design

**The scope/slot gate cannot be evaluated at mount time.** `m.contribReg.Len()` is 0 when `ms.Init` mounts the routes, because `ms.Provide` runs after. A mount-time check would have made this entire fix a silent no-op for every real module. The count is read per call; `TestLifecycleProvisioner_ReadsSlotsPerCall` guards it.

**An existing install at watermark == target gets no lifecycle call at all** — `runInstallLifecycle`'s `default:` branch is a no-op. Since an SDK rebuild adds no migration, that is the *common* case. Those heal on first use: the first `StoredContributions` or `/contrib` request provisions and retries once. This is why the lazy heal path is not optional.

## Verification

`gofmt`/`build`/`vet` clean; `go test -count=1 ./...` and `go test -race -count=1 ./...` both green across 21 packages. Integration tests ran against a **real Postgres** (`postgres:17-alpine`).

Each half was disabled in turn to prove the tests have teeth:

| disabled | result |
|---|---|
| provisioner | `…_contributions missing after install — the deployed plane still has no contribution store` |
| heal | `relation "m9f1c…_contributions" does not exist (SQLSTATE 42P01)` — the reported bug, verbatim |
| advisory lock + tolerance | 3/3 runs failed with `duplicate key … pg_type_typname_nsp_index` on 8 concurrent installs |

## Rollout, and what this does NOT fix

Modules must be rebuilt against this SDK and redeployed. No platform change, no migration, no re-install.

⚠️ **Necessary, not sufficient.** The contribution *push* still has no deployed transport — `pushContribution` → `RequestModule` resolves WS dev-tunnel sessions only. Until that exists, contributions remain non-functional in production regardless of this fix. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)