### PR TITLE
feat(manifest): localize UI page titles and descriptions

### DIFF
--- a/docs/concepts/i18n.md
+++ b/docs/concepts/i18n.md
@@ -82,40 +82,45 @@ stash "avoids prop-drilling MountContext through every page"). i18n mirrors that
 
 ## Manifest-string i18n (platform-rendered)
 
-Two options — they differ only in whether the Go SDK changes:
+`UIPage.Title` and `UIPage.Description` have per-locale manifest channels in
+`TitleLabels` and `DescriptionLabels`. Catalog keys use the page's existing
+`(Surface, Route)` identity: `ui.pages.<surface>.<route>.title` and
+`ui.pages.<surface>.<route>.description`. The empty main surface is authored as
+`main`; other surfaces and every route (including `/`) are used verbatim:
 
-- **Option A (v1, no Go change):** manifest strings stay in the module's
-  default language; only bundle strings localize. The nav label / page title
-  shows e.g. English while the page body is translated. Partial but zero-cost.
-- **Option B (full):** the Go SDK lets authors declare locale variants for
-  `UIPage` title/description and `Config.Name`/`Describe` — e.g. an additive
-  `TitleI18n map[string]string` (or a small localized-string type). The
-  platform picks the variant for the user's locale, falling back to the
-  default. Additive + backward-compatible.
+```json
+{"ui":{"pages":{
+  "main":     {"/": {"title":"影片"}, "/sessions": {"title":"工作階段"}},
+  "settings": {"/": {"title":"影片核心", "description":"設定影片分類與播放預設值。"}}
+}}}
+```
 
-**Recommendation: ship A, add B when manifest localization is actually
-wanted.** Keeps v1 entirely off the Go SDK.
+The label maps are additive and `omitempty`: modules without those catalog
+keys keep serving only the plain `Title`/`Description`, which remain the
+non-localized fallback. Empty locale values are emitted verbatim because they
+mean “translation pending”; consumers must resolve with logical-OR fallback
+(`labels[locale] || labels["en-US"] || plain`), never `??`.
 
 ## SDK / package impact — *does the SDK change?*
 
 | Piece | Change for v1? | What |
 |---|---|---|
-| **Go `app-module-sdk`** | **No** (Option A) | Only if/when manifest strings localize (Option B): additive locale-variant fields on `UIPage` + `Config`/`Describe`. |
+| **Go `app-module-sdk`** | **Yes — additive** | `UIPage.TitleLabels` / `DescriptionLabels` are populated from `ui.pages.<surface>.<route>.*`; plain strings remain the fallback and absent maps are omitted. `Config.Name` already uses `defaults.nameLabels`. |
 | **web-ui-kit** | **Yes — main change** | `createTranslator` helper + make `formatRelativeDate`/`formatDate`/number utils accept a `locale`. Pre-1.0 **patch** bump + `release` label (kit convention). |
 | **MountContext** | **Yes** | Add `locale` field. It's **duplicated** (platform `ModuleMount.tsx` + each module `index.tsx`) — edit both; no shared type today. Optional cleanup: extract a shared MountContext type. |
 | **web-applications (platform)** | **Yes** | Inject the current account-preference locale into `ctx.locale` at mount. |
 | **Module author convention** | n/a | Ship `locales/*.json`, wire `createTranslator` at mount. Optionally update `/ms-init` scaffold + document in ms-app-modules-example. |
 
-Net: **the Go SDK is untouched for v1.** The shared lift is a small
-web-ui-kit addition + a one-field mount-contract change + the platform
-injecting locale.
+Net: manifest strings now have additive Go SDK locale channels; bundle-string
+i18n still needs the web-ui-kit helper, mount-contract locale, and platform
+locale injection described above.
 
 ## Phasing
 
 1. `ctx.locale` + web-ui-kit `createTranslator` + locale-aware kit formatters;
    localize **oauth-core** bundle strings as the reference module. *(No Go change.)*
-2. Manifest-string localization (Go SDK Option B) if/when nav labels + titles
-   need translating.
+2. Manifest-string localization for module names and UI page titles /
+   descriptions. *(Implemented as additive per-locale manifest maps.)*
 3. *(Later, additive)* platform/agent auto-translation as a catalog **source** —
    author still reviews/overrides. The foundation (1) is unchanged; only who
    fills the non-English catalogs differs.
@@ -124,6 +129,5 @@ injecting locale.
 
 - **Translator home:** web-ui-kit (lean) vs a new tiny `module-web-sdk` package.
 - **Catalog format:** flat JSON + `{var}` (lean) vs next-intl/ICU-compatible.
-- **Manifest localization:** Option A now / B deferred (lean) vs B now.
 - **Shared MountContext type:** extract one (so future ctx fields aren't
   double-edited) vs keep duplicated for now.

--- a/internal/core/ui_page_labels_i18n_test.go
+++ b/internal/core/ui_page_labels_i18n_test.go
@@ -1,0 +1,168 @@
+package core
+
+import (
+	"maps"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/mirrorstack-ai/app-module-sdk/i18n"
+)
+
+func registerUIPageLabelTestPages(m *Module) {
+	m.RegisterUI(ModuleUI{DefaultPages: []UIPage{
+		{Route: "/", Title: "Videos", Export: "VideosPage"},
+		{Route: "/sessions", Title: "Sessions", Export: "SessionsPage"},
+		{
+			Route:       "/",
+			Surface:     UISurfaceSettings,
+			Title:       "Video Core",
+			Description: "Configure video categories and playback defaults.",
+			Export:      "VideoSettingsPage",
+		},
+	}})
+}
+
+func TestUIPageLabels_ResolveCatalogPerLocale(t *testing.T) {
+	i18n.Reset()
+	t.Cleanup(i18n.Reset)
+
+	m := newModuleWithSecret(t, Config{ID: "video", Name: "Video"})
+	registerUIPageLabelTestPages(m)
+
+	fsys := fstest.MapFS{
+		"i18n/en-US.json": &fstest.MapFile{Data: []byte(`{"ui":{"pages":{"main":{"/":{"title":"Videos"},"/sessions":{"title":"Sessions"}},"settings":{"/":{"title":"Video Core","description":"Configure video categories and playback defaults."}}}}}`)},
+		"i18n/zh-TW.json": &fstest.MapFile{Data: []byte(`{"ui":{"pages":{"main":{"/":{"title":"影片"},"/sessions":{"title":"工作階段"}},"settings":{"/":{"title":"影片核心","description":"設定影片分類與播放預設值。"}}}}}`)},
+	}
+	if err := i18n.RegisterMessages(fsys, "i18n"); err != nil {
+		t.Fatalf("RegisterMessages: %v", err)
+	}
+
+	got := manifestOf(t, m)
+	if got.UI == nil {
+		t.Fatal("manifest UI is nil")
+	}
+	pages := got.UI.DefaultPages
+	if len(pages) != 3 {
+		t.Fatalf("DefaultPages len = %d, want 3", len(pages))
+	}
+
+	wantTitles := []string{"Videos", "Sessions", "Video Core"}
+	wantZhTW := []string{"影片", "工作階段", "影片核心"}
+	for i := range pages {
+		if pages[i].Title != wantTitles[i] {
+			t.Errorf("DefaultPages[%d].Title = %q, want %q (raw stays the fallback)", i, pages[i].Title, wantTitles[i])
+		}
+		if pages[i].TitleLabels["zh-TW"] != wantZhTW[i] {
+			t.Errorf("DefaultPages[%d].TitleLabels[zh-TW] = %q, want %q", i, pages[i].TitleLabels["zh-TW"], wantZhTW[i])
+		}
+	}
+
+	if maps.Equal(pages[0].TitleLabels, pages[2].TitleLabels) {
+		t.Errorf("main / and settings / TitleLabels collided: %v", pages[0].TitleLabels)
+	}
+	if pages[0].DescriptionLabels != nil || pages[1].DescriptionLabels != nil {
+		t.Errorf("main-page DescriptionLabels = %v, %v; want both nil", pages[0].DescriptionLabels, pages[1].DescriptionLabels)
+	}
+	if pages[2].DescriptionLabels["zh-TW"] != "設定影片分類與播放預設值。" {
+		t.Errorf("settings DescriptionLabels[zh-TW] = %q, want %q", pages[2].DescriptionLabels["zh-TW"], "設定影片分類與播放預設值。")
+	}
+}
+
+func TestUIPageLabels_AbsentWhenNoCatalog(t *testing.T) {
+	i18n.Reset()
+	t.Cleanup(i18n.Reset)
+
+	m := newModuleWithSecret(t, Config{ID: "video", Name: "Video"})
+	registerUIPageLabelTestPages(m)
+	got := manifestOf(t, m)
+	if got.UI == nil {
+		t.Fatal("manifest UI is nil")
+	}
+
+	wantTitles := []string{"Videos", "Sessions", "Video Core"}
+	for i, page := range got.UI.DefaultPages {
+		if page.TitleLabels != nil {
+			t.Errorf("DefaultPages[%d].TitleLabels = %v, want nil", i, page.TitleLabels)
+		}
+		if page.DescriptionLabels != nil {
+			t.Errorf("DefaultPages[%d].DescriptionLabels = %v, want nil", i, page.DescriptionLabels)
+		}
+		if page.Title != wantTitles[i] {
+			t.Errorf("DefaultPages[%d].Title = %q, want %q (raw fallback)", i, page.Title, wantTitles[i])
+		}
+	}
+}
+
+func TestUIPageLabels_EmptyTranslationIsCarriedVerbatim(t *testing.T) {
+	i18n.Reset()
+	t.Cleanup(i18n.Reset)
+
+	m := newModuleWithSecret(t, Config{ID: "video", Name: "Video"})
+	registerUIPageLabelTestPages(m)
+	fsys := fstest.MapFS{
+		"i18n/en-US.json": &fstest.MapFile{Data: []byte(`{"ui":{"pages":{"main":{"/":{"title":"Videos"}}}}}`)},
+		"i18n/zh-TW.json": &fstest.MapFile{Data: []byte(`{"ui":{"pages":{"main":{"/":{"title":""}}}}}`)},
+	}
+	if err := i18n.RegisterMessages(fsys, "i18n"); err != nil {
+		t.Fatalf("RegisterMessages: %v", err)
+	}
+
+	got := manifestOf(t, m)
+	if got.UI == nil {
+		t.Fatal("manifest UI is nil")
+	}
+	labels := got.UI.DefaultPages[0].TitleLabels
+	if len(labels) != 2 {
+		t.Fatalf("TitleLabels = %v, want both en-US and zh-TW", labels)
+	}
+	if v, ok := labels["en-US"]; !ok || v != "Videos" {
+		t.Errorf("TitleLabels[en-US] = %q, present %v; want %q", v, ok, "Videos")
+	}
+	// Consumers must treat this as missing via || fallback, not ?? fallback.
+	if v, ok := labels["zh-TW"]; !ok || v != "" {
+		t.Errorf("TitleLabels[zh-TW] = %q, present %v; want present empty value", v, ok)
+	}
+}
+
+func TestUIPageLabels_RawJSONCarriesTitleLabels(t *testing.T) {
+	i18n.Reset()
+	t.Cleanup(i18n.Reset)
+
+	t.Run("catalog", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"i18n/en-US.json": &fstest.MapFile{Data: []byte(`{"ui":{"pages":{"main":{"/":{"title":"Videos"}}}}}`)},
+			"i18n/zh-TW.json": &fstest.MapFile{Data: []byte(`{"ui":{"pages":{"main":{"/":{"title":"影片"}}}}}`)},
+		}
+		if err := i18n.RegisterMessages(fsys, "i18n"); err != nil {
+			t.Fatalf("RegisterMessages: %v", err)
+		}
+
+		m := newModuleWithSecret(t, Config{ID: "video", Name: "Video"})
+		registerUIPageLabelTestPages(m)
+		rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+		if rec.Code != 200 {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, `"titleLabels":{`) {
+			t.Errorf("raw manifest lacks titleLabels object: %s", body)
+		}
+		if !strings.Contains(body, "影片") {
+			t.Errorf("raw manifest lacks zh-TW title: %s", body)
+		}
+	})
+
+	t.Run("no catalog", func(t *testing.T) {
+		i18n.Reset()
+		m := newModuleWithSecret(t, Config{ID: "video", Name: "Video"})
+		registerUIPageLabelTestPages(m)
+		rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+		if rec.Code != 200 {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if body := rec.Body.String(); strings.Contains(body, "titleLabels") {
+			t.Errorf("raw manifest contains titleLabels without catalog: %s", body)
+		}
+	})
+}

--- a/internal/registry/ui.go
+++ b/internal/registry/ui.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -79,13 +80,25 @@ type UIProp struct {
 // The page's nav-rail icon is the module's icon (Config.Icon). Pages
 // don't carry their own icon today — when distinct icons per page are
 // needed, an Icon field will be added back as optional.
+//
+// Title and Description remain the non-localized fallbacks, just as
+// Defaults.Name does for NameLabels. Per-locale values come from catalog keys
+// "ui.pages.<surface>.<route>.title" and ".description"; the main surface is
+// written as "main", and the route is used verbatim. Older modules omit the
+// label maps via omitempty and keep serving the plain strings unchanged.
+//
+// An empty per-locale value means "translation pending, not chosen". Consumers
+// must therefore fall back with logical-OR semantics (value[locale] ||
+// value["en-US"] || ...), never nullish-coalescing semantics.
 type UIPage struct {
-	Route       string `json:"route"`
-	Surface     string `json:"surface,omitempty"`
-	Title       string `json:"title"`
-	Description string `json:"description,omitempty"`
-	Icon        string `json:"icon,omitempty"`
-	Export      string `json:"export"`
+	Route             string            `json:"route"`
+	Surface           string            `json:"surface,omitempty"`
+	Title             string            `json:"title"`
+	TitleLabels       map[string]string `json:"titleLabels,omitempty"`
+	Description       string            `json:"description,omitempty"`
+	DescriptionLabels map[string]string `json:"descriptionLabels,omitempty"`
+	Icon              string            `json:"icon,omitempty"`
+	Export            string            `json:"export"`
 }
 
 // Known UIPage.Surface values. Empty string defaults to the main
@@ -226,6 +239,10 @@ func cloneUI(ui ModuleUI) *ModuleUI {
 	out := &ModuleUI{
 		Components:   make([]UIComponent, len(ui.Components)),
 		DefaultPages: slices.Clone(ui.DefaultPages),
+	}
+	for i := range out.DefaultPages {
+		out.DefaultPages[i].TitleLabels = maps.Clone(ui.DefaultPages[i].TitleLabels)
+		out.DefaultPages[i].DescriptionLabels = maps.Clone(ui.DefaultPages[i].DescriptionLabels)
 	}
 	for i, c := range ui.Components {
 		out.Components[i] = UIComponent{

--- a/internal/registry/ui_test.go
+++ b/internal/registry/ui_test.go
@@ -1,0 +1,39 @@
+package registry
+
+import "testing"
+
+func TestUIPageLabelMapsAreDeepCopied(t *testing.T) {
+	t.Parallel()
+
+	titleLabels := map[string]string{"zh-TW": "影片"}
+	descriptionLabels := map[string]string{"zh-TW": "影片說明"}
+	r := New()
+	r.SetUI(ModuleUI{DefaultPages: []UIPage{{
+		Route:             "/",
+		Title:             "Videos",
+		TitleLabels:       titleLabels,
+		Description:       "Video description",
+		DescriptionLabels: descriptionLabels,
+		Export:            "VideosPage",
+	}}})
+
+	titleLabels["zh-TW"] = "mutated caller title"
+	descriptionLabels["zh-TW"] = "mutated caller description"
+	got := r.UI()
+	if got.DefaultPages[0].TitleLabels["zh-TW"] != "影片" {
+		t.Errorf("registry TitleLabels mutated through caller map: %v", got.DefaultPages[0].TitleLabels)
+	}
+	if got.DefaultPages[0].DescriptionLabels["zh-TW"] != "影片說明" {
+		t.Errorf("registry DescriptionLabels mutated through caller map: %v", got.DefaultPages[0].DescriptionLabels)
+	}
+
+	got.DefaultPages[0].TitleLabels["zh-TW"] = "mutated return title"
+	got.DefaultPages[0].DescriptionLabels["zh-TW"] = "mutated return description"
+	again := r.UI()
+	if again.DefaultPages[0].TitleLabels["zh-TW"] != "影片" {
+		t.Errorf("registry TitleLabels mutated through UI return: %v", again.DefaultPages[0].TitleLabels)
+	}
+	if again.DefaultPages[0].DescriptionLabels["zh-TW"] != "影片說明" {
+		t.Errorf("registry DescriptionLabels mutated through UI return: %v", again.DefaultPages[0].DescriptionLabels)
+	}
+}

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -138,6 +138,59 @@ const (
 	tagLabelSep   = ","
 )
 
+const (
+	uiPageCatalogPrefix  = "ui.pages"
+	uiPageMainSurfaceKey = "main"
+)
+
+func uiPageCatalogKey(surface, route string) string {
+	if surface == registry.UISurfaceMain {
+		surface = uiPageMainSurfaceKey
+	}
+	return uiPageCatalogPrefix + "." + surface + "." + route
+}
+
+// localizeUIPages fills UIPage title/description label maps from catalog keys
+// "ui.pages.<surface>.<route>.title" and ".description". A page is already
+// identified by its (Surface, Route) pair in validateUI, so the catalog uses
+// that same pair rather than introducing a separate slug. The route is one
+// verbatim JSON key: authors have no transformation rule to remember, and two
+// distinct routes cannot collide. The empty main surface is written as "main":
+//
+//	{"ui":{"pages":{
+//	  "main":     {"/": {"title":"影片"}, "/sessions": {"title":"工作階段"}},
+//	  "settings": {"/": {"title":"影片核心", "description":"設定影片分類與播放預設值。"}}
+//	}}}
+func localizeUIPages(ui *registry.ModuleUI) *registry.ModuleUI {
+	if ui == nil {
+		return nil
+	}
+
+	// Registry.UI already returns a deep copy, so the manifest can safely
+	// enrich these pages in place without cloning them again.
+	for i := range ui.DefaultPages {
+		p := &ui.DefaultPages[i]
+		base := uiPageCatalogKey(p.Surface, p.Route)
+
+		// A non-empty author-set map is more specific and more local, so it
+		// wins over the process-wide catalog.
+		if len(p.TitleLabels) == 0 {
+			if labels := i18n.Lookup(base + ".title"); len(labels) > 0 {
+				p.TitleLabels = labels
+			}
+		}
+		if len(p.DescriptionLabels) == 0 {
+			if labels := i18n.Lookup(base + ".description"); len(labels) > 0 {
+				p.DescriptionLabels = labels
+			}
+		}
+	}
+
+	// Lookup results are emitted verbatim, including empty values: an empty
+	// translation is pending and consumers deliberately fall back with ||.
+	return ui
+}
+
 // ManifestEvents declares which events the module emits and which it subscribes to.
 type ManifestEvents struct {
 	Emits      []string          `json:"emits"`
@@ -222,7 +275,7 @@ func ManifestHandler(id, slug, name, icon string, tags []string, sqlFS fs.FS, ve
 			Resources:         ManifestResources{Storage: reg.StorageRequired()},
 			Metrics:           reg.Metrics(),
 			MCP:               buildManifestMCP(reg),
-			UI:                reg.UI(),
+			UI:                localizeUIPages(reg.UI()),
 			Provides:          contribSlots,
 			ContributesTo:     reg.OutboundContributions(),
 		}


### PR DESCRIPTION
## Why

Module-declared nav items render their English source string regardless of locale. On a zh-TW app the rail shows `Review` next to fully-translated chrome, because `user-approval/declare/ui.go:16` hardcodes `Title: "Review Queue"` and the manifest carries that literal straight to the platform.

Permission labels already support `ms.T(key)` against catalogs loaded via `RegisterMessages`. This extends the same mechanism to `UIPage.Title` / `.Description`, so a module can declare a catalog key instead of a literal and the manifest ships resolved labels per locale.

## 🔴 Note on the diff — this branch was rebased before opening

As originally cut, this branch's diff against `main` showed `auth_scope_truth_test.go | 508 ------`: it predated that file landing, so merging it would have **silently deleted a 508-line security test**. Rebased onto `main` (`e49d299`); the diff is now purely additive — 308 insertions, 27 deletions across 5 files, none of them a deletion of existing tests.

Worth stating because that deletion was invisible in the PR title and would have read as an ordinary feature merge.

## Verification

`gofmt` clean · `go vet` exit 0 · `go test ./...` all packages ok (refcache, registry, runtime, taskenv, meter, roles, storage, system).

New coverage: `internal/core/ui_page_labels_i18n_test.go` (168 lines) plus additions to `internal/registry/ui_test.go`.

## Follow-up (not in this PR)

`user-approval` still declares literals. Once this releases, its `ui.go` switches to `ms.T("nav.reviewQueue")` with zh-TW/en-US catalogs, then republishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)