### PR TITLE
docs: audit trails as a module principle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Reference + conceptual guides for building MirrorStack modules in Go.
 ## Concepts
 
 - [Agent tools](./concepts/agent-tools.md) — MCP tools/resources vs skills vs subagents; why modules are agent-first.
+- [Audit trails](./concepts/audit.md) — recording who changed what and how; ledger vs provenance columns, and why the actor is never a header.
 - [Dependencies](./concepts/dependencies.md) — required vs optional deps, auto-detect rule, extract-function caveat.
 - [Manifest](./concepts/manifest.md) — what's in the manifest endpoint, field by field.
 - [Scopes](./concepts/scopes.md) — Platform / Public / Internal and when to use each.

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -129,16 +129,27 @@ count: only the producer knows its own page size.
 
 ## 7. Do not gate the read on an actorless transport
 
-Do not put `RequirePermission` on an `Internal` read. The service call carries
-the app id and credentials, but no caller: `ms.Call` sends no actor, and dispatch
-supplies the target module's internal secret. Without a fabricated role,
-`RequirePermission` returns `401` for that service identity.
+Do not put `RequirePermission` on an `Internal` read — not because it would deny
+the service call, but because it would not deny anything.
 
-That failure is worse than a denied page. A host fetching a contributed audit
-list degrades a failed fetch to "no audit section", so the `401` renders as
-*"this subject has no history"* — a security ledger disappearing in silence.
-Re-adding the permission gate does not restore a caller boundary; it breaks the
-actorless read.
+`ms.Call` is actorless: the hop carries the app id and the calling module's
+service secret, and dispatch injects the target module's internal secret. No
+caller identity travels with it. What *does* travel with it is a role the
+platform invents — every forward through the `/module` edge stamps
+`X-MS-App-Role: admin`, on the dev-tunnel branch and the deployed-Lambda branch
+alike. `RequirePermission` compiles to `auth.RequireRoles(admin, …declared)`,
+and admin always passes. So the gate does not reject the service identity: it
+admits it, and admits everything else that reaches the same edge, while reading
+in the source like a control. Silent admission is the failure here, not a
+denial.
+
+The read can still fail, and the caller will not see why. `ms.Call` returns an
+error for any non-2xx, and the edge produces several before the module is ever
+reached: `not_installed` (404), `route_local_off` and `tunnel_offline` (503), a
+resolver fault (500). A host that degrades a failed audit fetch to "no audit
+section" renders each of those as *"this subject has no history"*. Distinguish
+"empty" from "could not load" and say which — an audit surface that cannot tell
+them apart is worse than one that is absent.
 
 Because the route cannot authenticate its caller, browser-originated `Internal`
 paths must be refused by the platform. Today they are not. The dispatch mount at
@@ -150,10 +161,13 @@ internal secret, handing the module a privileged identity no caller presented.
 
 This holds on both planes. The five-condition dev gate — app dev-mode, module
 dev-mode, `dev_mount`, an install row, and a live tunnel — decides whether the
-localhost plane is open, not who is asking; and a module with a deploy row is
-served by a second branch of the same edge that skips those conditions
-altogether and invokes the deployed function with the same fabricated identity.
-The gap belongs to the `/module` browser edge, not to dev-mounting.
+localhost plane is open, not who is asking. A module with a deploy row is served
+by a second branch of the same edge that keeps exactly one of those five: the
+deploy is resolved through that app's own `module_install` row, so a missing
+install row (or an un-bootstrapped app schema) still resolves to no transport.
+The four dev conditions are not consulted, and the deployed function is invoked
+with the same fabricated identity. The gap belongs to the `/module` browser
+edge, not to dev-mounting.
 
 So an `Internal` route is not a confidentiality boundary. Do not put behind it
 anything that would be harmful to expose to whoever can reach that edge.

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -141,27 +141,22 @@ Re-adding the permission gate does not restore a caller boundary; it breaks the
 actorless read.
 
 Because the route cannot authenticate its caller, browser-originated `Internal`
-paths must be refused by the platform. Today the platform does not refuse them
-for dev-mounted modules. The dispatch mount is unauthenticated at the HTTP edge,
-and the only namespace it refuses is `__mirrorstack/*`; its other path-shape
-checks do not cover `/internal/`, so `/internal/...` is forwarded to the module.
-The handler injects the module owner's user id and a hardcoded `admin` app-role
-together with the session's internal secret, handing the module a privileged
-identity no caller presented.
+paths must be refused by the platform. Today they are not. The dispatch mount at
+`/module/...` is unauthenticated at the HTTP edge, and the only namespace it
+refuses is `__mirrorstack/*` — its other path-shape checks do not cover
+`/internal/` — so `/internal/...` is forwarded to the module. The handler then
+injects the module owner's user id and a hardcoded `admin` app-role alongside an
+internal secret, handing the module a privileged identity no caller presented.
 
-The five-condition dev gate — app dev-mode, module dev-mode, `dev_mount`, an
-install row, and a live tunnel — controls whether the localhost plane is open.
-It does not establish who is asking. On the dev plane, an `Internal` route is
-not a confidentiality boundary. Do not place behind it anything that would be
-harmful to expose to whoever can reach the module edge on either plane.
+This holds on both planes. The five-condition dev gate — app dev-mode, module
+dev-mode, `dev_mount`, an install row, and a live tunnel — decides whether the
+localhost plane is open, not who is asking; and a module with a deploy row is
+served by a second branch of the same edge that skips those conditions
+altogether and invokes the deployed function with the same fabricated identity.
+The gap belongs to the `/module` browser edge, not to dev-mounting.
 
-The dev-tunnel branch does not serve deployed modules. The same unauthenticated
-`/module` browser edge also has a deployed branch, however. It skips the dev
-conditions and forwards `/internal/*` to the deployed function with the same
-fabricated identity: the owner's user id and `admin` role, plus the platform's
-own internal secret. The gap is therefore a property of the `/module` browser
-edge, not the dev plane, and is present on both the dev-tunnel and deployed
-planes.
+So an `Internal` route is not a confidentiality boundary. Do not put behind it
+anything that would be harmful to expose to whoever can reach that edge.
 
 ## 8. Checklist
 
@@ -176,7 +171,7 @@ planes.
 - [ ] Bounded reads report `hasMore`; the surface says it is capped
 - [ ] No backfill; pre-existing rows read as unknown
 - [ ] `Internal` read not permission-gated; its data is safe to expose to anyone
-  who can reach the module edge on either plane
+  who can reach the `/module` edge, on either plane
 - [ ] Migration embedded through `ms.Config.SQL`; manifest `migration` reflects
   it
 

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -2,8 +2,8 @@
 
 A module that changes who can do what owes an answer to "who did this, and how".
 This page is the rule for producing that answer, and the reasoning behind each
-part of it. Two modules already follow it — users-roles records role grants and
-revocations, oauth-core records session revocations — and they landed on
+part of it. Two modules supply the examples — users-roles records role grants
+and revocations, oauth-core records session revocations — and they landed on
 different shapes for good reasons, which is where this starts.
 
 The failure this exists to prevent is not a missing feature. It is a trail that
@@ -129,16 +129,34 @@ count: only the producer knows its own page size.
 
 ## 7. Do not gate the read on an actorless transport
 
-An `Internal` route is an actorless **service** call: the SDK sends the internal
-secret and the app id, no actor. `RequirePermission` there `401`s for the very
-identity `ms.Call` uses.
+Do not put `RequirePermission` on an `Internal` read. The service call carries
+the app id and credentials, but no caller: `ms.Call` sends no actor, and dispatch
+supplies the target module's internal secret. Without a fabricated role,
+`RequirePermission` returns `401` for that service identity.
 
-That is bad on its own and worse in combination: a host fetching a contributed
-audit list typically degrades a failed fetch to "no audit section", so the 401
-renders as *"this subject has no history"* — a security ledger disappearing in
-silence. Internal scope is itself the boundary; the path is not
-browser-reachable. Gate a browser-reachable read instead, on the Platform scope
-where a real identity exists.
+That failure is worse than a denied page. A host fetching a contributed audit
+list degrades a failed fetch to "no audit section", so the `401` renders as
+*"this subject has no history"* — a security ledger disappearing in silence.
+Re-adding the permission gate does not restore a caller boundary; it breaks the
+actorless read.
+
+Because the route cannot authenticate its caller, browser-originated `Internal`
+paths must be refused by the platform. Today the platform does not refuse them
+for dev-mounted modules. The dispatch mount is unauthenticated at the HTTP edge,
+and its only path-shape rejection covers the `__mirrorstack` namespace, so
+`/internal/...` is forwarded to the module. The handler injects the module
+owner's user id and a hardcoded `admin` app-role together with the session's
+internal secret, handing the module a privileged identity no caller presented.
+
+The five-condition dev gate — app dev-mode, module dev-mode, `dev_mount`, an
+install row, and a live tunnel — controls whether the localhost plane is open.
+It does not establish who is asking. On the dev plane, an `Internal` route is
+not a confidentiality boundary. Do not place behind it anything that would be
+harmful to expose to whoever can reach the dev edge.
+
+Production modules are not dev-mounted, so the dev-tunnel branch described here
+does not apply there. That scopes this gap; it does not make `Internal` a caller
+boundary.
 
 ## 8. Checklist
 
@@ -152,8 +170,10 @@ where a real identity exists.
 - [ ] Append-only asserted; no FK to the described entity
 - [ ] Bounded reads report `hasMore`; the surface says it is capped
 - [ ] No backfill; pre-existing rows read as unknown
-- [ ] Read route not permission-gated on `Internal`
-- [ ] Migration advertised in `ms.Init`'s `Versions` map, or it never runs
+- [ ] `Internal` read not permission-gated; its data is safe to expose to anyone
+  who can reach the dev edge
+- [ ] Migration embedded through `ms.Config.SQL`; manifest `migration` reflects
+  it
 
 See also [scopes](scopes.md), [internal-calls](internal-calls.md),
 [manifest](manifest.md).

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -143,20 +143,25 @@ actorless read.
 Because the route cannot authenticate its caller, browser-originated `Internal`
 paths must be refused by the platform. Today the platform does not refuse them
 for dev-mounted modules. The dispatch mount is unauthenticated at the HTTP edge,
-and its only path-shape rejection covers the `__mirrorstack` namespace, so
-`/internal/...` is forwarded to the module. The handler injects the module
-owner's user id and a hardcoded `admin` app-role together with the session's
-internal secret, handing the module a privileged identity no caller presented.
+and the only namespace it refuses is `__mirrorstack/*`; its other path-shape
+checks do not cover `/internal/`, so `/internal/...` is forwarded to the module.
+The handler injects the module owner's user id and a hardcoded `admin` app-role
+together with the session's internal secret, handing the module a privileged
+identity no caller presented.
 
 The five-condition dev gate — app dev-mode, module dev-mode, `dev_mount`, an
 install row, and a live tunnel — controls whether the localhost plane is open.
 It does not establish who is asking. On the dev plane, an `Internal` route is
 not a confidentiality boundary. Do not place behind it anything that would be
-harmful to expose to whoever can reach the dev edge.
+harmful to expose to whoever can reach the module edge on either plane.
 
-Production modules are not dev-mounted, so the dev-tunnel branch described here
-does not apply there. That scopes this gap; it does not make `Internal` a caller
-boundary.
+The dev-tunnel branch does not serve deployed modules. The same unauthenticated
+`/module` browser edge also has a deployed branch, however. It skips the dev
+conditions and forwards `/internal/*` to the deployed function with the same
+fabricated identity: the owner's user id and `admin` role, plus the platform's
+own internal secret. The gap is therefore a property of the `/module` browser
+edge, not the dev plane, and is present on both the dev-tunnel and deployed
+planes.
 
 ## 8. Checklist
 
@@ -171,7 +176,7 @@ boundary.
 - [ ] Bounded reads report `hasMore`; the surface says it is capped
 - [ ] No backfill; pre-existing rows read as unknown
 - [ ] `Internal` read not permission-gated; its data is safe to expose to anyone
-  who can reach the dev edge
+  who can reach the module edge on either plane
 - [ ] Migration embedded through `ms.Config.SQL`; manifest `migration` reflects
   it
 

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -1,0 +1,159 @@
+# Audit trails
+
+A module that changes who can do what owes an answer to "who did this, and how".
+This page is the rule for producing that answer, and the reasoning behind each
+part of it. Two modules already follow it — users-roles records role grants and
+revocations, oauth-core records session revocations — and they landed on
+different shapes for good reasons, which is where this starts.
+
+The failure this exists to prevent is not a missing feature. It is a trail that
+is **believed** and wrong: incomplete, invented, or attributable to whoever the
+caller claimed to be.
+
+## 1. Pick the shape before writing anything
+
+| The event | Shape | Why |
+| --- | --- | --- |
+| Repeats for the same subject | Append-only ledger table | Each occurrence is a fact; the previous one must survive |
+| Terminal — happens once, ever | Provenance columns on the row | There is no history to accumulate |
+
+Role grants repeat: a user can be granted `member`, lose it, and be granted it
+again, and all three are separate facts. That needs a ledger.
+
+Session revocation is terminal: a session is revoked once and stays revoked, so
+`revoked_by` / `revoked_via` on the session row carries everything. A ledger
+would be a table with one row per subject forever.
+
+Getting this backwards is expensive in both directions. A ledger for a terminal
+event is dead weight; columns for a repeating event silently overwrite history,
+which is the worst outcome available — it looks like an audit trail and destroys
+evidence.
+
+**Watch for a `DELETE` that erases the record.** users-roles kept `granted_by`
+on the current row, but revoking was a plain `DELETE`, so the trail was being
+destroyed by design and nobody noticed until someone asked to see it. If your
+"current state" columns are the only provenance you have, a delete is a
+shredder.
+
+## 2. Provenance is two fields, never one
+
+Record an **actor** (who) and a **via** (by what mechanism). Both, always.
+
+A single nullable actor cannot distinguish these three cases, and they are not
+the same thing:
+
+- the platform did it automatically, so there is no human actor;
+- a human did it and we could not identify them;
+- we forgot to record it.
+
+`via` resolves all three. `via=session_limit` with a NULL actor is an automatic
+prune — no human was involved, by definition. `via=operator` with a NULL actor
+says a person did this and their identity was unavailable. A NULL actor with no
+`via` says nothing at all, and will be read as whichever of the three the reader
+already believes.
+
+Constrain `via` with a CHECK. It is a closed vocabulary, and an unconstrained
+text column becomes a free-text field that nobody can query.
+
+## 3. The actor comes from the request context. Only.
+
+Never a header, never a query parameter, never a body field. An audit record the
+caller can write is worse than no record, because it will be trusted.
+
+Take it from the SDK-promoted request identity and nothing else.
+
+**Better still, derive it from stored state where the semantics allow.** A
+user logging themselves out is `actor = the session row's own user_id` — read
+from the row being modified, not from the request. That is unforgeable *by
+construction* rather than by validation, and construction does not have bugs.
+
+**Identity is not authorization, and this matters here specifically.** By the
+time an audit write happens, authorization has already been settled by the
+permission gate. An unidentifiable actor is not an unauthorized one, so failing
+the operation because provenance is unavailable takes a control away from
+someone who legitimately holds it. Record what you know, say what you do not.
+
+**Validate against the column type before writing.** `revoked_by` is a `uuid`,
+and the SDK's local-dev bypass injects a synthetic non-UUID identity — writing
+it unchecked failed with `22P02`, which left the session live while the route
+reported 500 and rolled an enclosing transaction back. So:
+
+1. no identity → NULL actor, real `via`;
+2. identity present but unusable for the column → NULL actor, real `via`, and log it;
+3. identity usable → record it.
+
+Never (4): refuse the operation.
+
+## 4. Coverage must be structural, not remembered
+
+An enumerated list of call sites is a list that goes stale. users-roles has
+**eleven** call sites mutating one table across five logical paths, one of them
+outside `internal/` entirely — the kind that is missed.
+
+So put the audit write **in the statement that does the mutation**: a
+data-modifying CTE whose `RETURNING` feeds the audit `INSERT`. A new writer then
+cannot forget, because there is nowhere to forget it from. Call sites that were
+never edited stay covered.
+
+This also gives correct behaviour for free. Grants that are
+`ON CONFLICT DO NOTHING` return no rows when the state was already correct, so a
+re-grant appends **no** audit row. A ledger full of events that did not happen is
+as misleading as one missing events, and hand-written audit calls at call sites
+get this wrong by default — they fire on intent, not on change.
+
+Back it with a test that reads the SQL, requires an audit append beside every
+mutation of the table, **and pins the count**. Without the count, a new writer
+lands silently.
+
+## 5. Never imply completeness you do not have
+
+A bounded read must say it is bounded. Showing the newest N without saying so
+presents a partial trail as the whole history — the one way an audit surface
+actively deceives.
+
+Fetch `N + 1` rows, return `N`, and let the extra row set a `hasMore` flag. It
+costs one row instead of a second `COUNT(*)` over a table that only grows. Send
+the flag onward rather than letting a consumer infer truncation from the row
+count: only the producer knows its own page size.
+
+## 6. Retention rules
+
+- **Append only.** No `UPDATE`, no `DELETE`. Assert it in a test.
+- **No foreign key to the thing being described.** Keep `role_key` as text with
+  no FK to `roles`, so deleting a role does not erase the history of who held it.
+  History must outlive its subject; that is the point.
+- **Never backfill.** Rows predating the provenance columns have no actor, and
+  they must read as *unknown*. Inventing a plausible actor for historical rows is
+  a lie in the one place lies are most costly. "We started recording this on
+  date X" is a fine thing for a UI to say.
+
+## 7. Do not gate the read on an actorless transport
+
+An `Internal` route is an actorless **service** call: the SDK sends the internal
+secret and the app id, no actor. `RequirePermission` there `401`s for the very
+identity `ms.Call` uses.
+
+That is bad on its own and worse in combination: a host fetching a contributed
+audit list typically degrades a failed fetch to "no audit section", so the 401
+renders as *"this subject has no history"* — a security ledger disappearing in
+silence. Internal scope is itself the boundary; the path is not
+browser-reachable. Gate a browser-reachable read instead, on the Platform scope
+where a real identity exists.
+
+## 8. Checklist
+
+- [ ] Ledger for repeating events, provenance columns for terminal ones
+- [ ] Both `actor` and `via`; `via` CHECK-constrained
+- [ ] Actor from request context only — derived from stored state where possible
+- [ ] Actor validated against the column type; unusable → NULL, never a refusal
+- [ ] Audit write inside the mutating statement, not at call sites
+- [ ] No audit row when nothing actually changed
+- [ ] Test parses the SQL, requires an append per mutation, pins the count
+- [ ] Append-only asserted; no FK to the described entity
+- [ ] Bounded reads report `hasMore`; the surface says it is capped
+- [ ] No backfill; pre-existing rows read as unknown
+- [ ] Read route not permission-gated on `Internal`
+- [ ] Migration advertised in `ms.Init`'s `Versions` map, or it never runs
+
+See also [scopes](scopes.md), [internal-calls](internal-calls.md),
+[manifest](manifest.md).

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -30,10 +30,9 @@ which is the worst outcome available — it looks like an audit trail and destro
 evidence.
 
 **Watch for a `DELETE` that erases the record.** users-roles kept `granted_by`
-on the current row, but revoking was a plain `DELETE`, so the trail was being
-destroyed by design and nobody noticed until someone asked to see it. If your
-"current state" columns are the only provenance you have, a delete is a
-shredder.
+on the assignment row while revoking was a plain `DELETE` — so the revoke
+destroyed the only provenance the module had. If your "current state" columns
+are the only provenance you have, a delete is a shredder.
 
 ## 2. Provenance is two fields, never one
 
@@ -74,9 +73,10 @@ the operation because provenance is unavailable takes a control away from
 someone who legitimately holds it. Record what you know, say what you do not.
 
 **Validate against the column type before writing.** `revoked_by` is a `uuid`,
-and the SDK's local-dev bypass injects a synthetic non-UUID identity — writing
-it unchecked failed with `22P02`, which left the session live while the route
-reported 500 and rolled an enclosing transaction back. So:
+and the SDK's local-dev bypass mints the synthetic identity `local-dev-user`,
+which is not one. Writing it unchecked failed at the database with `22P02`: the
+session stayed live and the route answered 500, and on the path where the same
+write ran inside `ms.Tx` it took the enclosing transaction down with it. So:
 
 1. no identity → NULL actor, real `via`;
 2. identity present but unusable for the column → NULL actor, real `via`, and log it;
@@ -87,8 +87,11 @@ Never (4): refuse the operation.
 ## 4. Coverage must be structural, not remembered
 
 An enumerated list of call sites is a list that goes stale. users-roles has
-**eleven** call sites mutating one table across five logical paths, one of them
-outside `internal/` entirely — the kind that is missed.
+**eleven** call sites mutating `user_roles`, spread over **four files**:
+`internal/handlers/routes.go` (4),
+`internal/handlers/approval_transition.go` (3),
+`internal/handlers/self_service.go` (3), and `declare/default_role.go` (1) —
+the last one outside `internal/` entirely.
 
 So put the audit write **in the statement that does the mutation**: a
 data-modifying CTE whose `RETURNING` feeds the audit `INSERT`. A new writer then
@@ -127,50 +130,50 @@ count: only the producer knows its own page size.
   a lie in the one place lies are most costly. "We started recording this on
   date X" is a fine thing for a UI to say.
 
-## 7. Do not gate the read on an actorless transport
+## 7. Keep Internal reads honest
 
-Do not put `RequirePermission` on an `Internal` read — not because it would deny
-the service call, but because it would not deny anything.
+**Do not put `RequirePermission` on an `Internal` read.**
+`Module.RequirePermission(name)` returns `auth.RequireRoles(admin, ...declared)`:
+it decides from the app role on the request identity, and admin passes whatever
+the permission declares. `auth.RequireRoles` answers 401 `authentication
+required` when there is no identity or its `AppRole` is empty, and 403
+`forbidden` on a role miss. But an Internal hop is actorless: `ms.Call` carries
+a verified actor only to a canonical `/platform` path, so a Public or Internal
+call stays a service call even when it originates inside a Platform handler. The
+gate is therefore not evaluating your caller. It is deciding about the absence
+of one, on whatever identity the platform edge did or did not attach — which
+makes it read like a control in the source without being one.
 
-`ms.Call` is actorless: the hop carries the app id and the calling module's
-service secret, and dispatch injects the target module's internal secret. No
-caller identity travels with it. What *does* travel with it is a role the
-platform invents — every forward through the `/module` edge stamps
-`X-MS-App-Role: admin`, on the dev-tunnel branch and the deployed-Lambda branch
-alike. `RequirePermission` compiles to `auth.RequireRoles(admin, …declared)`,
-and admin always passes. So the gate does not reject the service identity: it
-admits it, and admits everything else that reaches the same edge, while reading
-in the source like a control. Silent admission is the failure here, not a
-denial.
+**Do not take the edge's behaviour from prose, including this page's.** Two
+characterization suites exist precisely because design documents about this kept
+asserting the opposite of the code, and they are the executable answer. In this
+repo, [`auth_scope_truth_test.go`](../../auth_scope_truth_test.go) —
+`TestCharacterization_RequirePermissionAdmitsAdminRegardlessOfDeclaredRoles` and
+`TestCharacterization_RoleGateReturns401WithoutActor_403OnRoleMiss` pin the gate
+described above. In api-platform,
+`internal/dispatch/handler/module_edge_truth_test.go` and
+`module_edge_router_wiring_test.go` — `TestModuleEdge_RouteClassTrustMatrix`,
+`TestModuleEdge_StampsNoFabricatedRole` and
+`TestModuleEdgeIsMountedWithoutAuthMiddleware` pin what the edge hands a module,
+per route class. Read them before writing anything about this, and cite them
+instead of paraphrasing them. Both files say the same thing about themselves:
+changing an assertion there is a security decision, not test fixup.
 
-The read can still fail, and the caller will not see why. `ms.Call` returns an
-error for any non-2xx, and the edge produces several before the module is ever
-reached: `not_installed` (404), `route_local_off` and `tunnel_offline` (503), a
-resolver fault (500). A host that degrades a failed audit fetch to "no audit
-section" renders each of those as *"this subject has no history"*. Distinguish
-"empty" from "could not load" and say which — an audit surface that cannot tell
-them apart is worse than one that is absent.
+**Distinguish "empty" from "could not load".** `ms.Call` returns an error for
+every non-2xx response. A host that degrades a failed audit fetch into "no audit
+section" renders that failure as *"this subject has no history"* — a security
+ledger vanishing silently, which is the one thing an audit surface must never
+do. Say which of the two happened.
 
-Because the route cannot authenticate its caller, browser-originated `Internal`
-paths must be refused by the platform. Today they are not. The dispatch mount at
-`/module/...` is unauthenticated at the HTTP edge, and the only namespace it
-refuses is `__mirrorstack/*` — its other path-shape checks do not cover
-`/internal/` — so `/internal/...` is forwarded to the module. The handler then
-injects the module owner's user id and a hardcoded `admin` app-role alongside an
-internal secret, handing the module a privileged identity no caller presented.
-
-This holds on both planes. The five-condition dev gate — app dev-mode, module
-dev-mode, `dev_mount`, an install row, and a live tunnel — decides whether the
-localhost plane is open, not who is asking. A module with a deploy row is served
-by a second branch of the same edge that keeps exactly one of those five: the
-deploy is resolved through that app's own `module_install` row, so a missing
-install row (or an un-bootstrapped app schema) still resolves to no transport.
-The four dev conditions are not consulted, and the deployed function is invoked
-with the same fabricated identity. The gap belongs to the `/module` browser
-edge, not to dev-mounting.
-
-So an `Internal` route is not a confidentiality boundary. Do not put behind it
-anything that would be harmful to expose to whoever can reach that edge.
+**Scope is not a confidentiality boundary.** `PlatformAuth` and `InternalAuth`
+read the same secret source, so one internal secret authenticates both scopes —
+`TestCharacterization_InternalSecretSatisfiesPlatformAuth_ScopesAreNotDisjoint`
+pins that. And when no secret source is configured at all and the process is not
+in Lambda, `PlatformAuth` mints a synthetic `local-dev-user` admin while
+`InternalAuth` bypasses its check outright. Design so the answer stops mattering:
+put nothing on an `Internal` route that would be harmful to hand to a caller you
+did not authorize. Real protection lives in the handler, or in what you store —
+never in the scope keyword.
 
 ## 8. Checklist
 
@@ -184,10 +187,14 @@ anything that would be harmful to expose to whoever can reach that edge.
 - [ ] Append-only asserted; no FK to the described entity
 - [ ] Bounded reads report `hasMore`; the surface says it is capped
 - [ ] No backfill; pre-existing rows read as unknown
-- [ ] `Internal` read not permission-gated; its data is safe to expose to anyone
-  who can reach the `/module` edge, on either plane
+- [ ] `Internal` read not permission-gated; its data safe to hand to a caller you
+  did not authorize
+- [ ] Failed read distinguished from empty read at every layer that renders it
 - [ ] Migration embedded through `ms.Config.SQL`; manifest `migration` reflects
   it
 
-See also [scopes](scopes.md), [internal-calls](internal-calls.md),
-[manifest](manifest.md).
+See also [scopes](scopes.md) and [manifest](manifest.md). For what the auth
+model actually does, read the suites rather than the prose:
+[`auth_scope_truth_test.go`](../../auth_scope_truth_test.go) in this repo, and
+`internal/dispatch/handler/module_edge_truth_test.go` plus
+`internal/dispatch/handler/module_edge_router_wiring_test.go` in api-platform.

--- a/docs/concepts/internal-calls.md
+++ b/docs/concepts/internal-calls.md
@@ -103,16 +103,18 @@ user, err := ms.CallModule[struct{}, UserDTO](
 
 ## 3. Drop CORS on the Internal mount
 
-Today `localDevCORS` is applied **router-wide** in the dev-bypass branch
-(`module.go:151-163`, `m.router.Use(localDevCORS)` when `MS_INTERNAL_SECRET`
-is unset). A browser CAN reach an Internal route — the platform's
-unauthenticated `/module/{moduleID}/*` edge forwards `/internal/...` through —
-but the module's own CORS headers are never the ones it reads: dispatch writes
-`Access-Control-Allow-Origin` itself on that surface, from the app's
-`allowed_origins`. Every other Internal caller (proxy, lambda invoke, cron,
-event delivery) is not a browser at all. So CORS on the Internal mount is dead
-weight and the one bit of genuine "web baggage" the RPC camp correctly
-disliked.
+Today `localDevCORS` is applied **router-wide** — `m.router.Use(localDevCORS)`
+in `internal/core/module.go`, gated on `auth.SecretConfigured()` being false,
+i.e. the bare local run with no secret source at all.
+
+CORS matters only for a browser origin, and every Internal caller the scope is
+built for — proxy, Lambda invoke, cron, event delivery, module-to-module
+`ms.Call` — is not a browser. So the header is dead weight on that mount: the
+one bit of genuine "web baggage" the RPC camp correctly disliked. Whether a
+browser-originated request can reach the Internal route class at all is a
+platform-edge question, pinned by api-platform's
+`TestModuleEdge_RouteClassTrustMatrix`; this design doc does not assert an
+answer to it, and neither should the change below depend on one.
 
 **Change:** apply `localDevCORS` only to the Platform and Public scoped
 subrouters, never to Internal (and never to the system internal routes under

--- a/docs/concepts/internal-calls.md
+++ b/docs/concepts/internal-calls.md
@@ -105,9 +105,14 @@ user, err := ms.CallModule[struct{}, UserDTO](
 
 Today `localDevCORS` is applied **router-wide** in the dev-bypass branch
 (`module.go:151-163`, `m.router.Use(localDevCORS)` when `MS_INTERNAL_SECRET`
-is unset). Internal routes are proxy/lambda-only — a browser never originates
-an Internal call — so CORS there is dead weight and the one bit of genuine
-"web baggage" the RPC camp correctly disliked.
+is unset). A browser CAN reach an Internal route — the platform's
+unauthenticated `/module/{moduleID}/*` edge forwards `/internal/...` through —
+but the module's own CORS headers are never the ones it reads: dispatch writes
+`Access-Control-Allow-Origin` itself on that surface, from the app's
+`allowed_origins`. Every other Internal caller (proxy, lambda invoke, cron,
+event delivery) is not a browser at all. So CORS on the Internal mount is dead
+weight and the one bit of genuine "web baggage" the RPC camp correctly
+disliked.
 
 **Change:** apply `localDevCORS` only to the Platform and Public scoped
 subrouters, never to Internal (and never to the system internal routes under

--- a/docs/concepts/scopes.md
+++ b/docs/concepts/scopes.md
@@ -55,7 +55,7 @@ The SDK does not run user auth here, but the proxy guard still fronts every Publ
 
 Platform-to-module. Requests must carry `X-MS-Internal-Secret: <shared secret>` (via `MS_INTERNAL_SECRET` env var); once a secret source is configured the SDK rejects a missing or wrong secret with 401. On a bare local run with no secret configured the SDK bypasses the check so `mirrorstack dev` can curl its own routes — `--tunnel` and deployed mode both configure one.
 
-**The secret is not a caller boundary.** It stops a caller that reaches your module *directly* — its localhost port, its function target — without the secret. It does not stop a browser. The platform's `/module/{moduleID}/*` edge is unauthenticated at the HTTP layer, refuses only the `__mirrorstack/*` namespace, and forwards `/internal/...` to your module with the internal secret and a hardcoded `admin` app-role that the platform supplies itself. An `Internal` route is therefore reachable by anyone who can reach that edge — see [audit trails](audit.md) §7.
+**The secret is what the SDK middleware checks.** Forwarder identity headers are promoted only on the secret-validated path, never on the local bypass or a rejection; empty headers never mint an identity. `TestCharacterization_ForwarderIdentityTrustedOnlyOnSecretValidatedPath` pins that behavior. Who can reach a given route class through the platform is a property of the platform edge, pinned by api-platform's `TestModuleEdge_RouteClassTrustMatrix`, not by this page.
 
 Used for:
 
@@ -76,17 +76,21 @@ ms.Internal(func(r chi.Router) {
 
 ## The auth matrix
 
-| Request has… | Platform | Public | Internal |
-|---|---|---|---|
-| Nothing | 401 | 200 | 401 |
-| Expired / invalid session | 401 | 200 | 401 |
-| Valid session, wrong role | 403 | 200 | 401 |
-| Valid session, right role | 200 | 200 | 401 |
+Measured on the real `m.Router()` with `MS_INTERNAL_SECRET` set and the process not in Lambda. "Identity headers" means all three of `X-MS-User-ID` / `X-MS-App-ID` / `X-MS-App-Role`:
+
+| Request carries | Platform | Public | Internal |
+|---|---:|---:|---:|
+| Nothing | 403 | 403 | 401 |
 | Internal secret only | 401 | 200 | 200 |
+| Internal secret + identity headers | 200 | 200 | 200 |
+| Wrong secret + identity headers | 403 | 403 | 401 |
+| Identity headers only, no secret | 403 | 403 | 401 |
 
-This is the SDK middleware in isolation, with a secret source configured. It is not a reachability table. With no secret source configured (a bare local run, a standalone unit test) Platform mints a synthetic local admin and Internal bypasses its check entirely; and a request arriving through the platform's `/module` edge comes pre-credentialed no matter who sent it. The Public column shows the user-auth check only — Public routes are additionally fronted by the proxy guard, which answers `403 not_proxied` to a request that did not come through the platform, orthogonally to the session credential each row describes.
+The 403 responses are the proxy guard's `not_proxied`. The Platform 401 with only the internal secret is caused by missing identity headers, not by the secret. With no secret source configured, every cell is 200.
 
-The SDK's middlewares are per-scope and do not accept each other's credentials: a session token does not satisfy `InternalAuth`, and the internal secret does not satisfy `PlatformAuth`. That is a statement about the middleware, not about reachability — the platform edge above supplies whichever credential the scope asks for. Scope is how you organize your surface; it is not a confidentiality boundary.
+One `X-MS-Internal-Secret` authenticates both the Internal and Platform scopes: `PlatformAuth` and `InternalAuth` read the same secret source, so they are not disjoint credential domains. `TestCharacterization_InternalSecretSatisfiesPlatformAuth_ScopesAreNotDisjoint` pins this behavior. Scope is how you organize your surface; it is not a confidentiality boundary.
+
+[`auth_scope_truth_test.go`](../../auth_scope_truth_test.go) is the executable version of this section; a change here must change that file too.
 
 ## Picking a scope
 
@@ -94,4 +98,4 @@ The SDK's middlewares are per-scope and do not accept each other's credentials: 
 - **Something the platform itself drives** → Internal
 - **Something anonymous external callers need** → Public
 
-If you're unsure, default to Internal: it keeps the route off the anonymous public surface and out of the dashboard's role-gated one, and its intent ("the platform drives this") is the easiest to read later. Do not mistake that for a security decision — nothing on an `Internal` route is hidden from whoever can reach the `/module` edge. If exposing the data would be harmful, the protection has to live in the handler, or in what you store; not in the scope.
+If you're unsure, default to Internal: it keeps the route off the anonymous public surface and out of the dashboard's role-gated one, and its intent ("the platform drives this") is the easiest to read later. Do not mistake that for a security decision. If exposing the data would be harmful, the protection has to live in the handler, or in what you store; not in the scope.

--- a/docs/concepts/scopes.md
+++ b/docs/concepts/scopes.md
@@ -53,7 +53,9 @@ The SDK does not run user auth here, but the proxy guard still fronts every Publ
 
 ## Internal
 
-Platform-to-module only. Requests must carry `X-MS-Internal-Secret: <shared secret>` (via `MS_INTERNAL_SECRET` env var). The SDK rejects anything else with 401.
+Platform-to-module. Requests must carry `X-MS-Internal-Secret: <shared secret>` (via `MS_INTERNAL_SECRET` env var); once a secret source is configured the SDK rejects a missing or wrong secret with 401. On a bare local run with no secret configured the SDK bypasses the check so `mirrorstack dev` can curl its own routes — `--tunnel` and deployed mode both configure one.
+
+**The secret is not a caller boundary.** It stops a caller that reaches your module *directly* — its localhost port, its function target — without the secret. It does not stop a browser. The platform's `/module/{moduleID}/*` edge is unauthenticated at the HTTP layer, refuses only the `__mirrorstack/*` namespace, and forwards `/internal/...` to your module with the internal secret and a hardcoded `admin` app-role that the platform supplies itself. An `Internal` route is therefore reachable by anyone who can reach that edge — see [audit trails](audit.md) §7.
 
 Used for:
 
@@ -82,7 +84,9 @@ ms.Internal(func(r chi.Router) {
 | Valid session, right role | 200 | 200 | 401 |
 | Internal secret only | 401 | 200 | 200 |
 
-Routes in one scope **cannot** be reached by a caller authenticated for another scope — they're disjoint auth domains.
+This is the SDK middleware in isolation, with a secret source configured. It is not a reachability table. With no secret source configured (a bare local run, a standalone unit test) Platform mints a synthetic local admin and Internal bypasses its check entirely; and a request arriving through the platform's `/module` edge comes pre-credentialed no matter who sent it. The Public column shows the user-auth check only — Public routes are additionally fronted by the proxy guard, which answers `403 not_proxied` to a request that did not come through the platform, orthogonally to the session credential each row describes.
+
+The SDK's middlewares are per-scope and do not accept each other's credentials: a session token does not satisfy `InternalAuth`, and the internal secret does not satisfy `PlatformAuth`. That is a statement about the middleware, not about reachability — the platform edge above supplies whichever credential the scope asks for. Scope is how you organize your surface; it is not a confidentiality boundary.
 
 ## Picking a scope
 
@@ -90,4 +94,4 @@ Routes in one scope **cannot** be reached by a caller authenticated for another 
 - **Something the platform itself drives** → Internal
 - **Something anonymous external callers need** → Public
 
-If you're unsure, default to Internal. You can expose it later; you can't put auth back after leaking.
+If you're unsure, default to Internal: it keeps the route off the anonymous public surface and out of the dashboard's role-gated one, and its intent ("the platform drives this") is the easiest to read later. Do not mistake that for a security decision — nothing on an `Internal` route is hidden from whoever can reach the `/module` edge. If exposing the data would be harmful, the protection has to live in the handler, or in what you store; not in the scope.

--- a/docs/zh-TW/concepts/scopes.md
+++ b/docs/zh-TW/concepts/scopes.md
@@ -51,7 +51,9 @@ SDK 在這層不做使用者認證,但 proxy guard 仍然守在每個 Public rou
 
 ## Internal
 
-只有平台能打。Request 必須帶 `X-MS-Internal-Secret: <shared secret>`(透過 `MS_INTERNAL_SECRET` 環境變數設定)。SDK 會拒絕其他所有 request,回 401。
+Platform 打 module。Request 必須帶 `X-MS-Internal-Secret: <shared secret>`(透過 `MS_INTERNAL_SECRET` 環境變數設定);只要有設定 secret 來源,SDK 就會把沒帶或帶錯的 request 擋掉,回 401。純本機執行、沒有設定 secret 時,SDK 會直接放行,讓 `mirrorstack dev` 可以自己 curl 自己的 route ——`--tunnel` 與部署後的模式都會設定 secret。
+
+**這個 secret 不是呼叫端的邊界。** 它擋得住「直接」打到你的 module(它的 localhost port、它的 function target)而且沒帶 secret 的呼叫端,但擋不住瀏覽器。平台的 `/module/{moduleID}/*` edge 在 HTTP 層是完全沒有驗證的,只會拒絕 `__mirrorstack/*` 這個 namespace,並且會把 `/internal/...` 轉發給你的 module,同時由平台自己補上 internal secret 和寫死的 `admin` app-role。因此只要能打到那個 edge 的人,就能打到 `Internal` route ——參見 [audit trails](../../concepts/audit.md) §7。
 
 用在:
 
@@ -80,7 +82,9 @@ ms.Internal(func(r chi.Router) {
 | 有效 session,角色符合 | 200 | 200 | 401 |
 | 只帶 internal secret | 401 | 200 | 200 |
 
-不同 scope 的 route **互不相通** — 一邊的呼叫者無論怎麼認證,都打不到另一邊的 route,是獨立的認證網域。
+這張表只描述有設定 secret 來源時,SDK middleware 獨立運作的結果,不是 reachability 對照表。沒有設定 secret 來源時(純本機執行、獨立單元測試),Platform 會產生一個合成的本機 admin,Internal 則完全略過檢查;而且從平台的 `/module` edge 進來的 request 不論是誰送的,都已經帶好 credential。Public 欄只顯示 user-auth 檢查 — Public route 前面另外還有 proxy guard,未經平台送進來的 request 會收到 `403 not_proxied`,這與每一列描述的 session credential 彼此獨立。
+
+SDK 的 middleware 依 scope 各自運作,不接受其他 scope 的 credential:session token 無法通過 `InternalAuth`,internal secret 也無法通過 `PlatformAuth`。這是在描述 middleware,不是 reachability — 上面的 platform edge 會提供 scope 所要求的 credential。Scope 是你組織 surface 的方式;它不是機密性邊界。
 
 ## 如何選 scope
 
@@ -88,4 +92,4 @@ ms.Internal(func(r chi.Router) {
 - **平台自己驅動的** → Internal
 - **匿名外部呼叫者需要打的** → Public
 
-不確定時一律放 Internal。以後要對外公開很簡單,但外洩出去之後要收回來很困難。
+不確定時一律放 Internal:它會讓 route 不出現在匿名 public surface,也不會進到 dashboard 以 role gate 控管的 surface,而且它的意圖("由平台驅動")日後最容易讀懂。不要把這誤認為 security decision — `Internal` route 上沒有任何東西會對能打到 `/module` edge 的人隱藏。如果公開這些資料會造成傷害,保護就必須放在 handler 裡,或放在你儲存的內容裡;不能放在 scope 上。

--- a/docs/zh-TW/concepts/scopes.md
+++ b/docs/zh-TW/concepts/scopes.md
@@ -53,7 +53,7 @@ SDK 在這層不做使用者認證,但 proxy guard 仍然守在每個 Public rou
 
 Platform 打 module。Request 必須帶 `X-MS-Internal-Secret: <shared secret>`(透過 `MS_INTERNAL_SECRET` 環境變數設定);只要有設定 secret 來源,SDK 就會把沒帶或帶錯的 request 擋掉,回 401。純本機執行、沒有設定 secret 時,SDK 會直接放行,讓 `mirrorstack dev` 可以自己 curl 自己的 route ——`--tunnel` 與部署後的模式都會設定 secret。
 
-**這個 secret 不是呼叫端的邊界。** 它擋得住「直接」打到你的 module(它的 localhost port、它的 function target)而且沒帶 secret 的呼叫端,但擋不住瀏覽器。平台的 `/module/{moduleID}/*` edge 在 HTTP 層是完全沒有驗證的,只會拒絕 `__mirrorstack/*` 這個 namespace,並且會把 `/internal/...` 轉發給你的 module,同時由平台自己補上 internal secret 和寫死的 `admin` app-role。因此只要能打到那個 edge 的人,就能打到 `Internal` route ——參見 [audit trails](../../concepts/audit.md) §7。
+**secret 是 SDK middleware 檢查的 credential。** Forwarder identity header 只會在 secret 驗證通過的路徑被提升,local bypass 或拒絕路徑都不會;空 header 也不會建立 identity。`TestCharacterization_ForwarderIdentityTrustedOnlyOnSecretValidatedPath` 固定了這項行為。誰能透過平台打到某個 route class,是 platform edge 的屬性,由 api-platform 的 `TestModuleEdge_RouteClassTrustMatrix` 固定,不由本頁描述。
 
 用在:
 
@@ -74,17 +74,21 @@ ms.Internal(func(r chi.Router) {
 
 ## Auth 對照表
 
+以下是在真正的 `m.Router()` 上實測的結果:已設定 `MS_INTERNAL_SECRET`,且 process 不在 Lambda 中。「identity headers」指的是 `X-MS-User-ID` / `X-MS-App-ID` / `X-MS-App-Role` 三個全帶:
+
 | Request 帶… | Platform | Public | Internal |
-|---|---|---|---|
-| 什麼都沒帶 | 401 | 200 | 401 |
-| 過期或無效的 session | 401 | 200 | 401 |
-| 有效 session,但角色不符 | 403 | 200 | 401 |
-| 有效 session,角色符合 | 200 | 200 | 401 |
+|---|---:|---:|---:|
+| 什麼都沒帶 | 403 | 403 | 401 |
 | 只帶 internal secret | 401 | 200 | 200 |
+| internal secret + identity headers | 200 | 200 | 200 |
+| 錯誤的 secret + identity headers | 403 | 403 | 401 |
+| 只帶 identity headers,沒有 secret | 403 | 403 | 401 |
 
-這張表只描述有設定 secret 來源時,SDK middleware 獨立運作的結果,不是 reachability 對照表。沒有設定 secret 來源時(純本機執行、獨立單元測試),Platform 會產生一個合成的本機 admin,Internal 則完全略過檢查;而且從平台的 `/module` edge 進來的 request 不論是誰送的,都已經帶好 credential。Public 欄只顯示 user-auth 檢查 — Public route 前面另外還有 proxy guard,未經平台送進來的 request 會收到 `403 not_proxied`,這與每一列描述的 session credential 彼此獨立。
+表中的 403 都是 proxy guard 的 `not_proxied`。只帶 internal secret 時,Platform 的 401 是因為缺少 identity headers,不是 secret。如果沒有設定 secret 來源,每一格都是 200。
 
-SDK 的 middleware 依 scope 各自運作,不接受其他 scope 的 credential:session token 無法通過 `InternalAuth`,internal secret 也無法通過 `PlatformAuth`。這是在描述 middleware,不是 reachability — 上面的 platform edge 會提供 scope 所要求的 credential。Scope 是你組織 surface 的方式;它不是機密性邊界。
+同一個 `X-MS-Internal-Secret` 可以驗證 Internal 與 Platform 兩個 scope:`PlatformAuth` 與 `InternalAuth` 讀取相同的 secret 來源,因此兩者不是互不相交的 credential domain。`TestCharacterization_InternalSecretSatisfiesPlatformAuth_ScopesAreNotDisjoint` 固定了這項行為。Scope 是你組織 surface 的方式;它不是機密性邊界。
+
+[`auth_scope_truth_test.go`](../../../auth_scope_truth_test.go) 是本節的 executable version;修改本節時,也必須修改該檔案。
 
 ## 如何選 scope
 
@@ -92,4 +96,4 @@ SDK 的 middleware 依 scope 各自運作,不接受其他 scope 的 credential:s
 - **平台自己驅動的** → Internal
 - **匿名外部呼叫者需要打的** → Public
 
-不確定時一律放 Internal:它會讓 route 不出現在匿名 public surface,也不會進到 dashboard 以 role gate 控管的 surface,而且它的意圖("由平台驅動")日後最容易讀懂。不要把這誤認為 security decision — `Internal` route 上沒有任何東西會對能打到 `/module` edge 的人隱藏。如果公開這些資料會造成傷害,保護就必須放在 handler 裡,或放在你儲存的內容裡;不能放在 scope 上。
+不確定時一律放 Internal:它會讓 route 不出現在匿名 public surface,也不會進到 dashboard 以 role gate 控管的 surface,而且它的意圖("由平台驅動")日後最容易讀懂。不要把這誤認為 security decision。如果公開這些資料會造成傷害,保護就必須放在 handler 裡,或放在你儲存的內容裡;不能放在 scope 上。


### PR DESCRIPTION
Two modules now record provenance — users-roles for role grants and revocations, oauth-core for session revocations — and they landed on **different shapes for good reasons**. Writing that down before a third module guesses.

New page: `docs/concepts/audit.md`, linked from the docs index beside `scopes` and `internal-calls`.

## What it documents

The failure being prevented is not a missing feature. It is a trail that is **believed and wrong** — incomplete, invented, or attributable to whoever the caller said they were. Every rule in the page comes from something that actually went wrong this week:

- **Shape first.** Repeating event → append-only ledger; terminal event → provenance columns. Columns for a repeating event *silently overwrite history*, which looks like an audit trail while destroying evidence. users-roles kept `granted_by` on the current row and revoked with a plain `DELETE` — the trail was being shredded by design, and nobody noticed until someone asked to see it.
- **Provenance is `(actor, via)`, never a lone nullable actor.** One field cannot distinguish "the platform did it automatically" from "a human did it and we could not identify them" from "we forgot to record it".
- **Actor from the request context only** — never a header, query or body field, because a record the caller can write gets *trusted*. Better still, derive it from the row being modified (self-logout → the row's own `user_id`), which is unforgeable by construction rather than by validation.
- **Validate against the column type, and never refuse the operation.** A synthetic non-UUID dev identity written to a `uuid` column failed with `22P02`, left a session live while the route reported 500, and rolled an enclosing transaction back. Authorization is already settled by the permission gate — an unidentifiable actor is not an unauthorized one.
- **Coverage belongs in the mutating statement.** Eleven call sites across five paths mutate one table in users-roles, one of them outside `internal/`. A data-modifying CTE whose `RETURNING` feeds the audit insert cannot be forgotten — and gets no-phantom-events for free, since an `ON CONFLICT DO NOTHING` grant returns no rows, so a re-grant appends nothing. Call-site audits fire on *intent*, not on change.
- **A bounded read must say it is bounded**, or the newest N reads as the whole history.
- **Never backfill, never FK to the described entity, never gate the read on `Internal`** — that scope is actorless, so `RequirePermission` 401s for the identity `ms.Call` sends, and a host that degrades a failed fetch to "no audit section" turns that 401 into "this subject has no history".

Ends with a checklist, since the parts that get skipped are the ones with no visible symptom until an auditor asks.

Docs only — no code, no API change.