### PR TITLE
ci: run on the shared self-hosted runner labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Runner selection is data, not code.
+    # Unset RUNNER_LABELS falls back to GitHub-hosted arm64; the org variable currently
+    # points at the shared self-hosted labels. arm64 is deliberate.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
+    # Limit hung jobs to 20 minutes so they cannot occupy one of three shared runners for six hours.
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:17-alpine

--- a/.github/workflows/notify-core-pointer.yml
+++ b/.github/workflows/notify-core-pointer.yml
@@ -19,7 +19,10 @@ jobs:
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main'
       }}
-    runs-on: ubuntu-latest
+    # Runner selection is data, not code.
+    # Unset RUNNER_LABELS falls back to GitHub-hosted arm64; the org variable currently
+    # points at the shared self-hosted labels. arm64 is deliberate.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - name: Mint core-only workflow dispatcher token
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,10 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
-    runs-on: ubuntu-latest
+    # Runner selection is data, not code.
+    # Unset RUNNER_LABELS falls back to GitHub-hosted arm64; the org variable currently
+    # points at the shared self-hosted labels. arm64 is deliberate.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       contents: write
     steps:
@@ -52,8 +55,9 @@ jobs:
       - name: Verify tag does not already exist
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "Tag $TAG already exists — bump VERSION before merging." >&2
+          # Reused workspaces may retain local tags, so origin is the release authority.
+          if [ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]; then
+            echo "Tag $TAG already exists on origin — bump VERSION before merging." >&2
             exit 1
           fi
 


### PR DESCRIPTION
GitHub-hosted runners are billing-blocked org-wide right now — every hosted job dies at start with
`The job was not started because recent account payments have failed or your spending limit needs to
be increased`. All three workflows in this repo were on `ubuntu-latest`, so **all three are currently
dead**. This routes them at the org's self-hosted fleet, where minutes are free.

```yaml
runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
```

Byte-identical to the expression already in `api-platform` and `ms-app-modules`. Runner selection
stays **data, not code**: `RUNNER_LABELS` is an org variable (today `["self-hosted","ARM64"]`) and
the literal inside `fromJSON` is only the fallback for when the variable is unset — so the workflows
still resolve if it is ever removed. Targeting the *shared* labels rather than a group-specific one
means the currently-offline `dgx-spark` group picks work up again when it re-registers, with no code
change.

## Jobs moved — all three

The fleet is **Linux / arm64**, so each job was checked for an arch or preinstalled-software
assumption before moving it.

| Workflow | Job | Why it is safe on linux/arm64 |
|---|---|---|
| `ci.yml` | `test` | Go 1.26 resolves `linux-arm64` from `setup-go`. All three service images publish arm64 manifests (checked against the registry, below), and the runners carry a `docker` label. |
| `release.yml` | `release` | Pushes a git tag and creates a GitHub Release. It **compiles nothing** — the Go module proxy serves source straight from the tag — so there is no arch-specific artifact to get wrong. |
| `notify-core-pointer.yml` | `dispatch` | A JS action (`create-github-app-token`) plus one `gh workflow run`. Arch-neutral. Matches what `api-platform`, `ms-app-modules` and `mirrorstack-infra` already do with their copy of this workflow. |

Service-image arch check, from the Docker registry manifest lists:

```
=== softwaremill/elasticmq-native:latest ===   linux amd64 / linux arm64
=== library/postgres:17-alpine ===             amd64, arm v6, arm v7, arm64 v8, 386, ppc64le, riscv64, s390x
=== library/redis:7-alpine ===                 amd64, arm v6, arm v7, arm64 v8, 386, ppc64le, riscv64, s390x
```

`elasticmq-native` was the one worth checking — it is a GraalVM native-image build, i.e. exactly the
shape of thing that is often amd64-only. It publishes arm64.

## Jobs NOT moved

None. There is no cross-platform matrix in this repo (no macOS/Windows legs to strand on Linux), and
no job produces an architecture-specific binary.

## Two changes that are not the label swap

Both are properties the hosted runners were hiding, not cleanups:

1. **`ci.yml` gains `timeout-minutes: 20`.** The 360-minute default was harmless on an ephemeral
   runner. The fleet is **three boxes, shared across every repo in the org** — a hung job would squat
   one of them for six hours.

2. **`release.yml` verifies the tag against `origin`, not the local repo.** Self-hosted workspaces are
   **reused** between jobs, not thrown away. The old `git rev-parse -q --verify refs/tags/$TAG` read
   the local tag namespace, which was only trustworthy because a hosted checkout is a fresh throwaway.
   On a reused workspace a leftover local tag from a run whose *push* failed persists — and would then
   permanently fail this guard, burning a version number for a release that never actually shipped.
   `git ls-remote --tags origin` asks the only authority on what was really released.
   (`actions/checkout` persists credentials, which the existing `git push origin` in the same job
   already depends on.)

Workspace reuse is not hypothetical here — a prior self-hosted run on this fleet shows the warm
`GOMODCACHE` left behind by an earlier job:

```
/usr/bin/tar: ../../../go/pkg/mod/github.com/mirrorstack-ai/app-module-sdk@v0.3.1/docker-compose.yml: Cannot open: File exists
```

## Run evidence

<!--RUN_EVIDENCE-->

## Not verifiable from this PR

`release.yml` triggers on `pull_request: closed` and `notify-core-pointer.yml` on `workflow_run`
after a push to `main`. Neither fires on this PR, so **neither is exercised by the checks below**.
Both call the `gh` CLI, which is preinstalled on GitHub's hosted images; I could not confirm from any
completed run that `gh` is on the self-hosted image. Blast radius if it is missing:

- `notify-core-pointer` — low. Per this repo's `CLAUDE.md`, core's scheduled scan is the documented
  fallback when the pointer PR does not appear.
- `release` — the tag push happens *before* `gh release create`, so a missing `gh` would leave the tag
  pushed and the GitHub Release object absent. For a Go module the tag is the part that matters (the
  module proxy needs nothing else) and the Release can be created by hand afterwards. Left on
  `ubuntu-latest` it cuts **no tag at all** today, so moving it is still the strictly better failure
  mode — but flagging it rather than claiming it verified.

The first `main` push after this merges will exercise both.
