### PR TITLE
feat(auth): propagate verified actor delegation

### DIFF
--- a/auth/context.go
+++ b/auth/context.go
@@ -43,6 +43,22 @@ func Get(ctx context.Context) *Identity {
 
 const payloadTrustKey = contextKey("ms-payload-trust")
 
+const proxyTrustKey = contextKey("ms-proxy-trust")
+
+// withProxyTrust marks the HTTP request after RequireProxy validates the
+// server-only platform token. PlatformAuth uses this private mark to know that
+// it may capture the dispatch-issued actor delegation header. Public routes do
+// not run PlatformAuth, so they never gain a delegation merely by being
+// proxied.
+func withProxyTrust(ctx context.Context) context.Context {
+	return context.WithValue(ctx, proxyTrustKey, true)
+}
+
+func proxyTrusted(ctx context.Context) bool {
+	trusted, _ := ctx.Value(proxyTrustKey).(bool)
+	return trusted
+}
+
 // WithPayloadTrust marks ctx as carrying identity injected from the typed
 // Lambda payload — set ONLY by runtime.NewLambdaHandler (the real Lambda
 // invoke path, or the dev lambda-invoke shim after its envelope-secret gate).

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/lambdaenv"
 )
@@ -81,7 +82,15 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Step 1: honor identity already attached upstream.
 			if existing := Get(r.Context()); existing != nil && existing.AppRole != "" {
-				next.ServeHTTP(w, r)
+				// On the HTTP plane RequireProxy established this identity and
+				// marked the context only after validating the platform token. The
+				// mark authorizes activation of its pending delegation. On Lambda,
+				// the typed payload is the equivalent trust boundary. A caller that
+				// merely preloads Identity cannot activate or smuggle one in.
+				if proxyTrusted(r.Context()) || PayloadTrusted(r.Context()) {
+					r = r.WithContext(actor.ActivatePendingDelegation(r.Context()))
+				}
+				next.ServeHTTP(w, stripActorDelegationHeader(r))
 				return
 			}
 
@@ -97,7 +106,7 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 					AppID:   "local-dev-app",
 					AppRole: RoleAdmin,
 				})
-				next.ServeHTTP(w, r.WithContext(ctx))
+				next.ServeHTTP(w, stripActorDelegationHeader(r.WithContext(ctx)))
 				return
 			}
 
@@ -134,7 +143,13 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 				AppID:   appID,
 				AppRole: appRole,
 			})
-			next.ServeHTTP(w, r.WithContext(ctx))
+			r = r.WithContext(ctx)
+			var ok bool
+			r, ok = captureTrustedActorDelegation(w, r)
+			if !ok {
+				return
+			}
+			next.ServeHTTP(w, r)
 		})
 	}
 }
@@ -208,7 +223,7 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 			// Mirrors RequireProxy: the mark is set only by the lambda entry,
 			// never from inbound request data, so a direct caller cannot forge it.
 			if PayloadTrusted(r.Context()) {
-				next.ServeHTTP(w, r)
+				next.ServeHTTP(w, stripActorDelegationHeader(r))
 				return
 			}
 
@@ -225,7 +240,7 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 					})
 					return
 				}
-				next.ServeHTTP(w, r)
+				next.ServeHTTP(w, stripActorDelegationHeader(r))
 				return
 			}
 
@@ -248,9 +263,66 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 			// CRITICAL ORDERING: this MUST stay below the constant-time check —
 			// promoting on the local bypass or any rejection branch would trust
 			// spoofable headers from an unauthenticated caller.
-			next.ServeHTTP(w, promoteForwarderIdentity(r))
+			next.ServeHTTP(w, promoteForwarderIdentity(stripActorDelegationHeader(r)))
 		})
 	}
+}
+
+// captureTrustedActorDelegation moves the private actor assertion off the
+// HTTP wire and into internal request context. Callers must invoke it only
+// after a platform trust signal has succeeded. Ambiguous, empty, oversized,
+// or delimiter-bearing values fail closed without logging the assertion.
+func captureTrustedActorDelegation(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+	r, assertion, ok := takeTrustedActorDelegation(w, r)
+	if !ok || assertion == "" {
+		return r, ok
+	}
+	return r.WithContext(actor.WithDelegation(r.Context(), assertion)), true
+}
+
+// capturePendingActorDelegation removes the private header immediately after
+// RequireProxy validates the platform token, but does not make it available to
+// ms.Call yet. PlatformAuth activates it; a Public handler therefore cannot
+// accidentally delegate a user even if dispatch sent the header on the wrong
+// route class.
+func capturePendingActorDelegation(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+	r, assertion, ok := takeTrustedActorDelegation(w, r)
+	if !ok || assertion == "" {
+		return r, ok
+	}
+	return r.WithContext(actor.WithPendingDelegation(r.Context(), assertion)), true
+}
+
+func takeTrustedActorDelegation(w http.ResponseWriter, r *http.Request) (*http.Request, string, bool) {
+	values := r.Header.Values(actor.HeaderDelegation)
+	if len(values) == 0 {
+		return r, "", true
+	}
+	if len(values) != 1 || !actor.ValidTransportValue(values[0]) {
+		log.Printf("mirrorstack: platform auth rejected invalid actor delegation (value_count=%d) from %s %s", len(values), r.RemoteAddr, r.URL.Path)
+		httputil.JSON(w, http.StatusUnauthorized, httputil.ErrorResponse{Error: "authentication required"})
+		return r, "", false
+	}
+	// Clone the header map before deleting so outer middleware retains its own
+	// immutable view while the module handler never sees the assertion.
+	trusted := r.Clone(r.Context())
+	trusted.Header = r.Header.Clone()
+	trusted.Header.Del(actor.HeaderDelegation)
+	return trusted, values[0], true
+}
+
+// stripActorDelegationHeader removes the private wire assertion on every
+// route that does not capture it. This includes Public/Internal, local auth
+// bypasses, and typed Lambda requests. It never changes the active or pending
+// private context value.
+func stripActorDelegationHeader(r *http.Request) *http.Request {
+	if len(r.Header.Values(actor.HeaderDelegation)) == 0 {
+		return r
+	}
+	clean := r.Clone(r.Context())
+	clean.Header = r.Header.Clone()
+	clean.Header.Del(actor.HeaderDelegation)
+	return clean
 }
 
 // CodeNotProxied is the stable error code returned when a request reaches a
@@ -320,7 +392,7 @@ func requireProxy(inLambda bool) func(http.Handler) http.Handler {
 			// request data — so honoring it here cannot be forged by a direct
 			// caller.
 			if inLambda || PayloadTrusted(r.Context()) {
-				next.ServeHTTP(w, r)
+				next.ServeHTTP(w, stripActorDelegationHeader(r))
 				return
 			}
 
@@ -331,7 +403,7 @@ func requireProxy(inLambda bool) func(http.Handler) http.Handler {
 			// came from dispatch, so trusting them would let a direct caller
 			// forge an app id. The surface is simply open (local dev / tests).
 			if !configured {
-				next.ServeHTTP(w, r)
+				next.ServeHTTP(w, stripActorDelegationHeader(r))
 				return
 			}
 
@@ -361,7 +433,13 @@ func requireProxy(inLambda bool) func(http.Handler) http.Handler {
 			//
 			// CRITICAL ORDERING: this MUST run only after the token check above
 			// passes. Promoting before validation would trust spoofable headers.
-			next.ServeHTTP(w, promoteForwarderIdentity(r))
+			trusted, ok := capturePendingActorDelegation(w, r)
+			if !ok {
+				return
+			}
+			trusted = promoteForwarderIdentity(trusted)
+			trusted = trusted.WithContext(withProxyTrust(trusted.Context()))
+			next.ServeHTTP(w, trusted)
 		})
 	}
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -87,8 +87,10 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 				// mark authorizes activation of its pending delegation. On Lambda,
 				// the typed payload is the equivalent trust boundary. A caller that
 				// merely preloads Identity cannot activate or smuggle one in.
-				if proxyTrusted(r.Context()) || PayloadTrusted(r.Context()) {
+				if actor.PlatformSurface(r.Context()) && (proxyTrusted(r.Context()) || PayloadTrusted(r.Context())) {
 					r = r.WithContext(actor.ActivatePendingDelegation(r.Context()))
+				} else {
+					r = discardActorDelegation(r)
 				}
 				next.ServeHTTP(w, stripActorDelegationHeader(r))
 				return
@@ -106,7 +108,7 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 					AppID:   "local-dev-app",
 					AppRole: RoleAdmin,
 				})
-				next.ServeHTTP(w, stripActorDelegationHeader(r.WithContext(ctx)))
+				next.ServeHTTP(w, discardActorDelegation(r.WithContext(ctx)))
 				return
 			}
 
@@ -144,10 +146,15 @@ func platformAuth(inLambda bool) func(http.Handler) http.Handler {
 				AppRole: appRole,
 			})
 			r = r.WithContext(ctx)
-			var ok bool
-			r, ok = captureTrustedActorDelegation(w, r)
-			if !ok {
-				return
+			if actor.PlatformSurface(r.Context()) {
+				var ok bool
+				r, ok = capturePendingActorDelegation(w, r)
+				if !ok {
+					return
+				}
+				r = r.WithContext(actor.ActivatePendingDelegation(r.Context()))
+			} else {
+				r = discardActorDelegation(r)
 			}
 			next.ServeHTTP(w, r)
 		})
@@ -223,7 +230,7 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 			// Mirrors RequireProxy: the mark is set only by the lambda entry,
 			// never from inbound request data, so a direct caller cannot forge it.
 			if PayloadTrusted(r.Context()) {
-				next.ServeHTTP(w, stripActorDelegationHeader(r))
+				next.ServeHTTP(w, discardActorDelegation(r))
 				return
 			}
 
@@ -240,7 +247,7 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 					})
 					return
 				}
-				next.ServeHTTP(w, stripActorDelegationHeader(r))
+				next.ServeHTTP(w, discardActorDelegation(r))
 				return
 			}
 
@@ -263,21 +270,9 @@ func internalAuth(inLambda bool) func(http.Handler) http.Handler {
 			// CRITICAL ORDERING: this MUST stay below the constant-time check —
 			// promoting on the local bypass or any rejection branch would trust
 			// spoofable headers from an unauthenticated caller.
-			next.ServeHTTP(w, promoteForwarderIdentity(stripActorDelegationHeader(r)))
+			next.ServeHTTP(w, promoteForwarderIdentity(discardActorDelegation(r)))
 		})
 	}
-}
-
-// captureTrustedActorDelegation moves the private actor assertion off the
-// HTTP wire and into internal request context. Callers must invoke it only
-// after a platform trust signal has succeeded. Ambiguous, empty, oversized,
-// or delimiter-bearing values fail closed without logging the assertion.
-func captureTrustedActorDelegation(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
-	r, assertion, ok := takeTrustedActorDelegation(w, r)
-	if !ok || assertion == "" {
-		return r, ok
-	}
-	return r.WithContext(actor.WithDelegation(r.Context(), assertion)), true
 }
 
 // capturePendingActorDelegation removes the private header immediately after
@@ -323,6 +318,14 @@ func stripActorDelegationHeader(r *http.Request) *http.Request {
 	clean.Header = r.Header.Clone()
 	clean.Header.Del(actor.HeaderDelegation)
 	return clean
+}
+
+// discardActorDelegation removes the wire header and shadows any active or
+// pending assertion inherited from a typed payload or an upstream context.
+// Use this at every Public/Internal or unauthenticated local boundary.
+func discardActorDelegation(r *http.Request) *http.Request {
+	r = stripActorDelegationHeader(r)
+	return r.WithContext(actor.WithoutDelegation(r.Context()))
 }
 
 // CodeNotProxied is the stable error code returned when a request reaches a
@@ -392,7 +395,11 @@ func requireProxy(inLambda bool) func(http.Handler) http.Handler {
 			// request data — so honoring it here cannot be forged by a direct
 			// caller.
 			if inLambda || PayloadTrusted(r.Context()) {
-				next.ServeHTTP(w, stripActorDelegationHeader(r))
+				if actor.PlatformSurface(r.Context()) {
+					next.ServeHTTP(w, stripActorDelegationHeader(r))
+				} else {
+					next.ServeHTTP(w, discardActorDelegation(r))
+				}
 				return
 			}
 
@@ -403,7 +410,7 @@ func requireProxy(inLambda bool) func(http.Handler) http.Handler {
 			// came from dispatch, so trusting them would let a direct caller
 			// forge an app id. The surface is simply open (local dev / tests).
 			if !configured {
-				next.ServeHTTP(w, stripActorDelegationHeader(r))
+				next.ServeHTTP(w, discardActorDelegation(r))
 				return
 			}
 
@@ -433,9 +440,15 @@ func requireProxy(inLambda bool) func(http.Handler) http.Handler {
 			//
 			// CRITICAL ORDERING: this MUST run only after the token check above
 			// passes. Promoting before validation would trust spoofable headers.
-			trusted, ok := capturePendingActorDelegation(w, r)
-			if !ok {
-				return
+			trusted := r
+			if actor.PlatformSurface(r.Context()) {
+				var ok bool
+				trusted, ok = capturePendingActorDelegation(w, r)
+				if !ok {
+					return
+				}
+			} else {
+				trusted = discardActorDelegation(r)
 			}
 			trusted = promoteForwarderIdentity(trusted)
 			trusted = trusted.WithContext(withProxyTrust(trusted.Context()))

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 )
 
 func okHandler(w http.ResponseWriter, r *http.Request) {
@@ -443,6 +445,44 @@ func TestInternalAuth_PlatformToken_FallbackToInternalSecret(t *testing.T) {
 	}
 }
 
+func TestInternalAuth_StripsActorDelegationWithoutActivatingIt(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
+	t.Setenv("MS_PLATFORM_TOKEN", "")
+	t.Setenv("MS_INTERNAL_SECRET", "internal-secret")
+
+	for _, tc := range []struct {
+		name   string
+		values []string
+	}{
+		{name: "valid", values: []string{"msa1.payload.signature"}},
+		{name: "duplicate", values: []string{"msa1.first.signature", "msa1.second.signature"}},
+		{name: "invalid", values: []string{"contains whitespace"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotHeader, gotActor string
+			handler := internalAuth(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHeader = r.Header.Get(actor.HeaderDelegation)
+				gotActor = actor.Delegation(r.Context())
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(http.MethodPost, "/internal/work", nil)
+			req.Header.Set(HeaderInternalSecret, "internal-secret")
+			for _, value := range tc.values {
+				req.Header.Add(actor.HeaderDelegation, value)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if gotHeader != "" || gotActor != "" {
+				t.Errorf("internal handler saw header=%q actor=%q, want both empty", gotHeader, gotActor)
+			}
+		})
+	}
+}
+
 func TestInternalAuth_PlatformToken_NeitherSet_Bypass(t *testing.T) {
 	t.Setenv("MS_PLATFORM_TOKEN", "")
 	t.Setenv("MS_INTERNAL_SECRET", "")
@@ -481,6 +521,65 @@ func TestPlatformAuth_PlatformToken_ValidToken_InjectsIdentity(t *testing.T) {
 	}
 	if seen.UserID != "u-pt-1" || seen.AppID != "a-pt-2" || seen.AppRole != RoleMember {
 		t.Errorf("identity mismatch: got %+v", seen)
+	}
+}
+
+func TestPlatformAuth_TrustedProxyActivatesPrivateActorDelegation(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-789")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	const assertion = "msa1.payload.signature"
+	var gotActor, gotHeader string
+	handler := requireProxy(false)(platformAuth(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotActor = actor.Delegation(r.Context())
+		gotHeader = r.Header.Get(actor.HeaderDelegation)
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest("GET", "/platform/users", nil)
+	req.Header.Set(HeaderPlatformToken, "pt-secret-789")
+	req.Header.Set(HeaderUserID, "u-pt-1")
+	req.Header.Set(HeaderAppID, "a-pt-2")
+	req.Header.Set(HeaderAppRole, RoleMember)
+	req.Header.Set(actor.HeaderDelegation, assertion)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if gotActor != assertion {
+		t.Errorf("private actor delegation = %q, want trusted assertion", gotActor)
+	}
+	if gotHeader != "" {
+		t.Errorf("module handler saw private actor header %q, want it removed", gotHeader)
+	}
+}
+
+func TestPlatformAuth_DuplicateActorDelegationFailsClosed(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
+	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-789")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	reached := false
+	handler := requireProxy(false)(platformAuth(false)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		reached = true
+	})))
+
+	req := httptest.NewRequest("GET", "/platform/users", nil)
+	req.Header.Set(HeaderPlatformToken, "pt-secret-789")
+	req.Header.Set(HeaderUserID, "u-pt-1")
+	req.Header.Set(HeaderAppID, "a-pt-2")
+	req.Header.Set(HeaderAppRole, RoleMember)
+	req.Header.Add(actor.HeaderDelegation, "msa1.first.signature")
+	req.Header.Add(actor.HeaderDelegation, "msa1.second.signature")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("handler reached with an ambiguous actor delegation")
 	}
 }
 
@@ -746,6 +845,35 @@ func TestRequireProxy_ValidToken_PromotesIdentity(t *testing.T) {
 	}
 }
 
+func TestRequireProxy_PublicRouteCannotUseActorDelegation(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
+	t.Setenv("MS_PLATFORM_TOKEN", "real-token")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+	const assertion = "msa1.payload.signature"
+	var gotActor, gotHeader string
+	handler := requireProxy(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotActor = actor.Delegation(r.Context())
+		gotHeader = r.Header.Get(actor.HeaderDelegation)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/public/items", nil)
+	req.Header.Set(HeaderPlatformToken, "real-token")
+	req.Header.Set(actor.HeaderDelegation, assertion)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if gotActor != "" {
+		t.Errorf("public handler received active actor delegation %q", gotActor)
+	}
+	if gotHeader != "" {
+		t.Errorf("public handler saw private actor header %q, want it removed", gotHeader)
+	}
+}
+
 func TestRequireProxy_RejectedRequest_NeverPromotes(t *testing.T) {
 	// A request rejected by the guard (no/wrong token) must NEVER reach the
 	// handler, so no identity is ever promoted from its (spoofable) headers.
@@ -781,12 +909,15 @@ func TestRequireProxy_NoSecretInert_DoesNotPromote(t *testing.T) {
 	t.Setenv("MS_PLATFORM_TOKEN", "")
 	t.Setenv("MS_INTERNAL_SECRET", "")
 	var seen *Identity
+	var gotActorHeader string
 	handler := requireProxy(false)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		seen = Get(r.Context())
+		gotActorHeader = r.Header.Get(actor.HeaderDelegation)
 	}))
 
 	req := httptest.NewRequest("GET", "/public/me", nil)
 	req.Header.Set(HeaderAppID, "spoofed-app")
+	req.Header.Set(actor.HeaderDelegation, "browser-supplied")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -795,6 +926,9 @@ func TestRequireProxy_NoSecretInert_DoesNotPromote(t *testing.T) {
 	}
 	if seen != nil {
 		t.Errorf("inert guard must not promote unvalidated headers; got identity %+v", seen)
+	}
+	if gotActorHeader != "" {
+		t.Errorf("inert guard exposed private actor header %q", gotActorHeader)
 	}
 }
 

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -524,17 +524,23 @@ func TestPlatformAuth_PlatformToken_ValidToken_InjectsIdentity(t *testing.T) {
 	}
 }
 
+func withPlatformSurfaceForTest(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(actor.WithPlatformSurface(r.Context())))
+	})
+}
+
 func TestPlatformAuth_TrustedProxyActivatesPrivateActorDelegation(t *testing.T) {
 	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
 	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-789")
 	t.Setenv("MS_INTERNAL_SECRET", "")
 	const assertion = "msa1.payload.signature"
 	var gotActor, gotHeader string
-	handler := requireProxy(false)(platformAuth(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := withPlatformSurfaceForTest(requireProxy(false)(platformAuth(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotActor = actor.Delegation(r.Context())
 		gotHeader = r.Header.Get(actor.HeaderDelegation)
 		w.WriteHeader(http.StatusOK)
-	})))
+	}))))
 
 	req := httptest.NewRequest("GET", "/platform/users", nil)
 	req.Header.Set(HeaderPlatformToken, "pt-secret-789")
@@ -561,9 +567,9 @@ func TestPlatformAuth_DuplicateActorDelegationFailsClosed(t *testing.T) {
 	t.Setenv("MS_PLATFORM_TOKEN", "pt-secret-789")
 	t.Setenv("MS_INTERNAL_SECRET", "")
 	reached := false
-	handler := requireProxy(false)(platformAuth(false)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	handler := withPlatformSurfaceForTest(requireProxy(false)(platformAuth(false)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		reached = true
-	})))
+	}))))
 
 	req := httptest.NewRequest("GET", "/platform/users", nil)
 	req.Header.Set(HeaderPlatformToken, "pt-secret-789")

--- a/internal/actor/context.go
+++ b/internal/actor/context.go
@@ -1,0 +1,62 @@
+// Package actor carries the dispatch-issued actor delegation between trusted
+// SDK ingestion and outbound inter-module calls. It lives under internal so a
+// module cannot manufacture a delegation through the public SDK surface.
+package actor
+
+import (
+	"context"
+	"strings"
+)
+
+// HeaderDelegation is the private dispatch-to-SDK wire header. Browser-facing
+// code must never receive or set it; auth middleware captures it only after the
+// platform proxy credential has been verified.
+const HeaderDelegation = "X-MS-Actor-Delegation"
+
+// MaxDelegationBytes bounds an opaque delegation before it is retained in a
+// request context or forwarded on another hop. Current signed tokens are well
+// below this limit.
+const MaxDelegationBytes = 4096
+
+type delegationKey struct{}
+type pendingDelegationKey struct{}
+
+// ValidTransportValue applies only transport-level safety checks. Dispatch is
+// the authority that verifies the signature, claims, expiry, and caller/app
+// binding; the SDK deliberately does not duplicate that policy.
+func ValidTransportValue(assertion string) bool {
+	return assertion != "" && len(assertion) <= MaxDelegationBytes &&
+		!strings.ContainsAny(assertion, ", \t\r\n")
+}
+
+// WithDelegation stores an already trusted opaque assertion in ctx.
+func WithDelegation(ctx context.Context, assertion string) context.Context {
+	if assertion == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, delegationKey{}, assertion)
+}
+
+// Delegation returns the private opaque assertion, or "" when this request
+// has no end-user actor to delegate.
+func Delegation(ctx context.Context) string {
+	assertion, _ := ctx.Value(delegationKey{}).(string)
+	return assertion
+}
+
+// WithPendingDelegation holds a proxy-validated HTTP assertion until
+// PlatformAuth confirms the request is on the platform surface. Public routes
+// may carry this private pending value but cannot forward it through ms.Call.
+func WithPendingDelegation(ctx context.Context, assertion string) context.Context {
+	if assertion == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, pendingDelegationKey{}, assertion)
+}
+
+// ActivatePendingDelegation promotes the private pending assertion for
+// server-side calls made by a platform handler.
+func ActivatePendingDelegation(ctx context.Context) context.Context {
+	assertion, _ := ctx.Value(pendingDelegationKey{}).(string)
+	return WithDelegation(ctx, assertion)
+}

--- a/internal/actor/context.go
+++ b/internal/actor/context.go
@@ -20,6 +20,7 @@ const MaxDelegationBytes = 4096
 
 type delegationKey struct{}
 type pendingDelegationKey struct{}
+type platformSurfaceKey struct{}
 
 // ValidTransportValue applies only transport-level safety checks. Dispatch is
 // the authority that verifies the signature, claims, expiry, and caller/app
@@ -44,9 +45,9 @@ func Delegation(ctx context.Context) string {
 	return assertion
 }
 
-// WithPendingDelegation holds a proxy-validated HTTP assertion until
-// PlatformAuth confirms the request is on the platform surface. Public routes
-// may carry this private pending value but cannot forward it through ms.Call.
+// WithPendingDelegation holds a trusted transport assertion until
+// PlatformAuth confirms the request is on the platform surface. Public and
+// Internal boundaries discard this private pending value before module code.
 func WithPendingDelegation(ctx context.Context, assertion string) context.Context {
 	if assertion == "" {
 		return ctx
@@ -54,9 +55,37 @@ func WithPendingDelegation(ctx context.Context, assertion string) context.Contex
 	return context.WithValue(ctx, pendingDelegationKey{}, assertion)
 }
 
-// ActivatePendingDelegation promotes the private pending assertion for
-// server-side calls made by a platform handler.
+// WithPlatformSurface marks the request as having entered through
+// Module.Platform. The marker lives in this internal package so module code
+// cannot manufacture the activation capability by nesting exported auth
+// middleware inside a Public or Internal handler.
+func WithPlatformSurface(ctx context.Context) context.Context {
+	return context.WithValue(ctx, platformSurfaceKey{}, true)
+}
+
+// PlatformSurface reports whether Module.Platform marked this request.
+func PlatformSurface(ctx context.Context) bool {
+	marked, _ := ctx.Value(platformSurfaceKey{}).(bool)
+	return marked
+}
+
+// WithoutDelegation shadows both active and pending delegation inherited from
+// an upstream context. Public and Internal boundaries use it before module
+// code runs, so nested exported middleware cannot recover a typed Lambda or
+// proxy-captured assertion.
+func WithoutDelegation(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, delegationKey{}, "")
+	return context.WithValue(ctx, pendingDelegationKey{}, "")
+}
+
+// ActivatePendingDelegation promotes the private pending assertion only when
+// the request carries Module.Platform's internal surface capability. It also
+// shadows the pending value after promotion so there is one active state.
 func ActivatePendingDelegation(ctx context.Context) context.Context {
+	if !PlatformSurface(ctx) {
+		return WithoutDelegation(ctx)
+	}
 	assertion, _ := ctx.Value(pendingDelegationKey{}).(string)
+	ctx = WithoutDelegation(ctx)
 	return WithDelegation(ctx, assertion)
 }

--- a/internal/core/actor_delegation_test.go
+++ b/internal/core/actor_delegation_test.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
+)
+
+func TestLambdaActorDelegationActivatesOnlyOnPlatformSurface(t *testing.T) {
+	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
+	t.Setenv("MS_PLATFORM_TOKEN", "")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+
+	m, err := New(Config{ID: "actor_scope_test", Name: "Actor scope test"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	type observation struct{ actor, header string }
+	seen := map[string]observation{}
+	handler := func(scope string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			seen[scope] = observation{
+				actor:  actor.Delegation(r.Context()),
+				header: r.Header.Get(actor.HeaderDelegation),
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+	m.Public(func(r chi.Router) { r.Get("/actor", handler("public")) })
+	m.Platform(func(r chi.Router) { r.Get("/actor", handler("platform")) })
+	m.Internal(func(r chi.Router) { r.Get("/actor", handler("internal")) })
+
+	invoke := runtime.NewLambdaHandler(m.Router())
+	for _, scope := range []string{"public", "platform", "internal"} {
+		payload, marshalErr := json.Marshal(runtime.LambdaRequest{
+			Method:          http.MethodGet,
+			Path:            "/" + scope + "/actor",
+			UserID:          "u-1",
+			AppID:           "a-1",
+			AppRole:         "admin",
+			ActorDelegation: "msa1.payload.signature",
+			Headers: map[string]string{
+				actor.HeaderDelegation: "msa1.raw-spoof.signature",
+			},
+		})
+		if marshalErr != nil {
+			t.Fatalf("marshal %s: %v", scope, marshalErr)
+		}
+		resp, invokeErr := invoke(context.Background(), payload)
+		if invokeErr != nil {
+			t.Fatalf("invoke %s: %v", scope, invokeErr)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("invoke %s status = %d, want 204: %s", scope, resp.StatusCode, resp.Body)
+		}
+	}
+
+	if got := seen["platform"]; got.actor != "msa1.payload.signature" || got.header != "" {
+		t.Errorf("platform actor/header = %q/%q, want typed actor and no raw header", got.actor, got.header)
+	}
+	for _, scope := range []string{"public", "internal"} {
+		if got := seen[scope]; got.actor != "" || got.header != "" {
+			t.Errorf("%s actor/header = %q/%q, want both empty", scope, got.actor, got.header)
+		}
+	}
+}

--- a/internal/core/actor_delegation_test.go
+++ b/internal/core/actor_delegation_test.go
@@ -4,12 +4,126 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
 )
+
+func TestNestedPlatformAuthCannotActivateActorDelegationOnHTTPNonPlatformSurfaces(t *testing.T) {
+	const delegation = "msa1.http.payload.signature"
+	seen := map[string][]string{}
+	dispatch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen[r.URL.Path] = r.Header.Values(actor.HeaderDelegation)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer dispatch.Close()
+
+	t.Setenv("MS_DISPATCH_URL", dispatch.URL)
+	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
+	t.Setenv("MS_PLATFORM_TOKEN", "platform-token")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+
+	m, err := New(Config{ID: "actor_http_nested_test", Name: "Actor HTTP nested test"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	registerNestedPlatformCall := func(register func(func(chi.Router)), scope string) {
+		call := auth.PlatformAuth()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if callErr := m.CallGet(r.Context(), "target", "/platform/"+scope, nil); callErr != nil {
+				http.Error(w, callErr.Error(), http.StatusBadGateway)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		register(func(r chi.Router) { r.Get("/nested", call.ServeHTTP) })
+	}
+	registerNestedPlatformCall(m.Public, "public")
+	registerNestedPlatformCall(m.Internal, "internal")
+
+	for _, scope := range []string{"public", "internal"} {
+		req := httptest.NewRequest(http.MethodGet, "/"+scope+"/nested", nil)
+		req.Header.Set(auth.HeaderPlatformToken, "platform-token")
+		req.Header.Set(auth.HeaderUserID, "u-1")
+		req.Header.Set(auth.HeaderAppID, "a-1")
+		req.Header.Set(auth.HeaderAppRole, auth.RoleAdmin)
+		req.Header.Set(actor.HeaderDelegation, delegation)
+		rec := httptest.NewRecorder()
+		m.Router().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("%s status = %d, want 204: %s", scope, rec.Code, rec.Body.String())
+		}
+	}
+
+	for _, scope := range []string{"public", "internal"} {
+		if got := seen["/module/target/platform/"+scope]; len(got) != 0 {
+			t.Errorf("%s nested PlatformAuth forwarded %s = %q, want none", scope, actor.HeaderDelegation, got)
+		}
+	}
+}
+
+func TestNestedPlatformAuthCannotActivateActorDelegationOnLambdaNonPlatformSurfaces(t *testing.T) {
+	const delegation = "msa1.lambda.payload.signature"
+	seen := map[string][]string{}
+	dispatch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen[r.URL.Path] = r.Header.Values(actor.HeaderDelegation)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer dispatch.Close()
+
+	t.Setenv("MS_DISPATCH_URL", dispatch.URL)
+	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")
+	t.Setenv("MS_PLATFORM_TOKEN", "platform-token")
+	t.Setenv("MS_INTERNAL_SECRET", "")
+
+	m, err := New(Config{ID: "actor_lambda_nested_test", Name: "Actor Lambda nested test"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	registerNestedPlatformCall := func(register func(func(chi.Router)), scope string) {
+		call := auth.PlatformAuth()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if callErr := m.CallGet(r.Context(), "target", "/platform/"+scope, nil); callErr != nil {
+				http.Error(w, callErr.Error(), http.StatusBadGateway)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		register(func(r chi.Router) { r.Get("/nested", call.ServeHTTP) })
+	}
+	registerNestedPlatformCall(m.Public, "public")
+	registerNestedPlatformCall(m.Internal, "internal")
+
+	invoke := runtime.NewLambdaHandler(m.Router())
+	for _, scope := range []string{"public", "internal"} {
+		payload, marshalErr := json.Marshal(runtime.LambdaRequest{
+			Method:          http.MethodGet,
+			Path:            "/" + scope + "/nested",
+			UserID:          "u-1",
+			AppID:           "a-1",
+			AppRole:         auth.RoleAdmin,
+			ActorDelegation: delegation,
+		})
+		if marshalErr != nil {
+			t.Fatalf("marshal %s: %v", scope, marshalErr)
+		}
+		resp, invokeErr := invoke(context.Background(), payload)
+		if invokeErr != nil {
+			t.Fatalf("invoke %s: %v", scope, invokeErr)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("invoke %s status = %d, want 204: %s", scope, resp.StatusCode, resp.Body)
+		}
+	}
+
+	for _, scope := range []string{"public", "internal"} {
+		if got := seen["/module/target/platform/"+scope]; len(got) != 0 {
+			t.Errorf("%s nested PlatformAuth forwarded %s = %q, want none", scope, actor.HeaderDelegation, got)
+		}
+	}
+}
 
 func TestLambdaActorDelegationActivatesOnlyOnPlatformSurface(t *testing.T) {
 	t.Setenv("MS_PLATFORM_TOKEN_FILE", "")

--- a/internal/core/call.go
+++ b/internal/core/call.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	pathpkg "path"
 	"strings"
 	"time"
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 )
 
 // devDispatchFallback is used when MS_DISPATCH_URL is unset. Modules run inside
@@ -59,7 +62,10 @@ func resolveCallURL(targetModuleID, path string) string {
 // identity before forwarding.
 //
 // path must include its leading slash and any raw query string, e.g.
-// "/internal/exchange" or "/internal/users?limit=10".
+// "/internal/exchange" or "/platform/users?limit=10". A verified actor
+// delegation is forwarded only to a canonical /platform route. Public and
+// Internal calls remain actorless service calls even when they originate in a
+// Platform handler.
 //
 // DEV/DISPATCH TRANSPORT — see resolveCallURL for the prod (#146) seam.
 func (m *Module) Call(ctx context.Context, targetModuleID, method, path string, body, out any) error {
@@ -86,6 +92,9 @@ func (m *Module) Call(ctx context.Context, targetModuleID, method, path string, 
 	if secret := moduleSessionSecret(); secret != "" {
 		req.Header.Set("X-MS-Service-Secret", secret)
 	}
+	if delegation := actor.Delegation(ctx); delegation != "" && isPlatformCallPath(path) {
+		req.Header.Set(actor.HeaderDelegation, delegation)
+	}
 
 	resp, err := callHTTP.Do(req)
 	if err != nil {
@@ -100,6 +109,22 @@ func (m *Module) Call(ctx context.Context, targetModuleID, method, path string, 
 		return nil
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// isPlatformCallPath recognizes only canonical module Platform routes. It
+// parses the request target before classification so dot-segment or encoded
+// traversal cannot make an assertion appear to target /platform while the
+// receiving HTTP stack resolves it somewhere else.
+func isPlatformCallPath(raw string) bool {
+	u, err := url.ParseRequestURI(raw)
+	if err != nil || u.IsAbs() || u.Host != "" || u.Fragment != "" {
+		return false
+	}
+	cleaned := pathpkg.Clean(u.Path)
+	if cleaned != u.Path && !(u.Path == "/platform/" && cleaned == "/platform") {
+		return false
+	}
+	return u.Path == "/platform" || strings.HasPrefix(u.Path, "/platform/")
 }
 
 // CallGet is Call specialized to GET (no request body). path carries any raw

--- a/internal/core/call_test.go
+++ b/internal/core/call_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 )
 
 func TestDispatchBaseFallsBackWhenUnset(t *testing.T) {
@@ -79,15 +80,42 @@ func TestResolveCallURL_Building(t *testing.T) {
 	}
 }
 
-func TestCall_SendsAppIDServiceSecretAndDecodesResponse(t *testing.T) {
+func TestIsPlatformCallPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/platform", want: true},
+		{path: "/platform/", want: true},
+		{path: "/platform/users", want: true},
+		{path: "/platform/users?limit=10", want: true},
+		{path: "/public/users", want: false},
+		{path: "/internal/users", want: false},
+		{path: "/platformish/users", want: false},
+		{path: "/platform/../internal/users", want: false},
+		{path: "/platform/%2e%2e/internal/users", want: false},
+		{path: "https://example.test/platform/users", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := isPlatformCallPath(tc.path); got != tc.want {
+				t.Errorf("isPlatformCallPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCall_SendsAppIDServiceSecretActorDelegationAndDecodesResponse(t *testing.T) {
 	var gotMethod, gotPath, gotAppID, gotCT string
-	var gotSecrets []string
+	var gotSecrets, gotDelegations []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotAppID = r.Header.Get("X-MS-App-ID")
 		gotCT = r.Header.Get("Content-Type")
 		gotSecrets = r.Header.Values("X-MS-Service-Secret")
+		gotDelegations = r.Header.Values(actor.HeaderDelegation)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
@@ -97,11 +125,12 @@ func TestCall_SendsAppIDServiceSecretAndDecodesResponse(t *testing.T) {
 
 	m, _ := New(Config{ID: "demo"})
 	ctx := auth.Set(context.Background(), auth.Identity{AppID: "a-456"})
+	ctx = actor.WithDelegation(ctx, "msa1.payload.signature")
 
 	var out struct {
 		OK bool `json:"ok"`
 	}
-	if err := m.CallPost(ctx, "m0123", "/internal/exchange", map[string]string{"code": "x"}, &out); err != nil {
+	if err := m.CallPost(ctx, "m0123", "/platform/exchange", map[string]string{"code": "x"}, &out); err != nil {
 		t.Fatalf("CallPost: %v", err)
 	}
 	if !out.OK {
@@ -110,8 +139,8 @@ func TestCall_SendsAppIDServiceSecretAndDecodesResponse(t *testing.T) {
 	if gotMethod != http.MethodPost {
 		t.Errorf("method = %q, want POST", gotMethod)
 	}
-	if gotPath != "/module/m0123/internal/exchange" {
-		t.Errorf("path = %q, want /module/m0123/internal/exchange", gotPath)
+	if gotPath != "/module/m0123/platform/exchange" {
+		t.Errorf("path = %q, want /module/m0123/platform/exchange", gotPath)
 	}
 	if gotAppID != "a-456" {
 		t.Errorf("X-MS-App-ID = %q, want a-456", gotAppID)
@@ -122,12 +151,39 @@ func TestCall_SendsAppIDServiceSecretAndDecodesResponse(t *testing.T) {
 	if len(gotSecrets) != 1 || gotSecrets[0] != "session-secret-1" {
 		t.Errorf("X-MS-Service-Secret values = %q, want exactly [session-secret-1]", gotSecrets)
 	}
+	if len(gotDelegations) != 1 || gotDelegations[0] != "msa1.payload.signature" {
+		t.Errorf("%s values = %q, want exactly one trusted assertion", actor.HeaderDelegation, gotDelegations)
+	}
+}
+
+func TestCall_OmitsActorDelegationOutsidePlatformRoutes(t *testing.T) {
+	var requests [][]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Header.Values(actor.HeaderDelegation))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+
+	m, _ := New(Config{ID: "demo"})
+	ctx := actor.WithDelegation(context.Background(), "msa1.payload.signature")
+	for _, callPath := range []string{"/internal/exchange", "/public/catalog", "/platformish/not-platform"} {
+		if err := m.CallGet(ctx, "m0123", callPath, nil); err != nil {
+			t.Fatalf("CallGet(%q): %v", callPath, err)
+		}
+	}
+	for index, values := range requests {
+		if len(values) != 0 {
+			t.Errorf("request %d actor values = %q, want none", index, values)
+		}
+	}
 }
 
 func TestCall_OmitsEmptyServiceSecret(t *testing.T) {
-	var gotSecrets []string
+	var gotSecrets, gotDelegations []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotSecrets = r.Header.Values("X-MS-Service-Secret")
+		gotDelegations = r.Header.Values(actor.HeaderDelegation)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -142,10 +198,14 @@ func TestCall_OmitsEmptyServiceSecret(t *testing.T) {
 	if len(gotSecrets) != 0 {
 		t.Errorf("X-MS-Service-Secret values = %q, want no header", gotSecrets)
 	}
+	if len(gotDelegations) != 0 {
+		t.Errorf("%s values = %q, want no header", actor.HeaderDelegation, gotDelegations)
+	}
 }
 
 func TestCall_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
 	const serviceSecret = "session-secret-must-not-leak"
+	const actorDelegation = "msa1.actor-must-not-leak.signature"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 		_, _ = w.Write([]byte("upstream module unavailable"))
@@ -155,7 +215,8 @@ func TestCall_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
 	t.Setenv("MS_INTERNAL_SECRET", serviceSecret)
 
 	m, _ := New(Config{ID: "demo"})
-	err := m.CallGet(context.Background(), "m0123", "/internal/users", nil)
+	ctx := actor.WithDelegation(context.Background(), actorDelegation)
+	err := m.CallGet(ctx, "m0123", "/internal/users", nil)
 	if err == nil {
 		t.Fatal("expected error on non-2xx, got nil")
 	}
@@ -171,6 +232,9 @@ func TestCall_Non2xxReturnsErrorWithTruncatedBody(t *testing.T) {
 	}
 	if strings.Contains(msg, serviceSecret) {
 		t.Errorf("error leaked X-MS-Service-Secret: %q", msg)
+	}
+	if strings.Contains(msg, actorDelegation) {
+		t.Errorf("error leaked %s: %q", actor.HeaderDelegation, msg)
 	}
 }
 

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
 	"github.com/mirrorstack-ai/app-module-sdk/i18n"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/contributions"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/httputil"
 	"github.com/mirrorstack-ai/app-module-sdk/internal/migration"
@@ -330,12 +331,17 @@ func (m *Module) Router() *chi.Mux { return m.router }
 // Default role gate: admin only. Use Module.RequirePermission to
 // open routes to member/viewer.
 func (m *Module) Platform(fn func(r chi.Router)) {
-	// proxyGuard runs BEFORE PlatformAuth: reject non-proxied callers at the
-	// trust boundary, then let PlatformAuth read the now-trusted identity
-	// headers. (PlatformAuth already validates the platform token on its own,
-	// so the guard is belt-and-suspenders here, but keeping it makes the
-	// public + platform surfaces enforce identically and auditably.)
-	m.scopedRoutes(registry.ScopePlatform, fn, m.proxyGuard, m.platformAuth)
+	// platformActorSurface installs the private capability before proxyGuard
+	// captures a pending actor assertion. PlatformAuth can activate delegation
+	// only while this marker is present, so a module cannot reproduce the
+	// capability by nesting the exported middleware on another surface.
+	m.scopedRoutes(registry.ScopePlatform, fn, platformActorSurface, m.proxyGuard, m.platformAuth)
+}
+
+func platformActorSurface(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(actor.WithPlatformSurface(r.Context())))
+	})
 }
 
 // Public registers routes with public auth scope (anyone, including

--- a/internal/runtime/inject.go
+++ b/internal/runtime/inject.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 )
 
@@ -14,12 +15,13 @@ import (
 // Used by both the Lambda handler and the task worker — any change here
 // applies to both paths automatically.
 type InjectParams struct {
-	Resources    *Resources
-	Dependencies []DependencyGrant
-	UserID       string
-	AppID        string
-	AppRole      string
-	AppSchema    string
+	Resources       *Resources
+	Dependencies    []DependencyGrant
+	UserID          string
+	AppID           string
+	AppRole         string
+	AppSchema       string
+	ActorDelegation string
 }
 
 // validRoles is the set of platform roles the SDK recognizes. Messages
@@ -43,6 +45,9 @@ func InjectResources(ctx context.Context, p InjectParams) (context.Context, erro
 	}
 	if !validRoles[p.AppRole] {
 		return ctx, fmt.Errorf("mirrorstack: unknown app role %q", p.AppRole)
+	}
+	if p.ActorDelegation != "" && !actor.ValidTransportValue(p.ActorDelegation) {
+		return ctx, fmt.Errorf("mirrorstack: invalid actor delegation")
 	}
 
 	if p.Resources != nil {
@@ -71,6 +76,12 @@ func InjectResources(ctx context.Context, p InjectParams) (context.Context, erro
 			AppID:   p.AppID,
 			AppRole: p.AppRole,
 		})
+	}
+	if p.ActorDelegation != "" {
+		// Lambda route scope is not known here. Keep the assertion pending;
+		// PlatformAuth activates it only on a Platform route after the typed
+		// payload trust mark is present. Public/Internal remain actorless.
+		ctx = actor.WithPendingDelegation(ctx, p.ActorDelegation)
 	}
 	return ctx, nil
 }

--- a/internal/runtime/inject_test.go
+++ b/internal/runtime/inject_test.go
@@ -2,11 +2,13 @@ package runtime
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 	"github.com/mirrorstack-ai/app-module-sdk/storage"
 )
 
@@ -19,10 +21,11 @@ func TestInjectResources_FullInjection(t *testing.T) {
 			Cache:   &cache.Credential{Endpoint: "localhost:6379", Username: "cu"},
 			Storage: &storage.Credential{Bucket: "b", Region: "r"},
 		},
-		UserID:    "user-1",
-		AppID:     "app-1",
-		AppRole:   "admin",
-		AppSchema: "app_abc123",
+		UserID:          "user-1",
+		AppID:           "app-1",
+		AppRole:         "admin",
+		AppSchema:       "app_abc123",
+		ActorDelegation: "msa1.payload.signature",
 	})
 	if err != nil {
 		t.Fatalf("InjectResources: %v", err)
@@ -42,6 +45,9 @@ func TestInjectResources_FullInjection(t *testing.T) {
 	}
 	if a := auth.Get(ctx); a == nil || a.UserID != "user-1" || a.AppRole != "admin" {
 		t.Errorf("auth identity not injected correctly: %+v", a)
+	}
+	if got := actor.Delegation(ctx); got != "" {
+		t.Errorf("actor delegation = %q, want pending until PlatformAuth", got)
 	}
 }
 
@@ -87,5 +93,19 @@ func TestInjectResources_EmptyRoleAllowed(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("empty role should be allowed: %v", err)
+	}
+}
+
+func TestInjectResources_InvalidActorDelegation(t *testing.T) {
+	t.Parallel()
+
+	_, err := InjectResources(context.Background(), InjectParams{
+		ActorDelegation: "contains whitespace",
+	})
+	if err == nil {
+		t.Fatal("expected invalid actor delegation to be rejected")
+	}
+	if strings.Contains(err.Error(), "contains whitespace") {
+		t.Errorf("error leaked actor delegation: %q", err)
 	}
 }

--- a/internal/runtime/lambda.go
+++ b/internal/runtime/lambda.go
@@ -72,6 +72,10 @@ type LambdaRequest struct {
 	AppID     string `json:"appId,omitempty"`
 	AppRole   string `json:"appRole,omitempty"`
 	AppSchema string `json:"appSchema,omitempty"`
+	// ActorDelegation is an opaque, short-lived dispatch-signed assertion.
+	// It is a typed trusted field because every inbound X-MS-* claim header is
+	// stripped before the module router runs.
+	ActorDelegation string `json:"actorDelegation,omitempty"`
 }
 
 // LambdaResponse is returned to the platform after handling a request.
@@ -156,12 +160,13 @@ func NewLambdaHandler(handler http.Handler) func(context.Context, json.RawMessag
 		// InjectResources is the shared injection function used by both
 		// Lambda and task worker paths — see inject.go.
 		reqCtx, err := InjectResources(httpReq.Context(), InjectParams{
-			Resources:    req.Resources,
-			Dependencies: req.Dependencies,
-			UserID:       req.UserID,
-			AppID:        req.AppID,
-			AppRole:      req.AppRole,
-			AppSchema:    req.AppSchema,
+			Resources:       req.Resources,
+			Dependencies:    req.Dependencies,
+			UserID:          req.UserID,
+			AppID:           req.AppID,
+			AppRole:         req.AppRole,
+			AppSchema:       req.AppSchema,
+			ActorDelegation: req.ActorDelegation,
 		})
 		if err != nil {
 			return jsonError(400, err.Error()), nil

--- a/internal/runtime/lambda_test.go
+++ b/internal/runtime/lambda_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mirrorstack-ai/app-module-sdk/auth"
 	"github.com/mirrorstack-ai/app-module-sdk/cache"
 	"github.com/mirrorstack-ai/app-module-sdk/db"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
 )
 
 func mustMarshal(t *testing.T, v any) json.RawMessage {
@@ -222,6 +223,37 @@ func TestNewLambdaHandler_AuthSecretHeadersSurvive(t *testing.T) {
 		if body[claim] != "" {
 			t.Errorf("identity claim %q must be stripped, got %q", claim, body[claim])
 		}
+	}
+}
+
+func TestNewLambdaHandler_KeepsTypedActorPendingAndStripsRawHeader(t *testing.T) {
+	r := chi.NewRouter()
+	var gotActor, gotHeader string
+	r.Get("/check", func(w http.ResponseWriter, r *http.Request) {
+		gotActor = actor.Delegation(r.Context())
+		gotHeader = r.Header.Get(actor.HeaderDelegation)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	handler := NewLambdaHandler(r)
+	resp, err := handler(context.Background(), mustMarshal(t, LambdaRequest{
+		Method:          http.MethodGet,
+		Path:            "/check",
+		ActorDelegation: "msa1.typed.signature",
+		Headers: map[string]string{
+			actor.HeaderDelegation: "msa1.spoofed.signature",
+		},
+	}))
+	requireNoErr(t, err)
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", resp.StatusCode, resp.Body)
+	}
+	if gotActor != "" {
+		t.Errorf("actor delegation = %q, want pending until a Platform route authenticates", gotActor)
+	}
+	if gotHeader != "" {
+		t.Errorf("raw %s reached handler as %q", actor.HeaderDelegation, gotHeader)
 	}
 }
 


### PR DESCRIPTION
## Summary

- capture dispatch-issued actor delegation only after a trusted Platform ingress
- bind actor activation to an internal `Module.Platform` surface capability that module code cannot recreate by nesting exported auth middleware
- scrub both active and pending delegation at every Public/Internal HTTP and Lambda boundary
- forward exactly one private assertion from `ms.Call` only to canonical `/platform` targets
- strip raw assertions from handlers and reject ambiguous Platform values without logging tokens
- preserve direct tunnel and typed Lambda transport parity

## Security contract

The SDK treats the assertion as opaque. Dispatch remains responsible for signature, expiry, app, user, role, and caller-module validation. The assertion is stored only in an internal context package and is never exposed through the public module SDK or browser bundle contract.

`auth.PlatformAuth` is authentication middleware, not a delegation capability. Actor activation additionally requires the private surface marker installed only by `Module.Platform`; Public/Internal boundaries shadow any inherited active or pending value before module code runs.

## Verification

Exact reviewed HEAD: `17eeb17`

- adversarial regression reproduced before the fix: nested exported `PlatformAuth` forwarded delegation from HTTP Public and Lambda Public/Internal handlers to canonical `/platform` `ms.Call` targets
- the same HTTP and Lambda adversarial tests pass after the fix; outbound delegation is absent on Public/Internal
- genuine `Module.Platform` Lambda activation remains green
- focused `-race` auth/core/runtime suites pass
- full `go test ./...` passes (`internal/core` 150.825s)
- `go vet ./...` passes
- `git diff --check` passes
- `review-like-me` mechanical scan: 0 findings; manual P1-P6/P4 security review: APPROVE
- independent adversarial final review: PASS, no merge-blocking finding

Part of mirrorstack-ai/mirrorstack-core-v2#397

Closes #171