### PR TITLE
feat: declare and isolate module storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Keys auto-prefixed: developer writes `"views:123"`, Redis stores `"app_abc123:mo
 
 ### Platform resources
 
-- [x] `ms.Storage(ctx)` — S3 presigned URLs + CDN (R2 cache) + multipart upload
+- [x] `ms.RequireStorage()` + `ms.Storage(ctx)` — explicit startup declaration, then per-request S3 presigned URLs + CDN (R2 cache) + multipart upload
 - [x] `ms.Cache(ctx)` — scoped Redis (ElastiCache Serverless)
 - [x] `ms.Meter(ctx)` — custom usage metrics for billing
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -116,12 +116,14 @@ ms.Tx(ctx, func(q db.Querier) error {
 | Function | Purpose |
 |---|---|
 | `ms.Cache(ctx)` | Per-app Redis client. |
-| `ms.Storage(ctx)` | Per-app object storage. S3 as origin + presigned multipart upload; reads served from R2 via a Cloudflare Worker cache layer. |
+| `ms.RequireStorage()` | Declare during startup that this module needs its per-app object-storage namespace. Undeclared modules receive no credential. |
+| `ms.Storage(ctx)` | Resolve the declared per-app object storage for this request. S3 is the origin with presigned multipart upload; reads may be served through the configured CDN. Returns `storage.ErrNotDeclared` if startup omitted `ms.RequireStorage()`. |
 | `ms.Meter(name, opts...)` | DECLARE a usage metric once in setup. The kind is an OPTION (`ms.Counter`/`ms.Gauge`); also `ms.Unit`/`ms.Price`. A custom metric MUST pass exactly one kind. A reserved `infra.*`/`platform.*` metric may pass `ms.Price` ONLY (a customer-passthrough override; kind/unit are platform-owned). Registers it into the manifest; returns nothing. |
 | `ms.Record(ctx, name, value)` | Emit a usage event BY NAME for a declared metric. Mirrors `ms.Emits`/`ms.Emit`; errors on an undeclared name and on a reserved `infra.*`/`platform.*` name (platform-measured, never self-reported). |
 
 ```go
 // setup
+ms.RequireStorage()
 ms.Meter("transcode.minutes", ms.Counter, ms.Unit("minute"), ms.Price(50_000))
 ms.Meter("infra.compute.ms", ms.Price(0)) // reserved: absorb platform compute (price-only override)
 // handler

--- a/docs/zh-TW/api-reference.md
+++ b/docs/zh-TW/api-reference.md
@@ -112,10 +112,12 @@ ms.Tx(ctx, func(q db.Querier) error {
 | Function | 用途 |
 |---|---|
 | `ms.Cache(ctx)` | Per-app Redis client。 |
-| `ms.Storage(ctx)` | Per-app 物件儲存。S3 為 origin + presigned multipart upload;讀取走 R2 + Cloudflare Worker 做快取。 |
+| `ms.RequireStorage()` | 啟動時明確宣告模組需要 per-app 物件儲存命名空間；未宣告的模組不會取得任何儲存憑證。 |
+| `ms.Storage(ctx)` | 取得此 request 已宣告的 per-app 物件儲存。S3 為 origin，支援 presigned multipart upload；若啟動時未呼叫 `ms.RequireStorage()`，回傳 `storage.ErrNotDeclared`。 |
 | `ms.Meter(ctx).Record(metric, value)` | 以非同步 Lambda invoke 發送計費事件。 |
 
 ```go
+ms.RequireStorage() // setup
 ms.Meter(r.Context()).Record("transcode.minutes", 12)
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jackc/pgx/v5 v5.9.2
@@ -31,7 +32,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -130,7 +130,7 @@ type Module struct {
 	devCache       *cache.Client
 	devCacheErr    error
 	devStorageOnce sync.Once // dev mode: lazy storage init
-	devStorage     *storage.Client
+	devStorage     *storage.DevMinter
 	devStorageErr  error
 	taskHandlers   map[string]taskEntry // registered task handlers (startup-only writes)
 	sqsClient      *msqs.Client         // nil in dev mode (MS_TASK_QUEUE_URL unset)

--- a/internal/core/resources.go
+++ b/internal/core/resources.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
@@ -46,32 +47,51 @@ func (m *Module) resolveCache(ctx context.Context) (*cache.Client, func(), error
 	return m.devCache, func() {}, nil
 }
 
-// Storage returns a scoped storage client. Keys are auto-prefixed with the app/module path.
+// Storage returns a client always scoped to apps/<app>/<module>/.
 //
 //	s, err := mod.Storage(r.Context())
 //	if err != nil { ... }
 //	url, err := s.PresignPut(ctx, "photo.jpg", 15*time.Minute)
 //	cdnURL, err := s.URL("photo.jpg")
 //
-// Prefix and CDN base come from the per-invocation STS credential in production,
-// or env vars in dev mode. resolveStorage handles both paths — NewFromCredential
-// already sets the prefix from cred.Prefix, so no separate ForApp scoping is needed.
+// Production enforces that scope with the IAM session policy on the vended
+// credential; the client prefix is ergonomics, not a boundary. Dev mints the
+// same policy shape and MinIO enforces it.
 func (m *Module) Storage(ctx context.Context) (storage.Storer, error) {
 	return m.resolveStorage(ctx)
 }
 
 func (m *Module) resolveStorage(ctx context.Context) (*storage.Client, error) {
-	// Production: STS credentials from Lambda payload.
+	// DEPLOYED: the platform vends a prefix-scoped STS credential per invocation.
 	// No caching — S3 client creation is cheap (no I/O), and STS tokens rotate
 	// frequently. Caching by AccessKeyID risks using stale credentials.
 	if cred := storage.CredentialFrom(ctx); cred != nil {
 		return storage.NewFromCredential(*cred)
 	}
-	// Dev: env vars
+	if storage.UnderLambda() {
+		return nil, storage.ErrNotVended
+	}
+	identity := auth.Get(ctx)
+	if identity == nil || identity.AppID == "" {
+		return nil, fmt.Errorf("mirrorstack: Storage: this request carries no app scope (no X-MS-App-ID header), so there is no app prefix to scope storage to")
+	}
+	// DEV: initialize the parent-key minter once, then mint/cache by request scope.
 	m.devStorageOnce.Do(func() {
-		m.devStorage, m.devStorageErr = storage.Open(context.Background())
+		cfg, err := storage.DevConfigFromEnv()
+		if err != nil {
+			m.devStorageErr = err
+			return
+		}
+		m.devStorage, m.devStorageErr = storage.NewDevMinter(context.Background(), cfg)
 	})
-	return m.devStorage, m.devStorageErr
+	if m.devStorageErr != nil {
+		return nil, m.devStorageErr
+	}
+	cred, err := m.devStorage.Mint(ctx, identity.AppID, m.config.ID)
+	if err != nil {
+		return nil, err
+	}
+	return storage.NewFromCredentialForDev(cred, m.devStorage.Config())
 }
 
 // Meter DECLARES a usage metric. Call it once, up front (startup code), per

--- a/internal/core/resources.go
+++ b/internal/core/resources.go
@@ -58,7 +58,17 @@ func (m *Module) resolveCache(ctx context.Context) (*cache.Client, func(), error
 // credential; the client prefix is ergonomics, not a boundary. Dev mints the
 // same policy shape and MinIO enforces it.
 func (m *Module) Storage(ctx context.Context) (storage.Storer, error) {
+	if !m.registry.StorageRequired() {
+		return nil, storage.ErrNotDeclared
+	}
 	return m.resolveStorage(ctx)
+}
+
+// RequireStorage opts this module into its per-app storage namespace. Call it
+// once during startup before Start. The declaration is emitted in the manifest
+// and is the platform's gate for vending temporary storage credentials.
+func (m *Module) RequireStorage() {
+	m.registry.RequireStorage()
 }
 
 func (m *Module) resolveStorage(ctx context.Context) (*storage.Client, error) {
@@ -158,6 +168,9 @@ func Cache(ctx context.Context) (cache.Cacher, func(), error) {
 func Storage(ctx context.Context) (storage.Storer, error) {
 	return mustDefault("Storage").Storage(ctx)
 }
+
+// RequireStorage declares storage on the default module created by Init.
+func RequireStorage() { mustDefault("RequireStorage").RequireStorage() }
 
 // Meter declares a usage metric on the default module (side effect, no return).
 // Panics before Init.

--- a/internal/core/storage_test.go
+++ b/internal/core/storage_test.go
@@ -7,8 +7,25 @@ import (
 	"testing"
 
 	"github.com/mirrorstack-ai/app-module-sdk/internal/lambdaenv"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/registry"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 )
+
+func TestStorageRequiresDeclarationBeforeResolving(t *testing.T) {
+	t.Setenv(lambdaenv.VarName, "test-function")
+	m := &Module{config: Config{ID: "media"}, registry: registry.New()}
+
+	_, err := m.Storage(context.Background())
+	if !errors.Is(err, storage.ErrNotDeclared) {
+		t.Fatalf("undeclared Storage err=%v, want ErrNotDeclared", err)
+	}
+
+	m.RequireStorage()
+	_, err = m.Storage(context.Background())
+	if !errors.Is(err, storage.ErrNotVended) {
+		t.Fatalf("declared Storage err=%v, want ErrNotVended from the next gate", err)
+	}
+}
 
 func TestResolveStorageUnderLambdaWithoutCredential(t *testing.T) {
 	t.Setenv(lambdaenv.VarName, "test-function")

--- a/internal/core/storage_test.go
+++ b/internal/core/storage_test.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/lambdaenv"
+	"github.com/mirrorstack-ai/app-module-sdk/storage"
+)
+
+func TestResolveStorageUnderLambdaWithoutCredential(t *testing.T) {
+	t.Setenv(lambdaenv.VarName, "test-function")
+	m := &Module{config: Config{ID: "media"}}
+	_, err := m.resolveStorage(context.Background())
+	if !errors.Is(err, storage.ErrNotVended) || !strings.Contains(err.Error(), "PLATFORM") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestResolveStorageDevRequiresAppScope(t *testing.T) {
+	t.Setenv(lambdaenv.VarName, "")
+	m := &Module{config: Config{ID: "media"}}
+	_, err := m.resolveStorage(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "app scope") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -207,6 +207,7 @@ type Registry struct {
 	outboundContributions []OutboundContribution
 	mcpTools              []MCPToolDecl
 	mcpResources          []MCPResourceDecl
+	storageRequired       bool
 	ui                    *ModuleUI
 }
 
@@ -215,6 +216,23 @@ func New() *Registry {
 		routes:     make(map[Scope][]Route),
 		subscribes: make(map[string]string),
 	}
+}
+
+// RequireStorage declares that this module needs its per-app object-storage
+// namespace. The platform uses this manifest bit as the authorization gate for
+// vending a temporary S3 credential; modules that do not opt in receive no S3
+// access at all.
+func (r *Registry) RequireStorage() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.storageRequired = true
+}
+
+// StorageRequired reports whether RequireStorage was declared.
+func (r *Registry) StorageRequired() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.storageRequired
 }
 
 // SetDescription sets the module's human-readable description. Last-write-wins;

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -2,6 +2,18 @@ package registry
 
 import "testing"
 
+func TestRequireStorageIsExplicitAndIdempotent(t *testing.T) {
+	r := New()
+	if r.StorageRequired() {
+		t.Fatal("new registry unexpectedly requires storage")
+	}
+	r.RequireStorage()
+	r.RequireStorage()
+	if !r.StorageRequired() {
+		t.Fatal("RequireStorage did not persist the declaration")
+	}
+}
+
 func TestAddRoute_GroupsByScope(t *testing.T) {
 	t.Parallel()
 

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -139,6 +139,11 @@ func Cache(ctx context.Context) (cache.Cacher, func(), error) { return core.Cach
 // Storage returns a scoped storage client on the default module.
 func Storage(ctx context.Context) (storage.Storer, error) { return core.Storage(ctx) }
 
+// RequireStorage declares that this module needs its per-app object-storage
+// namespace. Call it during startup before Start; the platform vends storage
+// credentials only to modules whose manifest contains this declaration.
+func RequireStorage() { core.RequireStorage() }
+
 // MetricOption configures a metric at declaration. The KIND is itself an option
 // (Counter / Gauge), alongside Unit and Price.
 type MetricOption = meter.MetricOption

--- a/storage/credential.go
+++ b/storage/credential.go
@@ -12,24 +12,32 @@ const credentialKey = contextKey("ms-storage-credential")
 // Credential holds S3 access details injected by the platform per invocation.
 // STS temp credentials scoped to the app/module S3 prefix.
 type Credential struct {
-	Bucket          string `json:"bucket"`
-	Region          string `json:"region"`
-	Prefix          string `json:"prefix"`  // "apps/app_abc/mod_media/"
+	Bucket string `json:"bucket"`
+	Region string `json:"region"`
+	// Prefix is apps/<appUUID>/<moduleUUID>/ in production. Dev uses
+	// apps/<appUUID>/<module-slug>/ because the SDK has no production module UUID.
+	Prefix          string `json:"prefix"`
 	CDNBase         string `json:"cdnBase"` // "https://media.mirrorstack.ai"
 	AccessKeyID     string `json:"accessKeyId"`
 	SecretAccessKey string `json:"secretAccessKey"`
 	SessionToken    string `json:"sessionToken"`
 }
 
-// validate checks that all required fields are populated. Prefix is required:
+// validate checks that all required fields are populated. Prefix is required
+// and must end in "/":
 // without it, tenant isolation silently collapses to the bucket root because
-// every key is concatenated as `prefix + key` with an empty prefix. Storage
+// every key is concatenated as `prefix + key` with an empty prefix. The trailing
+// slash prevents a policy for one prefix from matching a sibling whose ID merely
+// starts with the same bytes. Storage
 // credentials are not pool-cached (STS rotation makes caching by AccessKeyID
 // unsafe), so there is no cacheKey method. SessionToken is optional —
 // long-lived IAM keys are valid in dev/test setups.
 func (c Credential) validate() error {
 	if c.Bucket == "" || c.Region == "" || c.Prefix == "" || c.CDNBase == "" || c.AccessKeyID == "" || c.SecretAccessKey == "" {
 		return fmt.Errorf("mirrorstack/storage: credential missing required fields (bucket=%q region=%q prefix=%q cdnBase=%q)", c.Bucket, c.Region, c.Prefix, c.CDNBase)
+	}
+	if c.Prefix[len(c.Prefix)-1] != '/' {
+		return fmt.Errorf("mirrorstack/storage: credential prefix must end with a trailing slash to preserve the storage policy boundary (prefix=%q)", c.Prefix)
 	}
 	return nil
 }

--- a/storage/credential.go
+++ b/storage/credential.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 type contextKey string
@@ -14,13 +15,18 @@ const credentialKey = contextKey("ms-storage-credential")
 type Credential struct {
 	Bucket string `json:"bucket"`
 	Region string `json:"region"`
-	// Prefix is apps/<appUUID>/<moduleUUID>/ in production. Dev uses
-	// apps/<appUUID>/<module-slug>/ because the SDK has no production module UUID.
+	// Prefix is apps/<appUUID>/<moduleUUID>/ in production. Dev uses the
+	// platform-minted Config.ID in the module segment because no installed
+	// module UUID exists in a local tunnel session.
 	Prefix          string `json:"prefix"`
 	CDNBase         string `json:"cdnBase"` // "https://media.mirrorstack.ai"
 	AccessKeyID     string `json:"accessKeyId"`
 	SecretAccessKey string `json:"secretAccessKey"`
 	SessionToken    string `json:"sessionToken"`
+	// ExpiresAt is the STS credential expiry. Older platform envelopes may omit
+	// it; clients preserve that compatibility while newer envelopes use it to
+	// keep presigned URLs within the credential lifetime.
+	ExpiresAt time.Time `json:"expiresAt,omitzero"`
 }
 
 // validate checks that all required fields are populated. Prefix is required

--- a/storage/dev.go
+++ b/storage/dev.go
@@ -1,0 +1,242 @@
+package storage
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"golang.org/x/sync/singleflight"
+)
+
+var (
+	canonicalAppIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	// Deliberately narrower than internal/core's moduleIDPattern. This local
+	// restatement prevents future callers from injecting policy metacharacters.
+	devModuleIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,35}$`)
+)
+
+const (
+	// maxPresignTTL is the longest expiry a module asks for today (video-core: 15 min).
+	maxPresignTTL = 900 * time.Second
+	// presignSafetyMargin leaves room for request and clock skew around redemption.
+	presignSafetyMargin = 300 * time.Second
+	// A SigV4 presigned URL carries X-Amz-Security-Token and S3 validates that token on
+	// redemption, so the URL's real validity is min(X-Amz-Expires, remaining token lifetime).
+	// Re-minting this far ahead of expiry guarantees a presigned URL never outlives its token.
+	refreshBuffer = maxPresignTTL + presignSafetyMargin
+)
+
+// DevConfig is the local S3-compatible (MinIO) plane, read from env.
+type DevConfig struct {
+	Bucket, Region  string
+	Endpoint        string // S3_ENDPOINT — container -> MinIO
+	PublicEndpoint  string // S3_PUBLIC_ENDPOINT — browser -> MinIO
+	STSEndpoint     string // S3_STS_ENDPOINT — defaults to Endpoint
+	CDNBase         string // CDN_BASE_URL
+	RoleARN         string // S3_STS_ROLE_ARN
+	AccessKeyID     string // AWS_ACCESS_KEY_ID
+	SecretAccessKey string // AWS_SECRET_ACCESS_KEY
+}
+
+// DevConfigFromEnv reads the explicitly configured local plane. Decision 03
+// forbids an AWS fallback: that fallback previously waited on EC2 IMDS and
+// returned a 502 while also collapsing tenant scope to the bucket root.
+func DevConfigFromEnv() (DevConfig, error) {
+	cfg := DevConfig{
+		Bucket:          valueOr("S3_BUCKET", "mirrorstack-dev"),
+		Region:          valueOr("S3_REGION", "ap-northeast-1"),
+		Endpoint:        os.Getenv("S3_ENDPOINT"),
+		PublicEndpoint:  os.Getenv("S3_PUBLIC_ENDPOINT"),
+		STSEndpoint:     os.Getenv("S3_STS_ENDPOINT"),
+		CDNBase:         os.Getenv("CDN_BASE_URL"),
+		RoleARN:         valueOr("S3_STS_ROLE_ARN", "arn:minio:iam:::role/module-storage"),
+		AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
+		SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+	}
+	missing := make([]string, 0, 3)
+	for name, value := range map[string]string{
+		"S3_ENDPOINT": cfg.Endpoint, "AWS_ACCESS_KEY_ID": cfg.AccessKeyID, "AWS_SECRET_ACCESS_KEY": cfg.SecretAccessKey,
+	} {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		// Stable ordering makes the diagnostic useful in logs and tests.
+		order := []string{"S3_ENDPOINT", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}
+		missing = missing[:0]
+		for _, name := range order {
+			if os.Getenv(name) == "" {
+				missing = append(missing, name)
+			}
+		}
+		return DevConfig{}, fmt.Errorf("mirrorstack/storage: dev storage is not configured (missing %s) — `mirrorstack dev` expects a local S3 (MinIO) at S3_ENDPOINT with S3_PUBLIC_ENDPOINT for browser-reachable presigned URLs; see ms-app-modules/docker-compose.yml. Refusing to fall back to real AWS: an unconfigured fall-back is what made presign hang for 5 s on EC2 IMDS and then 502", strings.Join(missing, ", "))
+	}
+	if cfg.PublicEndpoint == "" {
+		cfg.PublicEndpoint = cfg.Endpoint
+	}
+	if cfg.STSEndpoint == "" {
+		cfg.STSEndpoint = cfg.Endpoint
+	}
+	if cfg.CDNBase == "" {
+		cfg.CDNBase = strings.TrimRight(cfg.PublicEndpoint, "/") + "/" + cfg.Bucket
+	}
+	return cfg, nil
+}
+
+func valueOr(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
+
+type assumeRoleAPI interface {
+	AssumeRole(context.Context, *sts.AssumeRoleInput, ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+}
+
+type cachedCredential struct {
+	credential Credential
+	expires    time.Time
+}
+
+// DevMinter exchanges the local parent key for prefix-scoped session keys.
+type DevMinter struct {
+	cfg   DevConfig
+	sts   assumeRoleAPI
+	now   func() time.Time
+	mu    sync.RWMutex
+	cache map[string]cachedCredential
+	group singleflight.Group
+}
+
+// NewDevMinter constructs the local STS client without invoking network I/O.
+func NewDevMinter(_ context.Context, cfg DevConfig) (*DevMinter, error) {
+	if cfg.Endpoint == "" || cfg.STSEndpoint == "" || cfg.PublicEndpoint == "" || cfg.AccessKeyID == "" || cfg.SecretAccessKey == "" {
+		return nil, fmt.Errorf("mirrorstack/storage: invalid dev storage configuration: endpoints and parent credentials are required")
+	}
+	awsCfg := aws.Config{
+		Region:      cfg.Region,
+		Credentials: credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
+	}
+	api := sts.NewFromConfig(awsCfg, func(o *sts.Options) { o.BaseEndpoint = aws.String(cfg.STSEndpoint) })
+	return &DevMinter{cfg: cfg, sts: api, now: time.Now, cache: make(map[string]cachedCredential)}, nil
+}
+
+// Config returns the endpoints needed to construct a dev client after Mint.
+func (m *DevMinter) Config() DevConfig { return m.cfg }
+
+// NewFromCredentialForDev constructs the same credential-based client while
+// separating container and browser endpoints. Credential validation prevents
+// this path (and every other constructor) from ever producing an empty prefix.
+func NewFromCredentialForDev(cred Credential, cfg DevConfig) (*Client, error) {
+	return newClient(cred, cfg.Endpoint, cfg.PublicEndpoint)
+}
+
+// Mint returns a cached credential for the app/module pair or assumes a fresh role.
+func (m *DevMinter) Mint(ctx context.Context, appID, moduleID string) (Credential, error) {
+	appID, moduleID, err := canonicalizeDevScope(appID, moduleID)
+	if err != nil {
+		return Credential{}, err
+	}
+	key := appID + "\x00" + moduleID
+	if cred, ok := m.cached(key); ok {
+		return cred, nil
+	}
+	value, err, _ := m.group.Do(key, func() (any, error) {
+		if cred, ok := m.cached(key); ok {
+			return cred, nil
+		}
+		return m.mint(ctx, key, appID, moduleID)
+	})
+	if err != nil {
+		return Credential{}, err
+	}
+	return value.(Credential), nil
+}
+
+// canonicalizeDevScope is the sole path for caller-influenced identifiers into
+// dev credential cache keys, storage prefixes, and IAM session policies.
+func canonicalizeDevScope(appID, moduleID string) (string, string, error) {
+	canonicalAppID := strings.ToLower(appID)
+	if !canonicalAppIDPattern.MatchString(canonicalAppID) {
+		return "", "", fmt.Errorf("mirrorstack/storage: appID must be a canonical UUID — it is interpolated into the IAM session policy Resource, where a `*` would widen the grant to every app")
+	}
+	if !devModuleIDPattern.MatchString(moduleID) {
+		return "", "", fmt.Errorf("mirrorstack/storage: moduleID must match %s — it is interpolated into the IAM session policy Resource, where metacharacters could widen the grant", devModuleIDPattern)
+	}
+	return canonicalAppID, moduleID, nil
+}
+
+func (m *DevMinter) cached(key string) (Credential, bool) {
+	m.mu.RLock()
+	entry, ok := m.cache[key]
+	m.mu.RUnlock()
+	return entry.credential, ok && entry.expires.Sub(m.now()) > refreshBuffer
+}
+
+func (m *DevMinter) mint(ctx context.Context, cacheKey, appID, moduleID string) (Credential, error) {
+	prefix := "apps/" + appID + "/" + moduleID + "/"
+	policy, err := devSessionPolicy(m.cfg.Bucket, prefix)
+	if err != nil {
+		return Credential{}, err
+	}
+	digest := sha256.Sum256([]byte(appID + "\x00" + moduleID))
+	sessionName := "ms-dev-" + hex.EncodeToString(digest[:12])
+	duration := int32(3600)
+	out, err := m.sts.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn: aws.String(m.cfg.RoleARN), RoleSessionName: aws.String(sessionName),
+		Policy: aws.String(policy), DurationSeconds: aws.Int32(duration),
+	})
+	if err != nil {
+		return Credential{}, fmt.Errorf("mirrorstack/storage: dev STS AssumeRole failed: %w", err)
+	}
+	if out.Credentials == nil || out.Credentials.AccessKeyId == nil || out.Credentials.SecretAccessKey == nil || out.Credentials.Expiration == nil {
+		return Credential{}, fmt.Errorf("mirrorstack/storage: dev STS returned incomplete credentials")
+	}
+	cred := Credential{Bucket: m.cfg.Bucket, Region: m.cfg.Region, Prefix: prefix, CDNBase: m.cfg.CDNBase,
+		AccessKeyID: *out.Credentials.AccessKeyId, SecretAccessKey: *out.Credentials.SecretAccessKey}
+	if out.Credentials.SessionToken != nil {
+		cred.SessionToken = *out.Credentials.SessionToken
+	}
+	if err := cred.validate(); err != nil {
+		return Credential{}, err
+	}
+	m.mu.Lock()
+	m.cache[cacheKey] = cachedCredential{credential: cred, expires: *out.Credentials.Expiration}
+	m.mu.Unlock()
+	return cred, nil
+}
+
+type sessionPolicy struct {
+	Version   string            `json:"Version"`
+	Statement []policyStatement `json:"Statement"`
+}
+type policyStatement struct {
+	Sid      string   `json:"Sid"`
+	Effect   string   `json:"Effect"`
+	Action   []string `json:"Action"`
+	Resource string   `json:"Resource"`
+}
+
+func devSessionPolicy(bucket, prefix string) (string, error) {
+	p := sessionPolicy{Version: "2012-10-17", Statement: []policyStatement{{
+		Sid: "OwnPrefixRW", Effect: "Allow", Action: []string{"s3:GetObject", "s3:PutObject"},
+		Resource: "arn:aws:s3:::" + bucket + "/" + prefix + "*",
+	}}}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("mirrorstack/storage: encode dev session policy: %w", err)
+	}
+	return string(b), nil
+}

--- a/storage/dev.go
+++ b/storage/dev.go
@@ -20,9 +20,9 @@ import (
 
 var (
 	canonicalAppIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
-	// Deliberately narrower than internal/core's moduleIDPattern. This local
-	// restatement prevents future callers from injecting policy metacharacters.
-	devModuleIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,35}$`)
+	// This mirrors internal/core's Config.ID contract. The local restatement
+	// keeps the storage package independent while preventing policy metacharacters.
+	devModuleIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,35}$`)
 )
 
 const (
@@ -34,6 +34,9 @@ const (
 	// redemption, so the URL's real validity is min(X-Amz-Expires, remaining token lifetime).
 	// Re-minting this far ahead of expiry guarantees a presigned URL never outlives its token.
 	refreshBuffer = maxPresignTTL + presignSafetyMargin
+	// A tunnel can visit many app/module pairs over its lifetime. Keep the
+	// parent-key process from retaining every expired scope forever.
+	maxDevCredentialCacheEntries = 256
 )
 
 // DevConfig is the local S3-compatible (MinIO) plane, read from env.
@@ -205,7 +208,8 @@ func (m *DevMinter) mint(ctx context.Context, cacheKey, appID, moduleID string) 
 		return Credential{}, fmt.Errorf("mirrorstack/storage: dev STS returned incomplete credentials")
 	}
 	cred := Credential{Bucket: m.cfg.Bucket, Region: m.cfg.Region, Prefix: prefix, CDNBase: m.cfg.CDNBase,
-		AccessKeyID: *out.Credentials.AccessKeyId, SecretAccessKey: *out.Credentials.SecretAccessKey}
+		AccessKeyID: *out.Credentials.AccessKeyId, SecretAccessKey: *out.Credentials.SecretAccessKey,
+		ExpiresAt: *out.Credentials.Expiration}
 	if out.Credentials.SessionToken != nil {
 		cred.SessionToken = *out.Credentials.SessionToken
 	}
@@ -213,9 +217,26 @@ func (m *DevMinter) mint(ctx context.Context, cacheKey, appID, moduleID string) 
 		return Credential{}, err
 	}
 	m.mu.Lock()
+	if _, exists := m.cache[cacheKey]; !exists && len(m.cache) >= maxDevCredentialCacheEntries {
+		m.evictOneLocked()
+	}
 	m.cache[cacheKey] = cachedCredential{credential: cred, expires: *out.Credentials.Expiration}
 	m.mu.Unlock()
 	return cred, nil
+}
+
+func (m *DevMinter) evictOneLocked() {
+	var oldestKey string
+	var oldestExpiry time.Time
+	for key, entry := range m.cache {
+		if oldestKey == "" || entry.expires.Before(oldestExpiry) {
+			oldestKey = key
+			oldestExpiry = entry.expires
+		}
+	}
+	if oldestKey != "" {
+		delete(m.cache, oldestKey)
+	}
 }
 
 type sessionPolicy struct {
@@ -231,7 +252,7 @@ type policyStatement struct {
 
 func devSessionPolicy(bucket, prefix string) (string, error) {
 	p := sessionPolicy{Version: "2012-10-17", Statement: []policyStatement{{
-		Sid: "OwnPrefixRW", Effect: "Allow", Action: []string{"s3:GetObject", "s3:PutObject"},
+		Sid: "OwnPrefixRW", Effect: "Allow", Action: []string{"s3:GetObject", "s3:PutObject", "s3:AbortMultipartUpload"},
 		Resource: "arn:aws:s3:::" + bucket + "/" + prefix + "*",
 	}}}
 	b, err := json.Marshal(p)

--- a/storage/dev_test.go
+++ b/storage/dev_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strings"
 	"sync"
@@ -58,7 +59,7 @@ func TestDevConfigFromEnvFailsLoudly(t *testing.T) {
 }
 
 func TestDevSessionPolicyShape(t *testing.T) {
-	policy, err := devSessionPolicy("media", "apps/app-uuid/module-slug/")
+	policy, err := devSessionPolicy("media", "apps/app-uuid/module_id/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,8 +67,8 @@ func TestDevSessionPolicyShape(t *testing.T) {
 	if err := json.Unmarshal([]byte(policy), &got); err != nil {
 		t.Fatal(err)
 	}
-	wantResource := "arn:aws:s3:::media/apps/app-uuid/module-slug/*"
-	if len(got.Statement) != 1 || got.Statement[0].Resource != wantResource || strings.Join(got.Statement[0].Action, ",") != "s3:GetObject,s3:PutObject" {
+	wantResource := "arn:aws:s3:::media/apps/app-uuid/module_id/*"
+	if len(got.Statement) != 1 || got.Statement[0].Resource != wantResource || strings.Join(got.Statement[0].Action, ",") != "s3:GetObject,s3:PutObject,s3:AbortMultipartUpload" {
 		t.Fatalf("unexpected policy: %s", policy)
 	}
 }
@@ -110,6 +111,67 @@ func TestDevMintCachesPerAppModule(t *testing.T) {
 	}
 }
 
+func TestDevMintCoalescesConcurrentSameScope(t *testing.T) {
+	now := time.Now()
+	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+	m := testMinter(&now, fake)
+
+	const callers = 32
+	start := make(chan struct{})
+	credentials := make(chan Credential, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			cred, err := m.Mint(context.Background(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "video_core")
+			if err != nil {
+				errs <- err
+				return
+			}
+			credentials <- cred
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(credentials)
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	for cred := range credentials {
+		if cred.AccessKeyID != "key1" {
+			t.Fatalf("AccessKeyID=%q, want coalesced key1", cred.AccessKeyID)
+		}
+	}
+	if fake.calls != 1 {
+		t.Fatalf("AssumeRole calls=%d, want 1", fake.calls)
+	}
+}
+
+func TestDevCredentialCacheIsBounded(t *testing.T) {
+	now := time.Now()
+	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+	m := testMinter(&now, fake)
+	for i := 0; i <= maxDevCredentialCacheEntries; i++ {
+		appID := fmt.Sprintf("00000000-0000-0000-0000-%012x", i)
+		if _, err := m.Mint(context.Background(), appID, "mod"); err != nil {
+			t.Fatal(err)
+		}
+		now = now.Add(time.Second)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if got := len(m.cache); got != maxDevCredentialCacheEntries {
+		t.Fatalf("cache entries=%d, want bound %d", got, maxDevCredentialCacheEntries)
+	}
+	if _, ok := m.cache["00000000-0000-0000-0000-000000000000\x00mod"]; ok {
+		t.Fatal("oldest credential was not evicted")
+	}
+}
+
 func TestVendedCredentialOutlivesLongestPresign(t *testing.T) {
 	now := time.Now()
 	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
@@ -128,13 +190,13 @@ func TestVendedCredentialOutlivesLongestPresign(t *testing.T) {
 
 func TestDevMintRejectsPolicyMetacharacters(t *testing.T) {
 	validAppID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-	validModuleID := "video-core"
+	validModuleID := "video_core"
 	appIDs := []string{
 		"*", "?", "a*", "*/*", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/*",
 		"../../other", "apps/x", "%2e%2e", "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/*", "",
 		strings.Repeat("a", 35), strings.Repeat("a", 37), validAppID + "/", " " + validAppID + " ",
 	}
-	moduleIDs := []string{"*", "video/core", "video..core", "Video-Core", "video%core", ""}
+	moduleIDs := []string{"*", "video/core", "video..core", "Video_Core", "video-core", "video%core", ""}
 
 	for _, appID := range appIDs {
 		t.Run("appID="+appID, func(t *testing.T) {
@@ -165,7 +227,7 @@ func TestDevMintRejectsPolicyMetacharacters(t *testing.T) {
 func TestDevMintPolicyContainsNoWildcardBeyondTheFinalSegment(t *testing.T) {
 	now := time.Now()
 	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
-	if _, err := testMinter(&now, fake).Mint(context.Background(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "video-core"); err != nil {
+	if _, err := testMinter(&now, fake).Mint(context.Background(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "video_core"); err != nil {
 		t.Fatal(err)
 	}
 	var policy sessionPolicy
@@ -181,11 +243,11 @@ func TestDevMintPolicyContainsNoWildcardBeyondTheFinalSegment(t *testing.T) {
 func TestDevMintLowercasesTheAppID(t *testing.T) {
 	now := time.Now()
 	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
-	cred, err := testMinter(&now, fake).Mint(context.Background(), "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", "video-core")
+	cred, err := testMinter(&now, fake).Mint(context.Background(), "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", "video_core")
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantScope := "apps/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/video-core/"
+	wantScope := "apps/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/video_core/"
 	if cred.Prefix != wantScope {
 		t.Fatalf("prefix=%q, want %q", cred.Prefix, wantScope)
 	}

--- a/storage/dev_test.go
+++ b/storage/dev_test.go
@@ -1,0 +1,226 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+)
+
+type fakeSTS struct {
+	mu      sync.Mutex
+	calls   int
+	now     func() time.Time
+	expires time.Duration
+	inputs  []*sts.AssumeRoleInput
+}
+
+func (f *fakeSTS) AssumeRole(_ context.Context, in *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.inputs = append(f.inputs, in)
+	n := f.calls
+	return &sts.AssumeRoleOutput{Credentials: &types.Credentials{
+		AccessKeyId: aws.String("key" + string(rune('0'+n))), SecretAccessKey: aws.String("secret"),
+		SessionToken: aws.String("token"), Expiration: aws.Time(f.now().Add(f.expires)),
+	}}, nil
+}
+
+func testMinter(now *time.Time, fake *fakeSTS) *DevMinter {
+	cfg := DevConfig{Bucket: "bucket", Region: "region", Endpoint: "http://s3:9000", PublicEndpoint: "http://localhost:9000", STSEndpoint: "http://s3:9000", CDNBase: "http://localhost:9000/bucket", RoleARN: "arn:minio:iam:::role/module-storage", AccessKeyID: "parent", SecretAccessKey: "secret"}
+	return &DevMinter{cfg: cfg, sts: fake, now: func() time.Time { return *now }, cache: make(map[string]cachedCredential)}
+}
+
+func TestDevConfigFromEnvFailsLoudly(t *testing.T) {
+	for _, missing := range []string{"S3_ENDPOINT", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+		t.Run(missing, func(t *testing.T) {
+			t.Setenv("S3_ENDPOINT", "http://s3:9000")
+			t.Setenv("AWS_ACCESS_KEY_ID", "parent")
+			t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+			t.Setenv(missing, "")
+			cfg, err := DevConfigFromEnv()
+			if err == nil || !strings.Contains(err.Error(), missing) || !strings.Contains(err.Error(), "Refusing to fall back to real AWS") {
+				t.Fatalf("cfg=%+v err=%v", cfg, err)
+			}
+			if cfg.Endpoint != "" {
+				t.Fatalf("failure returned usable endpoint %q", cfg.Endpoint)
+			}
+		})
+	}
+}
+
+func TestDevSessionPolicyShape(t *testing.T) {
+	policy, err := devSessionPolicy("media", "apps/app-uuid/module-slug/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got sessionPolicy
+	if err := json.Unmarshal([]byte(policy), &got); err != nil {
+		t.Fatal(err)
+	}
+	wantResource := "arn:aws:s3:::media/apps/app-uuid/module-slug/*"
+	if len(got.Statement) != 1 || got.Statement[0].Resource != wantResource || strings.Join(got.Statement[0].Action, ",") != "s3:GetObject,s3:PutObject" {
+		t.Fatalf("unexpected policy: %s", policy)
+	}
+}
+
+func TestDevMintRejectsEmptyScope(t *testing.T) {
+	now := time.Now()
+	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+	m := testMinter(&now, fake)
+	for _, pair := range [][2]string{{"", "mod"}, {"app", ""}} {
+		if _, err := m.Mint(context.Background(), pair[0], pair[1]); err == nil {
+			t.Fatal("expected empty scope error")
+		}
+	}
+	if fake.calls != 0 {
+		t.Fatalf("STS called %d times", fake.calls)
+	}
+}
+
+func TestDevMintCachesPerAppModule(t *testing.T) {
+	now := time.Now()
+	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+	m := testMinter(&now, fake)
+	for range 2 {
+		if _, err := m.Mint(context.Background(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "mod"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := m.Mint(context.Background(), "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "mod"); err != nil {
+		t.Fatal(err)
+	}
+	if fake.calls != 2 {
+		t.Fatalf("calls=%d, want 2", fake.calls)
+	}
+	now = now.Add(time.Hour - refreshBuffer)
+	if _, err := m.Mint(context.Background(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "mod"); err != nil {
+		t.Fatal(err)
+	}
+	if fake.calls != 3 {
+		t.Fatalf("calls=%d, want refresh", fake.calls)
+	}
+}
+
+func TestVendedCredentialOutlivesLongestPresign(t *testing.T) {
+	now := time.Now()
+	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+	m := testMinter(&now, fake)
+	if _, err := m.Mint(context.Background(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "mod"); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Hour - refreshBuffer - time.Nanosecond)
+	if _, ok := m.cached("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\x00mod"); !ok {
+		t.Fatal("cache should still return credential")
+	}
+	if remaining := time.Hour - (time.Hour - refreshBuffer - time.Nanosecond); remaining <= maxPresignTTL {
+		t.Fatalf("remaining=%v", remaining)
+	}
+}
+
+func TestDevMintRejectsPolicyMetacharacters(t *testing.T) {
+	validAppID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	validModuleID := "video-core"
+	appIDs := []string{
+		"*", "?", "a*", "*/*", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/*",
+		"../../other", "apps/x", "%2e%2e", "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/*", "",
+		strings.Repeat("a", 35), strings.Repeat("a", 37), validAppID + "/", " " + validAppID + " ",
+	}
+	moduleIDs := []string{"*", "video/core", "video..core", "Video-Core", "video%core", ""}
+
+	for _, appID := range appIDs {
+		t.Run("appID="+appID, func(t *testing.T) {
+			now := time.Now()
+			fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+			if _, err := testMinter(&now, fake).Mint(context.Background(), appID, validModuleID); err == nil || !strings.Contains(err.Error(), "appID") {
+				t.Fatalf("err=%v, want appID validation error", err)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("STS called %d times", fake.calls)
+			}
+		})
+	}
+	for _, moduleID := range moduleIDs {
+		t.Run("moduleID="+moduleID, func(t *testing.T) {
+			now := time.Now()
+			fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+			if _, err := testMinter(&now, fake).Mint(context.Background(), validAppID, moduleID); err == nil || !strings.Contains(err.Error(), "moduleID") {
+				t.Fatalf("err=%v, want moduleID validation error", err)
+			}
+			if fake.calls != 0 {
+				t.Fatalf("STS called %d times", fake.calls)
+			}
+		})
+	}
+}
+
+func TestDevMintPolicyContainsNoWildcardBeyondTheFinalSegment(t *testing.T) {
+	now := time.Now()
+	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+	if _, err := testMinter(&now, fake).Mint(context.Background(), "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "video-core"); err != nil {
+		t.Fatal(err)
+	}
+	var policy sessionPolicy
+	if err := json.Unmarshal([]byte(aws.ToString(fake.inputs[0].Policy)), &policy); err != nil {
+		t.Fatal(err)
+	}
+	resource := policy.Statement[0].Resource
+	if strings.Count(resource, "*") != 1 || !strings.HasSuffix(resource, "*") {
+		t.Fatalf("resource=%q, want exactly one wildcard as the final character", resource)
+	}
+}
+
+func TestDevMintLowercasesTheAppID(t *testing.T) {
+	now := time.Now()
+	fake := &fakeSTS{now: func() time.Time { return now }, expires: time.Hour}
+	cred, err := testMinter(&now, fake).Mint(context.Background(), "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", "video-core")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantScope := "apps/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/video-core/"
+	if cred.Prefix != wantScope {
+		t.Fatalf("prefix=%q, want %q", cred.Prefix, wantScope)
+	}
+	var policy sessionPolicy
+	if err := json.Unmarshal([]byte(aws.ToString(fake.inputs[0].Policy)), &policy); err != nil {
+		t.Fatal(err)
+	}
+	if resource := policy.Statement[0].Resource; !strings.Contains(resource, "/"+wantScope+"*") {
+		t.Fatalf("resource=%q does not contain canonical scope %q", resource, wantScope)
+	}
+}
+
+func TestCredentialValidateRequiresTrailingSlash(t *testing.T) {
+	cred := Credential{
+		Bucket: "b", Region: "region", Prefix: "apps/app/mod", CDNBase: "https://x",
+		AccessKeyID: "key", SecretAccessKey: "secret",
+	}
+	err := cred.validate()
+	if err == nil || !strings.Contains(err.Error(), "trailing slash") {
+		t.Fatalf("err=%v, want trailing slash validation error", err)
+	}
+}
+
+func TestPresignUsesPublicEndpoint(t *testing.T) {
+	cred := Credential{Bucket: "bucket", Region: "region", Prefix: "apps/app/mod/", CDNBase: "http://localhost:9000/bucket", AccessKeyID: "key", SecretAccessKey: "secret", SessionToken: "token"}
+	c, err := newClient(cred, "http://s3:9000", "http://localhost:9000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := c.PresignPut(context.Background(), "video.mp4", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host != "localhost:9000" {
+		t.Fatalf("url=%q host=%q err=%v", raw, u.Host, err)
+	}
+}

--- a/storage/multipart.go
+++ b/storage/multipart.go
@@ -73,6 +73,10 @@ func (u *MultipartUpload) PresignPart(ctx context.Context, partNumber int32, exp
 	if partNumber < 1 || partNumber > 10000 {
 		return "", fmt.Errorf("mirrorstack/storage: partNumber must be between 1 and 10000, got %d", partNumber)
 	}
+	expires, err := u.client.presignTTL(expires)
+	if err != nil {
+		return "", err
+	}
 	req, err := u.client.presigner.PresignUploadPart(ctx, &s3.UploadPartInput{
 		Bucket:     aws.String(u.bucket),
 		Key:        aws.String(u.key),

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -74,11 +74,24 @@ type Client struct {
 	bucket    string
 	prefix    string // "apps/<app>/<module>/"; Credential.validate forbids empty
 	cdnBase   string // "https://media.mirrorstack.ai"
+	expiresAt time.Time
+	now       func() time.Time
 }
 
 // NewFromCredential creates a Client from platform-injected STS credentials.
 func NewFromCredential(cred Credential) (*Client, error) {
 	return newClient(cred, "", "")
+}
+
+// Open is retained for source compatibility with older SDK consumers. An
+// unscoped process-wide client can no longer be constructed safely; module
+// code must declare ms.RequireStorage and resolve ms.Storage per request so the
+// app identity participates in the credential scope.
+//
+// Deprecated: use ms.RequireStorage during startup and ms.Storage(ctx) in a
+// request handler.
+func Open(context.Context) (*Client, error) {
+	return nil, errors.New("mirrorstack/storage: Open is no longer safe because it cannot derive an app scope — use ms.RequireStorage() during startup and ms.Storage(ctx) per request")
 }
 
 // newClient separates the endpoint used by server-side S3 calls from the one
@@ -115,18 +128,25 @@ func newClient(cred Credential, internalEndpoint, publicEndpoint string) (*Clien
 		bucket:    cred.Bucket,
 		prefix:    cred.Prefix,
 		cdnBase:   cred.CDNBase,
+		expiresAt: cred.ExpiresAt,
+		now:       time.Now,
 	}, nil
 }
 
-// ForApp returns a new Client with an app-scoped prefix and CDN base.
-// Shares the underlying S3 client.
-func (c *Client) ForApp(prefix, cdnBase string) *Client {
+// ForApp is retained for source compatibility but can no longer rescope a
+// vended credential. Prefix and CDN base are platform-owned because the public
+// CDN path must remain inside the same app/module boundary as the IAM policy.
+//
+// Deprecated: resolve ms.Storage(ctx) separately for each request.
+func (c *Client) ForApp(_, _ string) *Client {
 	return &Client{
 		presigner: c.presigner,
 		s3Client:  c.s3Client,
 		bucket:    c.bucket,
-		prefix:    prefix,
-		cdnBase:   cdnBase,
+		prefix:    c.prefix,
+		cdnBase:   c.cdnBase,
+		expiresAt: c.expiresAt,
+		now:       c.now,
 	}
 }
 
@@ -135,11 +155,43 @@ func (c *Client) ForApp(prefix, cdnBase string) *Client {
 // public delivery routes may legitimately use storage too.
 var ErrNoCredential = fmt.Errorf("mirrorstack/storage: no storage credentials — presigned URLs require authenticated context")
 
+// ErrNotDeclared is returned when module code calls ms.Storage without first
+// declaring ms.RequireStorage during startup. Undeclared modules receive no
+// storage credential from the platform.
+var ErrNotDeclared = errors.New("mirrorstack/storage: storage was not declared — call ms.RequireStorage() during module startup before using ms.Storage(ctx)")
+
 // ErrNotVended is returned when a deployed invocation carries no storage credential.
 var ErrNotVended = errors.New("mirrorstack/storage: the platform did not vend storage credentials for this invocation (envelope resources.storage was absent) — this is a PLATFORM misconfiguration, not a module bug: the operator must wire dispatch's module-storage vend (MS_MODULE_STORAGE_ROLE_ARN / _BUCKET / _CDN_BASE)")
 
+// ErrCredentialExpired is returned when a vended STS credential has no safe
+// lifetime left for a new presigned URL.
+var ErrCredentialExpired = errors.New("mirrorstack/storage: storage credential expired before a safe presigned URL could be created")
+
 // UnderLambda reports whether the process is running under AWS Lambda.
 func UnderLambda() bool { return lambdaenv.IsSet() }
+
+const credentialExpirySafetyMargin = 30 * time.Second
+
+func (c *Client) presignTTL(requested time.Duration) (time.Duration, error) {
+	if requested <= 0 {
+		return 0, fmt.Errorf("mirrorstack/storage: presign expiry must be positive")
+	}
+	if c.expiresAt.IsZero() {
+		return requested, nil
+	}
+	now := time.Now
+	if c.now != nil {
+		now = c.now
+	}
+	remaining := c.expiresAt.Sub(now()) - credentialExpirySafetyMargin
+	if remaining <= 0 {
+		return 0, ErrCredentialExpired
+	}
+	if requested > remaining {
+		return remaining, nil
+	}
+	return requested, nil
+}
 
 // PresignPut generates a presigned S3 PUT URL for uploading a file.
 // Requires storage credentials in context (Platform/Internal routes only).
@@ -148,6 +200,10 @@ func (c *Client) PresignPut(ctx context.Context, key string, expires time.Durati
 		return "", err
 	}
 	if err := validateKey(key); err != nil {
+		return "", err
+	}
+	expires, err := c.presignTTL(expires)
+	if err != nil {
 		return "", err
 	}
 	fullKey := c.prefix + key
@@ -168,6 +224,10 @@ func (c *Client) PresignGet(ctx context.Context, key string, expires time.Durati
 		return "", err
 	}
 	if err := validateKey(key); err != nil {
+		return "", err
+	}
+	expires, err := c.presignTTL(expires)
+	if err != nil {
 		return "", err
 	}
 	fullKey := c.prefix + key

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,18 +2,21 @@
 //
 // S3 is the source of truth. Cloudflare R2 is the CDN cache layer (Worker handles caching).
 // Production: STS credentials injected per invocation via Lambda payload.
-// Dev: S3_BUCKET, S3_REGION, S3_ENDPOINT env vars with local defaults.
+// Dev uses locally minted, prefix-scoped STS credentials against MinIO. This
+// enforcement is self-imposed because the module process holds MinIO's parent
+// key: it gives dev identical key shapes and code paths, cross-app isolation in
+// one tunnel runner, and an end-to-end test of production's policy shape. The
+// real security wall is the production IAM session policy.
 package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
@@ -28,12 +31,11 @@ type Storer interface {
 	CreateMultipart(ctx context.Context, key, contentType string) (*MultipartUpload, error)
 }
 
-// validateKey rejects keys that would escape the prefix scope. S3 treats keys
-// as opaque (no traversal), but CDN URLs are normalized by browsers and AWS
-// SDK percent-decodes during canonical request building — so a key like
-// "../../other_app/secret.jpg" or "%2F..%2F..%2Fetc" would resolve to a
-// different tenant's path. This is the only path where prefix isolation can
-// be bypassed by caller-controlled input.
+// validateKey is hygiene for CDN URL normalization. Browsers normalize paths
+// and the AWS SDK percent-decodes while building canonical requests, so keys
+// such as "../../other/secret.jpg" are ambiguous at those boundaries. It runs
+// inside the module process and is not a security boundary; the IAM session
+// policy on the vended credential is the boundary.
 //
 // The "%" reject is conservative: S3 keys do not require percent-encoding
 // from the application layer (the SDK handles encoding). Filenames with "%"
@@ -70,12 +72,19 @@ type Client struct {
 	presigner *s3.PresignClient
 	s3Client  *s3.Client
 	bucket    string
-	prefix    string // "apps/app_abc/mod_media/"
+	prefix    string // "apps/<app>/<module>/"; Credential.validate forbids empty
 	cdnBase   string // "https://media.mirrorstack.ai"
 }
 
 // NewFromCredential creates a Client from platform-injected STS credentials.
 func NewFromCredential(cred Credential) (*Client, error) {
+	return newClient(cred, "", "")
+}
+
+// newClient separates the endpoint used by server-side S3 calls from the one
+// embedded in browser-facing signatures. Empty endpoints preserve AWS endpoint
+// resolution, which is the production behavior of NewFromCredential.
+func newClient(cred Credential, internalEndpoint, publicEndpoint string) (*Client, error) {
 	if err := cred.validate(); err != nil {
 		return nil, err
 	}
@@ -87,61 +96,25 @@ func NewFromCredential(cred Credential) (*Client, error) {
 			cred.SessionToken,
 		),
 	}
-	s3Client := s3.NewFromConfig(cfg)
+	makeS3 := func(endpoint string) *s3.Client {
+		return s3.NewFromConfig(cfg, func(o *s3.Options) {
+			if endpoint != "" {
+				o.BaseEndpoint = aws.String(endpoint)
+				o.UsePathStyle = true
+			}
+		})
+	}
+	s3Client := makeS3(internalEndpoint)
+	presignClient := s3Client
+	if publicEndpoint != internalEndpoint {
+		presignClient = makeS3(publicEndpoint)
+	}
 	return &Client{
-		presigner: s3.NewPresignClient(s3Client),
+		presigner: s3.NewPresignClient(presignClient),
 		s3Client:  s3Client,
 		bucket:    cred.Bucket,
 		prefix:    cred.Prefix,
 		cdnBase:   cred.CDNBase,
-	}, nil
-}
-
-// Open creates a Client from env vars for dev mode.
-// Cannot be used in Lambda — credentials are injected per invocation.
-func Open(ctx context.Context) (*Client, error) {
-	if lambdaenv.IsSet() {
-		return nil, fmt.Errorf("mirrorstack/storage: Open() cannot be used in Lambda — credentials are injected per-invocation")
-	}
-
-	bucket := os.Getenv("S3_BUCKET")
-	if bucket == "" {
-		bucket = "mirrorstack-dev"
-	}
-	region := os.Getenv("S3_REGION")
-	if region == "" {
-		region = "ap-northeast-1"
-	}
-	cdnBase := os.Getenv("CDN_BASE_URL")
-	if cdnBase == "" {
-		cdnBase = "http://localhost:9000/" + bucket
-	}
-	endpoint := os.Getenv("S3_ENDPOINT")
-
-	var opts []func(*config.LoadOptions) error
-	opts = append(opts, config.WithRegion(region))
-	if endpoint != "" {
-		// MinIO or local S3-compatible
-		opts = append(opts, config.WithBaseEndpoint(endpoint))
-	}
-
-	cfg, err := config.LoadDefaultConfig(ctx, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("mirrorstack/storage: failed to load AWS config: %w", err)
-	}
-
-	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-		if endpoint != "" {
-			o.UsePathStyle = true // MinIO requires path-style
-		}
-	})
-
-	return &Client{
-		presigner: s3.NewPresignClient(s3Client),
-		s3Client:  s3Client,
-		bucket:    bucket,
-		prefix:    "",
-		cdnBase:   cdnBase,
 	}, nil
 }
 
@@ -158,8 +131,15 @@ func (c *Client) ForApp(prefix, cdnBase string) *Client {
 }
 
 // ErrNoCredential is returned when PresignPut/PresignGet is called without storage credentials.
-// This happens on Public routes where STS credentials are not injected.
+// A deployed invocation must receive credentials regardless of route class;
+// public delivery routes may legitimately use storage too.
 var ErrNoCredential = fmt.Errorf("mirrorstack/storage: no storage credentials — presigned URLs require authenticated context")
+
+// ErrNotVended is returned when a deployed invocation carries no storage credential.
+var ErrNotVended = errors.New("mirrorstack/storage: the platform did not vend storage credentials for this invocation (envelope resources.storage was absent) — this is a PLATFORM misconfiguration, not a module bug: the operator must wire dispatch's module-storage vend (MS_MODULE_STORAGE_ROLE_ARN / _BUCKET / _CDN_BASE)")
+
+// UnderLambda reports whether the process is running under AWS Lambda.
+func UnderLambda() bool { return lambdaenv.IsSet() }
 
 // PresignPut generates a presigned S3 PUT URL for uploading a file.
 // Requires storage credentials in context (Platform/Internal routes only).

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -33,18 +33,6 @@ func TestForApp_SharesS3Client(t *testing.T) {
 	}
 }
 
-func TestOpen_ReadsCDNBaseURL(t *testing.T) {
-	t.Setenv("CDN_BASE_URL", "https://media.beta.mirrorstack.ai")
-
-	c, err := Open(context.Background())
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	if c.cdnBase != "https://media.beta.mirrorstack.ai" {
-		t.Errorf("cdnBase = %q, want CDN_BASE_URL value", c.cdnBase)
-	}
-}
-
 func TestURL(t *testing.T) {
 	t.Parallel()
 
@@ -156,14 +144,6 @@ func TestRequireCredential(t *testing.T) {
 	full := &Client{presigner: &s3.PresignClient{}, s3Client: &s3.Client{}}
 	if err := full.requireCredential(); err != nil {
 		t.Errorf("expected nil for fully constructed client, got %v", err)
-	}
-}
-
-func TestOpen_LambdaGuard(t *testing.T) {
-	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "app-mod-media")
-	_, err := Open(context.Background())
-	if err == nil {
-		t.Error("expected error in Lambda environment")
 	}
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -2,21 +2,94 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-func TestForApp_Prefix(t *testing.T) {
-	c := &Client{bucket: "test-bucket", prefix: "", cdnBase: "https://cdn.example.com"}
-	scoped := c.ForApp("apps/app_abc/mod_media/", "https://media.mirrorstack.ai")
-
-	if scoped.prefix != "apps/app_abc/mod_media/" {
-		t.Errorf("expected prefix 'apps/app_abc/mod_media/', got %q", scoped.prefix)
+func TestCredentialExpiryRoundTripsOnTheWire(t *testing.T) {
+	want := time.Date(2026, time.August, 6, 12, 30, 0, 0, time.UTC)
+	b, err := json.Marshal(Credential{ExpiresAt: want})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if scoped.cdnBase != "https://media.mirrorstack.ai" {
-		t.Errorf("expected cdnBase 'https://media.mirrorstack.ai', got %q", scoped.cdnBase)
+	if !strings.Contains(string(b), `"expiresAt":"2026-08-06T12:30:00Z"`) {
+		t.Fatalf("wire credential missing expiry: %s", b)
+	}
+	var got Credential
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt=%v, want %v", got.ExpiresAt, want)
+	}
+}
+
+func TestOpenFailsClosedButRemainsSourceCompatible(t *testing.T) {
+	client, err := Open(context.Background())
+	if client != nil || err == nil || !strings.Contains(err.Error(), "cannot derive an app scope") {
+		t.Fatalf("Open client=%v err=%v, want fail-closed migration error", client, err)
+	}
+}
+
+func TestPresignTTLStaysWithinCredentialLifetime(t *testing.T) {
+	now := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	c := &Client{expiresAt: now.Add(10 * time.Minute), now: func() time.Time { return now }}
+
+	got, err := c.presignTTL(15 * time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 10*time.Minute - credentialExpirySafetyMargin; got != want {
+		t.Fatalf("clamped TTL=%v, want %v", got, want)
+	}
+	if got, err := c.presignTTL(time.Minute); err != nil || got != time.Minute {
+		t.Fatalf("short TTL=%v err=%v, want 1m", got, err)
+	}
+	c.expiresAt = now.Add(credentialExpirySafetyMargin)
+	if _, err := c.presignTTL(time.Minute); !errors.Is(err, ErrCredentialExpired) {
+		t.Fatalf("expired credential err=%v, want ErrCredentialExpired", err)
+	}
+}
+
+func TestMultipartPresignStaysWithinCredentialLifetime(t *testing.T) {
+	now := time.Date(2026, time.August, 6, 12, 0, 0, 0, time.UTC)
+	c, err := newClient(Credential{
+		Bucket: "bucket", Region: "ap-northeast-1", Prefix: "apps/app/mod/", CDNBase: "https://cdn.example.com",
+		AccessKeyID: "key", SecretAccessKey: "secret", SessionToken: "token", ExpiresAt: now.Add(10 * time.Minute),
+	}, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.now = func() time.Time { return now }
+	upload := &MultipartUpload{client: c, bucket: "bucket", key: "apps/app/mod/video.mp4", uploadID: "upload"}
+	raw, err := upload.PresignPart(context.Background(), 1, 15*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := parsed.Query().Get("X-Amz-Expires"), "570"; got != want {
+		t.Fatalf("X-Amz-Expires=%q, want %q", got, want)
+	}
+}
+
+func TestForAppCannotChangeVendedScope(t *testing.T) {
+	c := &Client{bucket: "test-bucket", prefix: "apps/app_a/mod_media/", cdnBase: "https://cdn.example.com"}
+	scoped := c.ForApp("apps/app_b/mod_media/", "https://attacker.example.com")
+
+	if scoped.prefix != c.prefix {
+		t.Errorf("ForApp changed vended prefix to %q", scoped.prefix)
+	}
+	if scoped.cdnBase != c.cdnBase {
+		t.Errorf("ForApp changed platform CDN base to %q", scoped.cdnBase)
 	}
 	if scoped.bucket != "test-bucket" {
 		t.Errorf("expected bucket 'test-bucket', got %q", scoped.bucket)
@@ -65,11 +138,11 @@ func TestURL(t *testing.T) {
 			want:    "https://media.mirrorstack.ai/apps/app_abc/mod_media/photos/avatar.jpg",
 		},
 		{
-			name:    "dev unscoped",
-			prefix:  "",
+			name:    "dev scoped",
+			prefix:  "apps/app_abc/mod_media/",
 			cdnBase: "http://localhost:9000/mirrorstack-dev",
 			key:     "test.txt",
-			want:    "http://localhost:9000/mirrorstack-dev/test.txt",
+			want:    "http://localhost:9000/mirrorstack-dev/apps/app_abc/mod_media/test.txt",
 		},
 	}
 

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -55,6 +55,9 @@ type ManifestPayload struct {
 	Schedules   []registry.Schedule   `json:"schedules"`
 	Tasks       []registry.Task       `json:"tasks"`
 	Permissions []registry.Permission `json:"permissions"`
+	// Resources declares privileged runtime resources the module needs. The
+	// platform must not vend a resource merely because the SDK supports it.
+	Resources ManifestResources `json:"resources"`
 	// Metrics lists the usage metrics this module declares (ms.Meter). The
 	// platform populates its metric_definitions catalog (kind/unit/price) from
 	// this at install/publish, so the catalog is authoritative before any usage
@@ -75,6 +78,12 @@ type ManifestPayload struct {
 	// the registration after app-owner approval. Always present; empty
 	// array when the module contributes nothing.
 	ContributesTo []registry.OutboundContribution `json:"contributesTo"`
+}
+
+// ManifestResources is the module's opt-in runtime-resource contract. Empty is
+// encoded as {} so old modules remain explicitly resource-free.
+type ManifestResources struct {
+	Storage bool `json:"storage,omitempty"`
 }
 
 // ManifestMCP declares the MCP tool and resource surface of the module. The
@@ -210,6 +219,7 @@ func ManifestHandler(id, slug, name, icon string, tags []string, sqlFS fs.FS, ve
 			Schedules:         reg.Schedules(),
 			Tasks:             reg.Tasks(),
 			Permissions:       reg.Permissions(),
+			Resources:         ManifestResources{Storage: reg.StorageRequired()},
 			Metrics:           reg.Metrics(),
 			MCP:               buildManifestMCP(reg),
 			UI:                reg.UI(),

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -46,6 +46,27 @@ func TestManifest_IDAndDefaults(t *testing.T) {
 	}
 }
 
+func TestManifest_StorageDeclarationIsExplicit(t *testing.T) {
+	base := registry.New()
+	baseRec := manifestResponse(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, base, nil))
+	if !strings.Contains(baseRec.Body.String(), `"resources":{}`) {
+		t.Fatalf("resource-free manifest must encode resources as an empty object: %s", baseRec.Body.String())
+	}
+	if decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, base, nil)).Resources.Storage {
+		t.Fatal("storage unexpectedly declared by default")
+	}
+
+	withStorage := registry.New()
+	withStorage.RequireStorage()
+	storageRec := manifestResponse(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, withStorage, nil))
+	if !decodeManifest(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, withStorage, nil)).Resources.Storage {
+		t.Fatal("storage declaration missing from manifest")
+	}
+	if baseRec.Header().Get("X-MS-Manifest-Hash") == storageRec.Header().Get("X-MS-Manifest-Hash") {
+		t.Fatal("manifest hash did not change after declaring storage")
+	}
+}
+
 func TestManifest_SlugSurfaced(t *testing.T) {
 	t.Parallel()
 	got := decodeManifest(t, ManifestHandler("m15c0f543cf164433b524d312dbf68159", "oauth", "Google Sign-In", "vpn_key", nil, nil, nil, registry.New(), nil))


### PR DESCRIPTION
## Summary
- require an explicit `resources.storage=true` manifest declaration before `ms.Storage` resolves
- replace unscoped dev storage with prefix-scoped MinIO STS credentials
- carry STS expiry over the invoke wire and bound put/get/multipart presigns to it
- preserve source compatibility while preventing `Open`/`ForApp` from creating or changing a vended scope
- document the declaration and migration contract

## Security contract
- no undeclared storage access
- exact `apps/<app>/<module>/` prefix
- object actions limited to get, put, and multipart abort
- bounded credential cache and coalesced concurrent minting
- no real-AWS fallback when dev storage is absent

## Verification
- `go test ./...`
- `go test -short -count=1 -timeout=5m ./...`
- `go test -race ./storage ./internal/core ./system`
- `go vet ./...`
- `git diff --check`

Part of mirrorstack-ai/mirrorstack-core-v2#338.
