### PR TITLE
fix(core): authenticate inter-module calls

### DIFF
--- a/internal/core/call.go
+++ b/internal/core/call.go
@@ -52,9 +52,11 @@ func resolveCallURL(targetModuleID, path string) string {
 //
 // The app id is read from the request context (auth.Get) — the same identity
 // the SDK injects for handlers — and sent as X-MS-App-ID so the dispatch can
-// resolve the install. The CALLER never holds the callee's credentials:
-// dispatch injects the TARGET module's per-session token + identity before
-// forwarding.
+// resolve the install. X-MS-Service-Secret carries this CALLING module's live
+// session/deploy credential, allowing dispatch to authenticate which installed
+// module initiated the internal hop. The caller never holds the CALLEE's
+// credentials: dispatch injects the target module's per-session token and
+// identity before forwarding.
 //
 // path must include its leading slash and any raw query string, e.g.
 // "/internal/exchange" or "/internal/users?limit=10".
@@ -81,6 +83,9 @@ func (m *Module) Call(ctx context.Context, targetModuleID, method, path string, 
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("X-MS-App-ID", appID)
+	if secret := moduleSessionSecret(); secret != "" {
+		req.Header.Set("X-MS-Service-Secret", secret)
+	}
 
 	resp, err := callHTTP.Do(req)
 	if err != nil {

--- a/internal/core/call_test.go
+++ b/internal/core/call_test.go
@@ -79,18 +79,21 @@ func TestResolveCallURL_Building(t *testing.T) {
 	}
 }
 
-func TestCall_SendsAppIDAndDecodesResponse(t *testing.T) {
+func TestCall_SendsAppIDServiceSecretAndDecodesResponse(t *testing.T) {
 	var gotMethod, gotPath, gotAppID, gotCT string
+	var gotSecrets []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotAppID = r.Header.Get("X-MS-App-ID")
 		gotCT = r.Header.Get("Content-Type")
+		gotSecrets = r.Header.Values("X-MS-Service-Secret")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer srv.Close()
 	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	t.Setenv("MS_INTERNAL_SECRET", "session-secret-1")
 
 	m, _ := New(Config{ID: "demo"})
 	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
@@ -116,15 +119,40 @@ func TestCall_SendsAppIDAndDecodesResponse(t *testing.T) {
 	if gotCT != "application/json" {
 		t.Errorf("Content-Type = %q, want application/json", gotCT)
 	}
+	if len(gotSecrets) != 1 || gotSecrets[0] != "session-secret-1" {
+		t.Errorf("X-MS-Service-Secret values = %q, want exactly [session-secret-1]", gotSecrets)
+	}
+}
+
+func TestCall_OmitsEmptyServiceSecret(t *testing.T) {
+	var gotSecrets []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSecrets = r.Header.Values("X-MS-Service-Secret")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	t.Setenv("MS_INTERNAL_SECRET", "")
+
+	m, _ := New(Config{ID: "demo"})
+	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+	if err := m.CallGet(ctx, "m0123", "/internal/ping", nil); err != nil {
+		t.Fatalf("CallGet: %v", err)
+	}
+	if len(gotSecrets) != 0 {
+		t.Errorf("X-MS-Service-Secret values = %q, want no header", gotSecrets)
+	}
 }
 
 func TestCall_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
+	const serviceSecret = "session-secret-must-not-leak"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 		_, _ = w.Write([]byte("upstream module unavailable"))
 	}))
 	defer srv.Close()
 	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	t.Setenv("MS_INTERNAL_SECRET", serviceSecret)
 
 	m, _ := New(Config{ID: "demo"})
 	err := m.CallGet(context.Background(), "m0123", "/internal/users", nil)
@@ -141,11 +169,16 @@ func TestCall_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
 	if !strings.Contains(msg, "/module/m0123/internal/users") {
 		t.Errorf("error %q missing request path", msg)
 	}
+	if strings.Contains(msg, serviceSecret) {
+		t.Errorf("error leaked X-MS-Service-Secret: %q", msg)
+	}
 }
 
 func TestCall_TransportErrorIncludesResolvedHost(t *testing.T) {
 	const dispatchURL = "http://unreachable-dispatch.example:8083"
+	const serviceSecret = "session-secret-must-not-leak"
 	t.Setenv("MS_DISPATCH_URL", dispatchURL)
+	t.Setenv("MS_INTERNAL_SECRET", serviceSecret)
 
 	previousClient := callHTTP
 	callHTTP = &http.Client{
@@ -162,6 +195,9 @@ func TestCall_TransportErrorIncludesResolvedHost(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), dispatchURL) {
 		t.Errorf("error %q missing resolved dispatch host %q", err, dispatchURL)
+	}
+	if strings.Contains(err.Error(), serviceSecret) {
+		t.Errorf("error leaked X-MS-Service-Secret: %q", err)
 	}
 }
 


### PR DESCRIPTION
Closes #169

Part of mirrorstack-ai/mirrorstack-core-v2#397.

Adds the existing module session/deploy credential to `ms.Call*` as `X-MS-Service-Secret`, matching the dispatch module-edge trust contract. Empty credentials remain omitted so dispatch is the fail-closed enforcement point.

Verification:
- `go test -race ./internal/core`
- `go test -count=1 ./...`
- `go vet ./...`
- targeted credential/error non-leak tests