### PR TITLE
feat(delivery): platform-minted, fail-closed CDN delivery credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## Unreleased
 
+Additive only — 4 exported symbols added (`ms.DeliveryURL`, `ms.Delivery`,
+`ms.DeliveryTicket`, `ms.GatedKeyPrefix`), none removed and none changed — so
+the release PR carrying this should be **v0.4.2**, a PATCH, per the pre-1.0
+convention. (Verified by diffing `go doc -all`, not by intent.)
+
+### Added
+
+- **Gated CDN delivery.** `ms.DeliveryURL(ctx, key, ttl)` returns the CDN URL for
+  one gated object with a short-lived, platform-minted delivery credential
+  attached; `ms.Delivery(ctx, prefix, ttl)` mints ONE credential covering a whole
+  prefix and returns a `ms.DeliveryTicket` whose `URL` method builds a URL per
+  object. Objects opt in by living under `ms.GatedKeyPrefix` (`_gated/`) inside
+  the module's own storage prefix.
+
+  This replaces per-request presigned S3 URLs for the bytes it covers. A
+  presigned URL is unique per request and therefore uncacheable by construction,
+  so every viewer paid a full S3 GET plus egress for every object; a delivery
+  token rides the query string, which the CDN excludes from its cache key, so one
+  cached object serves every entitled viewer.
+
+  **The module owns the entitlement decision, the platform owns the credential.**
+  Call this only after deciding the viewer is entitled. The signing key never
+  reaches the module, the token is unexported on the ticket, and the module id in
+  the token comes from the calling module's credential — never from anything the
+  module sends — so a token minted for one module is worthless against another
+  module's objects in the same app.
+
+  > [!IMPORTANT]
+  > **There is no unsigned fallback.** Every failure — mint refused, dispatch
+  > unreachable, a 200 carrying an empty token — returns an error and no URL.
+  > Do not "fix" a failing mint by emitting the bare CDN URL: unsigned URLs for
+  > gated content are public, they look exactly like a working feature, and they
+  > land in viewers' playlists where a rollback cannot reach them.
+  >
+  > Requires the platform mint endpoint (`POST /apps/{appRef}/cdn-tokens`) and a
+  > CDN edge that validates the token. **The edge validation must be deployed
+  > before any module emits a CDN URL** — the reverse order makes every gated
+  > object public.
+
 ## [v0.4.1] - 2026-08-16
 
 This release makes `ms.RunTask` a genuinely managed task: a one-shot process

--- a/internal/core/delivery.go
+++ b/internal/core/delivery.go
@@ -1,0 +1,374 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Gated CDN delivery — the module-facing half.
+//
+// WHO OWNS WHAT. The module owns the ENTITLEMENT DECISION (was the credit
+// charged, is the role held); the PLATFORM owns the DELIVERY CREDENTIAL. This
+// file is the seam between them: the module says "I have decided this viewer
+// may watch job J", the platform hands back a short-lived, prefix-scoped URL,
+// and cdn-worker verifies it at the edge. The module never sees, holds, or
+// derives the signing key — it receives a URL and nothing else, which is why
+// DeliveryTicket keeps the token in an UNEXPORTED field.
+//
+// WHY THIS EXISTS AT ALL. Serving a segment from a presigned S3 URL makes the
+// bytes uncacheable by construction: a fresh signature per request is a fresh
+// cache key per request, so every viewer pays a full S3 GET plus egress for
+// every segment. A delivery token rides the QUERY STRING, and cdn-worker's
+// cache key is the path only — so one cached object serves every entitled
+// viewer, and the credential does not fragment the cache.
+//
+// 🔴 THERE IS NO UNSIGNED FALLBACK, ANYWHERE IN THIS FILE. Every failure path
+// returns ("", err). Returning a bare CDN URL when minting fails would look
+// exactly like a working feature while serving paywalled content to anyone with
+// the link — and because those URLs land in viewers' playlists, it is not a
+// mistake a rollback can take back.
+
+// GatedKeyPrefix is the module-relative key prefix that opts an object into
+// token gating. A module writes gated objects under it and reads them back at
+// the same key, so the key it stores and the key it later serves are identical.
+//
+// The edge's rule is broader than this (any "/"-delimited segment equal to
+// "_gated" is gated) while the platform only ever MINTS for keys of the exact
+// apps/<app>/<module>/_gated/… shape. That asymmetry is deliberate and fails
+// closed: a creatively-nested key becomes unreachable, never public.
+const GatedKeyPrefix = "_gated/"
+
+// deliveryEnvelopeVersion is the mint envelope version. The platform rejects an
+// unknown version loudly rather than reading a future format as v1, so this
+// must move in lockstep with the endpoint.
+const deliveryEnvelopeVersion = 1
+
+// maxDeliveryPrefixLen bounds the module-relative prefix so the COMPOSED prefix
+// stays inside the platform's 512-byte ceiling. The platform prepends
+// "apps/<uuid>/<uuid>/" — 5 + 36 + 1 + 36 + 1 bytes — and that composed string
+// is signed into the token, which lands in every segment URL of every playlist
+// line. Checking here turns a guaranteed 400 into a local error with no round
+// trip.
+const maxDeliveryPrefixLen = 512 - (len("apps/") + 36 + len("/") + 36 + len("/"))
+
+// deliveryKeyCharset is the allowlist for every caller-supplied byte that ends
+// up in a signed prefix or in a URL path. It is the same charset the platform
+// enforces on the composed prefix.
+//
+// 🔴 THIS IS WHAT CLOSES DELIMITER INJECTION LOCALLY. The signed canonical
+// string is LF-delimited, and storage.validateKey does NOT reject "\n" (it
+// rejects only empty, leading '/', ".." and '%'). The platform re-checks the
+// composed prefix before signing and the edge checks it again after verifying,
+// so a hole here is not exploitable — but a module that discovers its newline
+// key was silently rejected 400 rounds later has been failed by this SDK, not
+// helped by it.
+var deliveryKeyCharset = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// deliveryParamPattern guards the query-parameter NAME the platform returns.
+// The name is returned rather than hardcoded here so a future rename is a
+// platform-only change — which means an unvalidated value would let a broken or
+// hostile response inject extra query structure into every segment URL.
+var deliveryParamPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,32}$`)
+
+// deliveryTokenCharset keeps the token to bytes that are safe verbatim in a
+// query value. It is deliberately NOT the token's two-part base64url shape:
+// pinning the shape here would recreate the coupling that returning `param`
+// exists to avoid. It only has to be true that the token needs no escaping, so
+// the bytes the platform signed are the bytes the edge verifies.
+var deliveryTokenCharset = regexp.MustCompile(`^[A-Za-z0-9._~-]+$`)
+
+// DeliveryTicket is ONE minted delivery credential together with the CDN origin
+// it is valid against. One ticket covers every object under Prefix, so a caller
+// with many keys — a transcode job is hundreds of segments across four
+// renditions — mints ONCE and calls URL for each. Minting per segment would
+// spend one platform round trip per playlist line.
+//
+// The credential itself is unexported on purpose: the module's contract is "you
+// get a URL", not "you get a token you may attach yourself". There is no
+// accessor, so there is no call site that can build an almost-right URL.
+type DeliveryTicket struct {
+	// Prefix is the platform-composed ABSOLUTE object-key prefix this ticket
+	// authorises: apps/<app>/<module>/_gated/…/. It is echoed by the platform so
+	// the module can assert what it actually got instead of reconstructing it.
+	Prefix string
+	// URLPrefix is the CDN origin joined to Prefix. The module never
+	// concatenates the CDN base itself — that string is platform configuration
+	// and the module must not hold a second opinion about it.
+	URLPrefix string
+	// ExpiresAt is when the credential dies. After it, the edge returns 403 and
+	// the viewer needs a re-mint (which is what re-fetching the playlist does).
+	ExpiresAt time.Time
+	// ExpiresIn is the CLAMPED lifetime the platform granted. It can be shorter
+	// than the ttl proposed — the proposal is a proposal — so a caller that
+	// wants to re-mint on schedule must read this rather than assume its own.
+	ExpiresIn time.Duration
+
+	param string
+	token string
+}
+
+// URL returns the delivery URL for one object, addressed RELATIVE to the
+// ticket's prefix. relativeKey is the tail: for a ticket on
+// "_gated/videos/v1/transcodes/j1/720p/" that is "seg_000042.ts".
+//
+// It never returns a URL without the credential attached — a ticket that
+// somehow reached a caller unarmed is an error, not a public URL.
+func (t DeliveryTicket) URL(relativeKey string) (string, error) {
+	if t.token == "" || t.param == "" || t.URLPrefix == "" {
+		return "", fmt.Errorf("ms.DeliveryTicket.URL: ticket is not armed (mint it with ms.Delivery)")
+	}
+	if err := validateDeliveryRelativeKey(relativeKey); err != nil {
+		return "", fmt.Errorf("ms.DeliveryTicket.URL: %w", err)
+	}
+	return t.URLPrefix + relativeKey + "?" + t.param + "=" + t.token, nil
+}
+
+// deliveryMintRequest is the mint envelope. Note what is ABSENT: no module id
+// and no app id. The platform resolves the app from the URL and the module from
+// the credential, so there is no field here a caller could point at somebody
+// else's storage.
+//
+// TTLSeconds is a pointer so "unset" (platform default) is distinguishable on
+// the wire from an explicit 0.
+type deliveryMintRequest struct {
+	V          int    `json:"v"`
+	Prefix     string `json:"prefix"`
+	TTLSeconds *int64 `json:"ttlSeconds,omitempty"`
+}
+
+type deliveryMintResponse struct {
+	Token     string `json:"token"`
+	Param     string `json:"param"`
+	Prefix    string `json:"prefix"`
+	URLPrefix string `json:"urlPrefix"`
+	ExpiresAt string `json:"expiresAt"`
+	ExpiresIn int64  `json:"expiresIn"`
+}
+
+// resolveDeliveryMintURL builds the platform-dispatch mint URL:
+//
+//	{base}/apps/{appID}/cdn-tokens
+//
+// base is MS_DISPATCH_URL with the host.docker.internal:8083 dev fallback when
+// unset — the same resolution Call, Emit and Notify use. DEV/DISPATCH
+// TRANSPORT: this resolver is the #146 seam, mirroring resolveEventBusURL.
+func resolveDeliveryMintURL(ctx context.Context, appID string) string {
+	return fmt.Sprintf("%s/apps/%s/cdn-tokens", dispatchBaseFor(ctx), appID)
+}
+
+// Delivery mints ONE delivery credential covering every object under prefix.
+//
+// prefix is relative to this module's own storage prefix — exactly the key
+// space ms.Storage operates in — and must start with GatedKeyPrefix and end
+// with "/". Scope it to the narrowest thing the entitlement decision actually
+// covered: for video that is one transcode job, which is one video across all
+// its renditions. Do not scope it at "_gated/": that is "every private object
+// this module owns", which is a bucket token wearing a smaller hat.
+//
+// ttl is a PROPOSAL. The platform clamps it into its own bounds and reports the
+// result as ExpiresIn; a zero ttl takes the platform default. Propose no more
+// than the remaining lifetime of the entitlement the caller is acting on — a
+// delivery credential outliving the entitlement that produced it is strictly
+// worse than the presigned URL it replaces.
+//
+// Not module-bound (no *Module receiver), and deliberately so: the platform
+// derives the calling module from the CREDENTIAL, never from anything sent. A
+// receiver would falsely suggest a module id travels in the request. Same shape
+// and same reason as AppID.
+//
+// 🔴 Fail closed. Every error path returns the zero ticket, which cannot
+// produce a URL. There is no degraded mode.
+func Delivery(ctx context.Context, prefix string, ttl time.Duration) (DeliveryTicket, error) {
+	appID, err := appIDFromContext(ctx, "Delivery")
+	if err != nil {
+		return DeliveryTicket{}, err
+	}
+	if err := validateDeliveryPrefix(prefix); err != nil {
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: %w", err)
+	}
+	ttlSeconds, err := deliveryTTLSeconds(ttl)
+	if err != nil {
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: %w", err)
+	}
+	secret, err := outboundServiceSecret(ctx, "Delivery")
+	if err != nil {
+		return DeliveryTicket{}, err
+	}
+
+	var resp deliveryMintResponse
+	if err := postDispatchJSONInto(ctx, "ms.Delivery", resolveDeliveryMintURL(ctx, appID), appID,
+		deliveryMintRequest{V: deliveryEnvelopeVersion, Prefix: prefix, TTLSeconds: ttlSeconds},
+		&resp,
+		map[string]string{"X-MS-Service-Secret": secret},
+	); err != nil {
+		return DeliveryTicket{}, err
+	}
+	return newDeliveryTicket(resp, prefix)
+}
+
+// newDeliveryTicket turns a 200 into a ticket, or into an error.
+//
+// A 2xx is NOT on its own evidence that a usable credential came back. An empty
+// token, a blank parameter name or a half-built origin would each produce a URL
+// that looks right and carries no credential — the "non-empty placeholder
+// defeats an is-it-empty gate" failure, except the placeholder here is the
+// empty string and the consequence is a public paywalled segment. Everything
+// below is therefore checked before a ticket exists at all.
+func newDeliveryTicket(resp deliveryMintResponse, requestedPrefix string) (DeliveryTicket, error) {
+	switch {
+	case resp.Token == "":
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform returned no delivery token")
+	case !deliveryTokenCharset.MatchString(resp.Token):
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform returned a delivery token that is not query-safe")
+	case !deliveryParamPattern.MatchString(resp.Param):
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform returned an unusable token parameter name %q", resp.Param)
+	case resp.ExpiresIn <= 0:
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform returned a non-positive token lifetime (%ds)", resp.ExpiresIn)
+	case !strings.HasSuffix(resp.Prefix, "/"):
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform returned a composed prefix that is not a prefix: %q", resp.Prefix)
+	// The composed prefix must END with what was asked for. A prefix that does
+	// not is a BROADER or DIFFERENT authorisation than the entitlement decision
+	// covered, and silently building URLs against it would widen the scope of
+	// every one of them.
+	case !strings.HasSuffix(resp.Prefix, requestedPrefix):
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform composed prefix %q does not cover the requested %q", resp.Prefix, requestedPrefix)
+	case !strings.HasPrefix(resp.URLPrefix, "http://") && !strings.HasPrefix(resp.URLPrefix, "https://"):
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform returned no usable CDN origin (%q)", resp.URLPrefix)
+	// urlPrefix is CDN origin + "/" + prefix. If it does not end in the very
+	// prefix the token authorises, URLs built from it address objects the token
+	// does not cover and the edge 403s every one of them.
+	case !strings.HasSuffix(resp.URLPrefix, resp.Prefix):
+		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: platform CDN url %q does not end in the composed prefix %q", resp.URLPrefix, resp.Prefix)
+	}
+
+	expiresIn := time.Duration(resp.ExpiresIn) * time.Second
+	// expiresAt is a convenience, not the authority: expiresIn is the clamped
+	// number the platform actually granted. An unparseable timestamp must not
+	// fail a mint that succeeded, so derive it rather than reject.
+	expiresAt, err := time.Parse(time.RFC3339, resp.ExpiresAt)
+	if err != nil {
+		expiresAt = time.Now().UTC().Add(expiresIn)
+	}
+	return DeliveryTicket{
+		Prefix:    resp.Prefix,
+		URLPrefix: resp.URLPrefix,
+		ExpiresAt: expiresAt.UTC(),
+		ExpiresIn: expiresIn,
+		param:     resp.Param,
+		token:     resp.Token,
+	}, nil
+}
+
+// DeliveryURL returns the CDN delivery URL for ONE gated object, with a freshly
+// minted credential attached. key is relative to this module's storage prefix
+// and must live under GatedKeyPrefix.
+//
+// It mints per call, scoped to the key's own directory. For many keys under one
+// prefix — a playlist's worth of segments — call Delivery once and use the
+// returned ticket, which is one platform round trip instead of hundreds.
+//
+// 🔴 An error means NO URL. It never degrades to the unsigned CDN URL and never
+// falls back to a presigned S3 URL: an unsigned URL for gated content is a
+// paywall bypass that looks like a working feature.
+func DeliveryURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
+	prefix, name, err := splitDeliveryKey(key)
+	if err != nil {
+		return "", fmt.Errorf("ms.DeliveryURL: %w", err)
+	}
+	ticket, err := Delivery(ctx, prefix, ttl)
+	if err != nil {
+		return "", err
+	}
+	return ticket.URL(name)
+}
+
+// splitDeliveryKey cuts a module-relative gated key into the prefix a token is
+// minted for and the object name within it.
+func splitDeliveryKey(key string) (prefix, name string, err error) {
+	if err := validateDeliveryRelativeKey(key); err != nil {
+		return "", "", err
+	}
+	// The gating requirement is enforced in ONE place — validateDeliveryPrefix on
+	// the derived prefix. An ungated key ("videos/v1/seg.ts") and a lookalike
+	// ("_gatedx/…") both fail there, and a key with no directory at all derives
+	// the empty prefix, which fails there too. A second copy of the same check
+	// here would only give two ways to disagree about what "gated" means.
+	cut := strings.LastIndex(key, "/")
+	prefix, name = key[:cut+1], key[cut+1:]
+	if err := validateDeliveryPrefix(prefix); err != nil {
+		return "", "", err
+	}
+	return prefix, name, nil
+}
+
+// validateDeliveryPrefix mirrors the platform's allowlist on the composed
+// prefix, applied to the module-relative half. The platform re-checks after
+// composing and the edge re-checks after verifying the signature — this copy
+// exists to fail in the caller's own stack frame, not to be the boundary.
+func validateDeliveryPrefix(prefix string) error {
+	switch {
+	case prefix == "":
+		return fmt.Errorf("prefix is required")
+	case !strings.HasPrefix(prefix, GatedKeyPrefix):
+		return fmt.Errorf("prefix %q must start with %q", prefix, GatedKeyPrefix)
+	case !strings.HasSuffix(prefix, "/"):
+		return fmt.Errorf("prefix %q must end with '/'", prefix)
+	case len(prefix) > maxDeliveryPrefixLen:
+		return fmt.Errorf("prefix exceeds %d bytes", maxDeliveryPrefixLen)
+	case strings.Contains(prefix, ".."):
+		return fmt.Errorf("prefix %q must not contain '..'", prefix)
+	case strings.Contains(prefix, "//"):
+		return fmt.Errorf("prefix %q must not contain '//'", prefix)
+	case !deliveryKeyCharset.MatchString(prefix):
+		return fmt.Errorf("prefix %q must contain only [A-Za-z0-9._/-]", prefix)
+	}
+	return nil
+}
+
+// validateDeliveryRelativeKey guards the bytes appended to a CDN URL path. The
+// charset is an allowlist rather than an escape step on purpose: the edge
+// matches the DECODED key against the signed prefix, so keeping the wire bytes
+// identical to the key bytes removes a whole class of "it encoded differently
+// on one side" failures.
+func validateDeliveryRelativeKey(key string) error {
+	switch {
+	case key == "":
+		return fmt.Errorf("key is required")
+	case strings.HasPrefix(key, "/"):
+		return fmt.Errorf("key %q must not start with '/'", key)
+	case strings.HasSuffix(key, "/"):
+		return fmt.Errorf("key %q must name an object, not a prefix", key)
+	case strings.Contains(key, ".."):
+		return fmt.Errorf("key %q must not contain '..'", key)
+	case strings.Contains(key, "//"):
+		return fmt.Errorf("key %q must not contain '//'", key)
+	case !deliveryKeyCharset.MatchString(key):
+		return fmt.Errorf("key %q must contain only [A-Za-z0-9._/-]", key)
+	}
+	return nil
+}
+
+// deliveryTTLSeconds turns a Duration proposal into the wire field.
+//
+// nil means "unset", which the platform reads as its default. A negative ttl is
+// a caller bug and is rejected rather than quietly defaulted — silently turning
+// a wrong lifetime into an hour hides the bug at the one place it is cheap to
+// see. A positive sub-second ttl rounds UP to 1s so it stays an explicit
+// proposal (the platform then clamps it to its floor) instead of truncating to
+// 0 and reading as "unset".
+func deliveryTTLSeconds(ttl time.Duration) (*int64, error) {
+	switch {
+	case ttl < 0:
+		return nil, fmt.Errorf("ttl must not be negative (got %s)", ttl)
+	case ttl == 0:
+		return nil, nil
+	}
+	seconds := int64(ttl / time.Second)
+	if ttl%time.Second != 0 {
+		seconds++
+	}
+	return &seconds, nil
+}

--- a/internal/core/delivery_test.go
+++ b/internal/core/delivery_test.go
@@ -1,0 +1,530 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+)
+
+const (
+	testDeliveryAppID    = "a-456"
+	testDeliveryPrefix   = "_gated/videos/v1/transcodes/j1/720p/"
+	testDeliveryKey      = testDeliveryPrefix + "seg_000042.ts"
+	testDeliveryToken    = "bXMtY2RuLXRva2VuOnYx.v3qShrO11hUS3ADd1nkukIeammYOYxJdKKBGbP-k3Ws"
+	testDeliveryComposed = "apps/1f0e2c3d-4a5b-6c7d-8e9f-0a1b2c3d4e5f/2a9d8c7b-6e5f-4a3b-2c1d-0e9f8a7b6c5d/" + testDeliveryPrefix
+	testDeliveryCDNBase  = "https://cdn.mirrorstack.ai"
+)
+
+// okMintResponse is the shape a healthy platform returns. Tests mutate a copy
+// of it so a failure case differs from success in exactly one field.
+func okMintResponse() deliveryMintResponse {
+	return deliveryMintResponse{
+		Token:     testDeliveryToken,
+		Param:     "mst",
+		Prefix:    testDeliveryComposed,
+		URLPrefix: testDeliveryCDNBase + "/" + testDeliveryComposed,
+		ExpiresAt: "2026-08-16T13:04:05Z",
+		ExpiresIn: 3600,
+	}
+}
+
+// mintServer stands in for dispatch. handler decides the reply; the recorded
+// request is returned so a test can assert what actually went on the wire.
+type mintRecord struct {
+	method  string
+	path    string
+	appID   string
+	secret  string
+	body    deliveryMintRequest
+	rawBody []byte
+	calls   int
+}
+
+func newMintServer(t *testing.T, handler func(w http.ResponseWriter, rec *mintRecord)) *mintRecord {
+	t.Helper()
+	rec := &mintRecord{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.calls++
+		rec.method = r.Method
+		rec.path = r.URL.Path
+		rec.appID = r.Header.Get("X-MS-App-ID")
+		rec.secret = r.Header.Get("X-MS-Service-Secret")
+		rec.rawBody, _ = io.ReadAll(r.Body)
+		_ = json.Unmarshal(rec.rawBody, &rec.body)
+		handler(w, rec)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	return rec
+}
+
+func writeMint(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func deliveryCtx() context.Context {
+	return auth.Set(context.Background(), auth.Identity{AppID: testDeliveryAppID})
+}
+
+func TestResolveDeliveryMintURL_Building(t *testing.T) {
+	cases := []struct {
+		name     string
+		dispatch string
+		want     string
+	}{
+		{"dev fallback when unset", "", devDispatchFallback + "/apps/a-456/cdn-tokens"},
+		{"explicit base", "http://dispatch:8083", "http://dispatch:8083/apps/a-456/cdn-tokens"},
+		{"trailing slash trimmed", "http://dispatch:8083/", "http://dispatch:8083/apps/a-456/cdn-tokens"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MS_DISPATCH_URL", tc.dispatch)
+			if got := resolveDeliveryMintURL(context.Background(), testDeliveryAppID); got != tc.want {
+				t.Errorf("resolveDeliveryMintURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The happy path, and the wire request that produced it. The credential is a
+// header, never a body field: the platform derives the module from it, so
+// there must be nothing in the envelope a caller could point elsewhere.
+func TestDeliveryURL_MintsAndAttachesTheCredential(t *testing.T) {
+	rec := newMintServer(t, func(w http.ResponseWriter, _ *mintRecord) {
+		writeMint(w, http.StatusOK, okMintResponse())
+	})
+	t.Setenv("MS_INTERNAL_SECRET", "module-credential")
+
+	got, err := DeliveryURL(deliveryCtx(), testDeliveryKey, time.Hour)
+	if err != nil {
+		t.Fatalf("DeliveryURL: %v", err)
+	}
+
+	want := testDeliveryCDNBase + "/" + testDeliveryComposed + "seg_000042.ts?mst=" + testDeliveryToken
+	if got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+	if rec.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", rec.method)
+	}
+	if rec.path != "/apps/"+testDeliveryAppID+"/cdn-tokens" {
+		t.Errorf("path = %q, want /apps/%s/cdn-tokens", rec.path, testDeliveryAppID)
+	}
+	if rec.appID != testDeliveryAppID {
+		t.Errorf("X-MS-App-ID = %q, want %q", rec.appID, testDeliveryAppID)
+	}
+	if rec.secret != "module-credential" {
+		t.Errorf("X-MS-Service-Secret = %q, want the module credential", rec.secret)
+	}
+	if rec.body.V != deliveryEnvelopeVersion {
+		t.Errorf("envelope v = %d, want %d", rec.body.V, deliveryEnvelopeVersion)
+	}
+	// The mint is scoped to the key's own directory, not to "_gated/".
+	if rec.body.Prefix != testDeliveryPrefix {
+		t.Errorf("minted prefix = %q, want %q", rec.body.Prefix, testDeliveryPrefix)
+	}
+	// A module id in the envelope would be a scope-escape seam. There must be
+	// no such field on the wire at all.
+	var raw map[string]any
+	if err := json.Unmarshal(rec.rawBody, &raw); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	for _, forbidden := range []string{"module", "moduleID", "moduleId", "app", "appID", "appId"} {
+		if _, ok := raw[forbidden]; ok {
+			t.Errorf("envelope carries %q; identity must come from the credential and the URL only", forbidden)
+		}
+	}
+}
+
+// A ticket is minted once and serves many objects — the property that makes
+// this usable for a transcode job's hundreds of segments.
+func TestDelivery_OneMintServesEveryObjectUnderThePrefix(t *testing.T) {
+	rec := newMintServer(t, func(w http.ResponseWriter, _ *mintRecord) {
+		writeMint(w, http.StatusOK, okMintResponse())
+	})
+
+	ticket, err := Delivery(deliveryCtx(), testDeliveryPrefix, time.Hour)
+	if err != nil {
+		t.Fatalf("Delivery: %v", err)
+	}
+	if ticket.ExpiresIn != time.Hour {
+		t.Errorf("ExpiresIn = %s, want 1h (the CLAMPED value the platform granted)", ticket.ExpiresIn)
+	}
+	if ticket.Prefix != testDeliveryComposed {
+		t.Errorf("Prefix = %q, want the platform-composed %q", ticket.Prefix, testDeliveryComposed)
+	}
+
+	for _, name := range []string{"seg_000001.ts", "seg_000042.ts", "init.mp4"} {
+		got, err := ticket.URL(name)
+		if err != nil {
+			t.Fatalf("ticket.URL(%q): %v", name, err)
+		}
+		if want := ticket.URLPrefix + name + "?mst=" + testDeliveryToken; got != want {
+			t.Errorf("ticket.URL(%q) = %q, want %q", name, got, want)
+		}
+	}
+	if rec.calls != 1 {
+		t.Errorf("mint calls = %d, want exactly 1 for the whole prefix", rec.calls)
+	}
+}
+
+// 🔴 THE FAIL-CLOSED TEST. Every way minting can fail must produce an error and
+// NO URL. A returned string here — even the correct-looking CDN URL — is a
+// paywall bypass: unsigned segment URLs are public, and they land in viewers'
+// playlists where a rollback cannot reach them.
+func TestDeliveryURL_MintFailureReturnsAnErrorAndNoURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		body    any
+		noServe bool // reply nothing usable: simulates an unreachable dispatch
+	}{
+		{name: "signing key unconfigured", status: http.StatusServiceUnavailable,
+			body: map[string]any{"error": map[string]string{"code": "token_signing_unavailable", "message": "cdn delivery tokens are not available"}}},
+		{name: "sender not recognised", status: http.StatusForbidden,
+			body: map[string]any{"error": map[string]string{"code": "unknown_sender", "message": "cdn token sender is not a live module"}}},
+		{name: "app not found", status: http.StatusNotFound,
+			body: map[string]any{"error": map[string]string{"code": "app_not_found", "message": "app not found"}}},
+		{name: "prefix rejected", status: http.StatusBadRequest,
+			body: map[string]any{"error": map[string]string{"code": "invalid_prefix", "message": "bad prefix"}}},
+		{name: "unparseable success body", status: http.StatusOK, body: nil, noServe: true},
+		{name: "200 with an empty token", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.Token = ""
+			return r
+		}()},
+		{name: "200 with a blank param name", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.Param = ""
+			return r
+		}()},
+		{name: "200 with a param name that injects query structure", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.Param = "mst&public=1"
+			return r
+		}()},
+		{name: "200 with a token that is not query-safe", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.Token = "abc&admin=1"
+			return r
+		}()},
+		{name: "200 with no CDN origin", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.URLPrefix = ""
+			return r
+		}()},
+		{name: "200 whose url does not end in the composed prefix", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.URLPrefix = testDeliveryCDNBase + "/somewhere/else/"
+			return r
+		}()},
+		{name: "200 whose composed prefix is broader than requested", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.Prefix = "apps/1f0e2c3d-4a5b-6c7d-8e9f-0a1b2c3d4e5f/2a9d8c7b-6e5f-4a3b-2c1d-0e9f8a7b6c5d/_gated/"
+			r.URLPrefix = testDeliveryCDNBase + "/" + r.Prefix
+			return r
+		}()},
+		{name: "200 with a non-positive lifetime", status: http.StatusOK, body: func() deliveryMintResponse {
+			r := okMintResponse()
+			r.ExpiresIn = 0
+			return r
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			newMintServer(t, func(w http.ResponseWriter, _ *mintRecord) {
+				if tc.noServe {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(tc.status)
+					_, _ = w.Write([]byte("not json at all"))
+					return
+				}
+				writeMint(w, tc.status, tc.body)
+			})
+
+			got, err := DeliveryURL(deliveryCtx(), testDeliveryKey, time.Hour)
+			if err == nil {
+				t.Fatalf("DeliveryURL succeeded on a failed mint and returned %q", got)
+			}
+			// The load-bearing assertion: not merely "an error", but NOTHING a
+			// caller could hand to a player.
+			if got != "" {
+				t.Fatalf("DeliveryURL returned %q alongside its error; a mint failure must yield NO url", got)
+			}
+			if strings.Contains(got, testDeliveryCDNBase) || strings.Contains(got, "http") {
+				t.Fatalf("DeliveryURL leaked an unsigned CDN url on failure: %q", got)
+			}
+		})
+	}
+}
+
+// The guarantee above holds through TWO independent layers — response screening
+// here, and the armed check on DeliveryTicket.URL — so removing either one alone
+// still fails closed. This test pins the FIRST layer on its own, so a mutation
+// that deletes it is visible instead of being absorbed by the second.
+//
+// A 2xx is not evidence of a usable credential. Every field below would build a
+// URL that looks right and carries nothing the edge will honour — and an empty
+// token is exactly the "non-empty placeholder defeats an is-it-empty gate" shape
+// this workspace has been bitten by, except the placeholder is "".
+func TestNewDeliveryTicket_RejectsAnUnusableMintResponse(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*deliveryMintResponse)
+		wantErr bool
+	}{
+		{name: "healthy response", mutate: func(*deliveryMintResponse) {}},
+		{name: "empty token", mutate: func(r *deliveryMintResponse) { r.Token = "" }, wantErr: true},
+		{name: "token carrying query structure", mutate: func(r *deliveryMintResponse) { r.Token = "tok&admin=1" }, wantErr: true},
+		{name: "empty param name", mutate: func(r *deliveryMintResponse) { r.Param = "" }, wantErr: true},
+		{name: "param name carrying query structure", mutate: func(r *deliveryMintResponse) { r.Param = "mst&public=1" }, wantErr: true},
+		{name: "zero lifetime", mutate: func(r *deliveryMintResponse) { r.ExpiresIn = 0 }, wantErr: true},
+		{name: "negative lifetime", mutate: func(r *deliveryMintResponse) { r.ExpiresIn = -1 }, wantErr: true},
+		{name: "composed prefix is not a prefix", mutate: func(r *deliveryMintResponse) { r.Prefix = strings.TrimSuffix(r.Prefix, "/") }, wantErr: true},
+		{name: "composed prefix broader than requested", mutate: func(r *deliveryMintResponse) {
+			r.Prefix = "apps/1f0e2c3d-4a5b-6c7d-8e9f-0a1b2c3d4e5f/2a9d8c7b-6e5f-4a3b-2c1d-0e9f8a7b6c5d/_gated/"
+			r.URLPrefix = testDeliveryCDNBase + "/" + r.Prefix
+		}, wantErr: true},
+		{name: "no cdn origin", mutate: func(r *deliveryMintResponse) { r.URLPrefix = "" }, wantErr: true},
+		{name: "cdn url is not absolute", mutate: func(r *deliveryMintResponse) { r.URLPrefix = "/" + r.Prefix }, wantErr: true},
+		{name: "cdn url does not end in the composed prefix", mutate: func(r *deliveryMintResponse) {
+			r.URLPrefix = testDeliveryCDNBase + "/somewhere/else/"
+		}, wantErr: true},
+		{name: "unparseable expiresAt falls back rather than failing a good mint",
+			mutate: func(r *deliveryMintResponse) { r.ExpiresAt = "not a timestamp" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := okMintResponse()
+			tc.mutate(&resp)
+
+			ticket, err := newDeliveryTicket(resp, testDeliveryPrefix)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("newDeliveryTicket accepted an unusable response and returned %+v", ticket)
+				}
+				if got, urlErr := ticket.URL("seg_000001.ts"); urlErr == nil || got != "" {
+					t.Fatalf("rejected ticket still produced %q (err=%v)", got, urlErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newDeliveryTicket: %v", err)
+			}
+			got, err := ticket.URL("seg_000001.ts")
+			if err != nil {
+				t.Fatalf("ticket.URL: %v", err)
+			}
+			if !strings.HasSuffix(got, "?mst="+testDeliveryToken) {
+				t.Errorf("url = %q, want the credential attached", got)
+			}
+			if ticket.ExpiresAt.IsZero() {
+				t.Error("ExpiresAt is zero; a caller cannot schedule a re-mint")
+			}
+		})
+	}
+}
+
+// The same guarantee at the ticket layer: a zero ticket cannot be talked into
+// producing an unsigned URL, so a caller that ignores Delivery's error still
+// cannot publish one.
+func TestDeliveryTicket_ZeroTicketCannotProduceAURL(t *testing.T) {
+	var zero DeliveryTicket
+	got, err := zero.URL("seg_000001.ts")
+	if err == nil {
+		t.Fatalf("zero ticket produced %q, want an error", got)
+	}
+	if got != "" {
+		t.Fatalf("zero ticket returned %q, want no url", got)
+	}
+}
+
+// ttl is a PROPOSAL and travels as whole seconds. "Unset" must stay
+// distinguishable from an explicit 0 on the wire, or the platform's default
+// silently replaces a caller's intent.
+func TestDeliveryURL_TTLPassthrough(t *testing.T) {
+	cases := []struct {
+		name    string
+		ttl     time.Duration
+		want    string // raw JSON value expected for ttlSeconds; "" = field absent
+		wantErr bool
+	}{
+		{name: "one hour", ttl: time.Hour, want: "3600"},
+		{name: "the platform floor", ttl: time.Minute, want: "60"},
+		{name: "above the platform ceiling is still sent verbatim and clamped there", ttl: 12 * time.Hour, want: "43200"},
+		{name: "zero omits the field so the platform default applies", ttl: 0, want: ""},
+		{name: "sub-second rounds up to an explicit 1s, never to absent", ttl: 500 * time.Millisecond, want: "1"},
+		{name: "fractional rounds up", ttl: 90500 * time.Millisecond, want: "91"},
+		{name: "negative is a caller bug, not a default", ttl: -time.Second, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newMintServer(t, func(w http.ResponseWriter, _ *mintRecord) {
+				writeMint(w, http.StatusOK, okMintResponse())
+			})
+
+			_, err := DeliveryURL(deliveryCtx(), testDeliveryKey, tc.ttl)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ttl %s: want an error", tc.ttl)
+				}
+				if rec.calls != 0 {
+					t.Errorf("ttl %s: rejected locally but still made %d mint call(s)", tc.ttl, rec.calls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ttl %s: %v", tc.ttl, err)
+			}
+
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(rec.rawBody, &raw); err != nil {
+				t.Fatalf("unmarshal envelope: %v", err)
+			}
+			field, present := raw["ttlSeconds"]
+			if tc.want == "" {
+				if present {
+					t.Errorf("ttl %s: ttlSeconds = %s, want the field to be ABSENT", tc.ttl, field)
+				}
+				return
+			}
+			if !present {
+				t.Fatalf("ttl %s: ttlSeconds absent, want %s", tc.ttl, tc.want)
+			}
+			if string(field) != tc.want {
+				t.Errorf("ttl %s: ttlSeconds = %s, want %s", tc.ttl, field, tc.want)
+			}
+		})
+	}
+}
+
+// An app-scoped context is required: the mint URL is app-scoped and the
+// platform re-resolves the app from it.
+func TestDeliveryURL_RequiresAnAppScopedContext(t *testing.T) {
+	rec := newMintServer(t, func(w http.ResponseWriter, _ *mintRecord) {
+		writeMint(w, http.StatusOK, okMintResponse())
+	})
+
+	got, err := DeliveryURL(context.Background(), testDeliveryKey, time.Hour)
+	if err == nil {
+		t.Fatalf("DeliveryURL without an app scope returned %q, want an error", got)
+	}
+	if got != "" {
+		t.Errorf("returned %q, want no url", got)
+	}
+	if rec.calls != 0 {
+		t.Errorf("made %d mint call(s) with no app scope, want 0", rec.calls)
+	}
+}
+
+func TestSplitDeliveryKey(t *testing.T) {
+	cases := []struct {
+		name       string
+		key        string
+		wantPrefix string
+		wantName   string
+		wantErr    bool
+	}{
+		{name: "segment under a job", key: testDeliveryKey, wantPrefix: testDeliveryPrefix, wantName: "seg_000042.ts"},
+		{name: "object directly under _gated", key: "_gated/probe.txt", wantPrefix: GatedKeyPrefix, wantName: "probe.txt"},
+		{name: "ungated key is not deliverable", key: "videos/v1/seg.ts", wantErr: true},
+		{name: "_gated as a substring is not the prefix", key: "_gatedx/v1/seg.ts", wantErr: true},
+		{name: "prefix, not an object", key: testDeliveryPrefix, wantErr: true},
+		{name: "empty", key: "", wantErr: true},
+		{name: "absolute", key: "/_gated/v1/seg.ts", wantErr: true},
+		{name: "traversal", key: "_gated/../other/seg.ts", wantErr: true},
+		{name: "double slash", key: "_gated//v1/seg.ts", wantErr: true},
+		{name: "percent-encoding", key: "_gated/v1/seg%2e.ts", wantErr: true},
+		// 🔴 The canonical string the platform signs is LF-delimited, and
+		// storage.validateKey does NOT reject "\n". A key that smuggles one must
+		// die here rather than travel.
+		{name: "newline would forge a canonical field", key: "_gated/v1/seg\n.ts", wantErr: true},
+		{name: "query separator would smuggle a second credential", key: "_gated/v1/seg.ts?mst=x", wantErr: true},
+		{name: "fragment", key: "_gated/v1/seg.ts#x", wantErr: true},
+		{name: "space", key: "_gated/v1/seg 1.ts", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix, name, err := splitDeliveryKey(tc.key)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("splitDeliveryKey(%q) = (%q, %q), want an error", tc.key, prefix, name)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("splitDeliveryKey(%q): %v", tc.key, err)
+			}
+			if prefix != tc.wantPrefix || name != tc.wantName {
+				t.Errorf("splitDeliveryKey(%q) = (%q, %q), want (%q, %q)", tc.key, prefix, name, tc.wantPrefix, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestValidateDeliveryPrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{name: "job prefix", prefix: testDeliveryPrefix},
+		{name: "bare _gated is legal here but is a bucket token; scope narrower", prefix: GatedKeyPrefix},
+		{name: "empty", prefix: "", wantErr: true},
+		{name: "ungated", prefix: "videos/v1/", wantErr: true},
+		{name: "no trailing slash", prefix: "_gated/videos/v1", wantErr: true},
+		{name: "traversal", prefix: "_gated/../", wantErr: true},
+		{name: "double slash", prefix: "_gated//v1/", wantErr: true},
+		{name: "newline", prefix: "_gated/v1\n/", wantErr: true},
+		{name: "too long for the platform's 512-byte composed ceiling",
+			prefix: GatedKeyPrefix + strings.Repeat("a", maxDeliveryPrefixLen) + "/", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDeliveryPrefix(tc.prefix)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateDeliveryPrefix(%q) = nil, want an error", tc.prefix)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateDeliveryPrefix(%q) = %v, want nil", tc.prefix, err)
+			}
+		})
+	}
+}
+
+func TestDeliveryTicket_URLRejectsKeysThatEscapeThePrefix(t *testing.T) {
+	newMintServer(t, func(w http.ResponseWriter, _ *mintRecord) {
+		writeMint(w, http.StatusOK, okMintResponse())
+	})
+	ticket, err := Delivery(deliveryCtx(), testDeliveryPrefix, time.Hour)
+	if err != nil {
+		t.Fatalf("Delivery: %v", err)
+	}
+
+	// The token authorises a prefix and the edge checks key.starts_with(p), so a
+	// relative key that walks out of it would be a 403 at best. Refuse to build
+	// the url rather than emit one that cannot work.
+	for _, key := range []string{"../other/seg.ts", "/seg.ts", "", "sub/", "seg.ts?mst=other", "seg\n.ts"} {
+		got, err := ticket.URL(key)
+		if err == nil {
+			t.Errorf("ticket.URL(%q) = %q, want an error", key, got)
+		}
+		if got != "" {
+			t.Errorf("ticket.URL(%q) returned %q, want no url", key, got)
+		}
+	}
+}

--- a/internal/core/dispatch_transport.go
+++ b/internal/core/dispatch_transport.go
@@ -117,6 +117,18 @@ func appIDFromContext(ctx context.Context, op string) (string, error) {
 // trusts an envelope assertion. A non-2xx response is returned as an error
 // prefixed with op ("ms.Emit", "ms.Notify"), body truncated to ~2 KB.
 func postDispatchJSON(ctx context.Context, op, url, appID string, payload any, extraHeaders map[string]string) error {
+	return postDispatchJSONInto(ctx, op, url, appID, payload, nil, extraHeaders)
+}
+
+// postDispatchJSONInto is postDispatchJSON for a surface that needs the
+// RESPONSE, decoding a 2xx body into out (pass nil to discard it, which is what
+// postDispatchJSON does). Everything else — base headers, the opt-in credential
+// rule, the non-2xx error contract — is shared, so a response-reading surface
+// cannot drift from a fire-and-forget one.
+//
+// A decode failure is an error, never a partially-populated out: a surface that
+// returns a CREDENTIAL must not proceed on half a response.
+func postDispatchJSONInto(ctx context.Context, op, url, appID string, payload, out any, extraHeaders map[string]string) error {
 	buf, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -141,6 +153,12 @@ func postDispatchJSON(ctx context.Context, op, url, appID string, payload any, e
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 		return fmt.Errorf("%s %s -> %d: %s", op, req.URL.Path, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("%s %s: decode response: %w", op, req.URL.Path, err)
 	}
 	return nil
 }

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -198,6 +198,54 @@ func Storage(ctx context.Context) (storage.Storer, error) { return core.Storage(
 // credentials only to modules whose manifest contains this declaration.
 func RequireStorage() { core.RequireStorage() }
 
+// --- Gated CDN delivery ---
+
+// GatedKeyPrefix is the module-relative storage-key prefix that opts an object
+// into token-gated CDN delivery. Write gated objects under it (and store that
+// same key), then hand viewers a URL from ms.DeliveryURL or ms.Delivery.
+//
+// Objects NOT under it are served by the CDN with no credential at all, so this
+// prefix is the whole difference between a public asset and a paywalled one.
+const GatedKeyPrefix = core.GatedKeyPrefix
+
+// DeliveryTicket is one minted delivery credential and the CDN origin it is
+// valid against, covering every object under its Prefix. Get one from
+// ms.Delivery and call its URL method per object.
+type DeliveryTicket = core.DeliveryTicket
+
+// DeliveryURL returns the CDN URL for ONE gated object, with a freshly minted,
+// short-lived delivery credential attached. key is relative to this module's
+// storage prefix (the same key space ms.Storage uses) and must live under
+// ms.GatedKeyPrefix. ttl is a proposal the platform clamps.
+//
+// Call it only AFTER deciding the viewer is entitled. The module owns that
+// decision — was the credit charged, is the role held — and the platform owns
+// the credential; the signing key never reaches the module.
+//
+// 🔴 An error means NO URL. It never degrades to an unsigned CDN URL: that
+// would serve paywalled bytes to anyone with the link while looking like a
+// working feature, and those URLs end up in viewers' playlists where a rollback
+// cannot reach them.
+//
+// One mint per call. For many objects under one prefix — a video's segments —
+// use ms.Delivery once and reuse the ticket.
+func DeliveryURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
+	return core.DeliveryURL(ctx, key, ttl)
+}
+
+// Delivery mints ONE delivery credential covering every object under prefix,
+// relative to this module's storage prefix. Scope it to what the entitlement
+// decision actually covered — for video that is one transcode job, i.e. one
+// video across all its renditions — never to bare "_gated/", which authorises
+// everything private the module owns.
+//
+// ttl is a proposal; read ExpiresIn on the returned ticket for the lifetime
+// actually granted, and propose no more than the entitlement's own remaining
+// life. Fails closed: an error yields a zero ticket, which cannot produce a URL.
+func Delivery(ctx context.Context, prefix string, ttl time.Duration) (DeliveryTicket, error) {
+	return core.Delivery(ctx, prefix, ttl)
+}
+
 // MetricOption configures a metric at declaration. The KIND is itself an option
 // (Counter / Gauge), alongside Unit and Price.
 type MetricOption = meter.MetricOption


### PR DESCRIPTION
Part of mirrorstack-ai/mirrorstack-core-v2#484

**Step 4-adjacent.** Additive surface only — nothing behaves differently until a module calls it.

## What this adds

`ms.Delivery(ctx, prefix, ttl)` — a module asks the platform for a short-lived credential that lets the CDN edge serve the module's own gated objects directly, instead of the module presigning an S3 URL per request. Plus `ms.GatedKeyPrefix`, the one definition of the key class the edge gates on.

The module never sees a platform signing key. It states *which prefix* and *how long*, and receives an opaque token to embed. The platform clamps the TTL and derives the module identity from the credential, so a module cannot ask for another module's objects.

**Fail-closed by construction:** there is no presign fallback inside `Delivery`. If the platform cannot mint — misconfigured, unreachable, prefix refused — the call errors and the caller decides. A silent fallback here would mean a paywall quietly degrading to "serve it anyway", which is the failure this whole workstream exists to prevent.

The doc comment states the obligation the caller carries: **propose no more than the remaining lifetime of the entitlement you are acting on.** A delivery credential that outlives the entitlement that produced it is strictly worse than the presigned URL it replaces.

## Release

Additive, no signature changes, no behaviour changes to existing surface ⇒ **patch**, `v0.4.2`, per this repo's pre-1.0 convention. A `release`-labelled PR needs to cut it before `video-core` can pin it — the module PR is blocked on that, not on this merge.

## Base note

Branched off a line that carried a local `chore: release v0.4.1` commit; rebased onto `origin/main`, where the identical release had already landed as #177. Git dropped the duplicate as an equivalent patch — the trees are byte-identical, verified. What remains is the single delivery commit.

## Verification

`go build ./... && go vet ./... && go test ./...` green across every package. `internal/core/delivery_test.go` covers prefix rejection, TTL clamping, mint failure propagation, and that no fallback path exists.


### Deploy order — gated CDN delivery

1. **Provision `MS_CDN_TOKEN_SECRET`** (≥ 32 random bytes) in *both*
   api-platform dispatch's environment and cdn-worker
   (`wrangler secret put`), **and `CDN_BASE_URL` in dispatch's environment**.
   Both are wired in `mirrorstack-infra/stacks/compute.go`'s dispatch env
   (the secret is CDK-generated; read it out of Secrets Manager and copy the
   same value to wrangler). ⚠️ A CloudFormation dynamic reference to a secret
   is **inert until the consuming resource changes** — filling the secret is
   not enough; force a deploy of the resource that reads it, and verify the
   running config, not the template.
   *Wrong ⇒* mint returns 503 and the edge returns 503 for gated keys. Fails
   closed: an outage, never an exposure. **`CDN_BASE_URL` is half of that
   gate** (`deliverable()`), and the 503 code is deliberately collapsed, so an
   operator who provisioned only the secret sees `token_signing_unavailable`
   for a secret they set correctly. Check dispatch's startup log: it names
   which half is missing.

2. **Deploy cdn-worker with token validation live.** Behaviourally a no-op at
   this point — no `_gated/` keys exist yet.
   *Wrong (i.e. skipped or done after step 5) ⇒* **every paywalled video is
   public.** `_gated/` keys are served to anyone with the URL, and the credit
   gate becomes decorative. This is the one ordering mistake in this workstream
   that cannot be undone by a rollback: the URLs are already in viewers'
   playlists.

3. **Verify at the edge, in production, with a throwaway object.** PUT a byte
   to `apps/<test-app>/<test-module>/_gated/probe.txt`. Confirm: no token ⇒
   403 + `no-store`; bad signature ⇒ 403; expired ⇒ 403; valid token ⇒ 200 +
   `private, max-age=31536000, immutable`; `HEAD` behaves identically. Then
   delete it.
   *Wrong ⇒* you discover a byte-level HMAC disagreement between two binaries
   at cutover, with real viewers on it.

4. **Deploy api-platform with the mint endpoint.**
   *Wrong (before step 2) ⇒* modules can obtain tokens nothing validates.
   Harmless in isolation, but it makes step 5 look ready when it is not.

5. **Deploy video-core**: new transcode jobs write under `_gated/`, and CDN
   URLs are emitted **only** for rows whose `hls_prefix` starts with `_gated/`
   (§2.3). Everything else keeps presigning.
   *Wrong ⇒* see step 2. This is the step that makes the exposure real.

6. **Backfill legacy rows** (reprocess, or copy into the `_gated/` prefix and
   update `hls_prefix`) at leisure. Cost-only; no security consequence in
   either direction.

Rollback at any point: stop emitting CDN URLs from video-core (step 5 reverts
alone). The edge validation, the mint endpoint, and the secret are all inert
without it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
