### PR TITLE
feat(storage): read a module's own object over the S3 API

### DIFF
--- a/storage/get.go
+++ b/storage/get.go
@@ -1,0 +1,66 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// MaxGetBytes caps what Get will read into memory. Get exists for small,
+// module-owned control files — HLS playlists, manifests, sidecars — and a cap
+// keeps a mistyped key from turning a 4 GB source video into an OOM. Streaming
+// a large object to a viewer is what PresignGet is for.
+const MaxGetBytes = 8 << 20
+
+// ErrObjectTooLarge is returned when an object exceeds MaxGetBytes.
+var ErrObjectTooLarge = errors.New("mirrorstack/storage: object exceeds MaxGetBytes")
+
+// Get reads one object's bytes through the S3 API.
+//
+// WHY THIS EXISTS, and when to use it instead of PresignGet. A presigned URL is
+// built for a BROWSER: it is signed against the client-facing endpoint, which in
+// dev is the host-published address of the object store. Fetching one from
+// inside the module is not merely wasteful (sign, then a second HTTP round trip
+// to your own storage) — it is wrong, because the module runs somewhere the
+// client-facing address may not resolve. In the dev container it resolves to the
+// container itself and the read fails with `dial tcp [::1]:9000: connection
+// refused`, which is how this was found: every HLS playlist read 502'd.
+//
+// Get goes over the S3 API with the module's own credential and the endpoint
+// that credential was minted for, so it is correct from wherever the module
+// runs. Rule of thumb: bytes YOU need, Get; bytes the VIEWER needs, PresignGet
+// or Delivery.
+//
+// The key is relative to the module's prefix, exactly like every other method
+// here, and is validated the same way.
+func (c *Client) Get(ctx context.Context, key string) ([]byte, error) {
+	if err := c.requireCredential(); err != nil {
+		return nil, err
+	}
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
+	out, err := c.s3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(c.prefix + key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mirrorstack/storage: get %q failed: %w", key, err)
+	}
+	defer out.Body.Close()
+	// LimitReader at MaxGetBytes+1 so exceeding the cap is DETECTED rather than
+	// silently truncated — a truncated playlist is a subtly broken video, which
+	// is far worse to debug than a refusal.
+	body, err := io.ReadAll(io.LimitReader(out.Body, MaxGetBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("mirrorstack/storage: read %q failed: %w", key, err)
+	}
+	if len(body) > MaxGetBytes {
+		return nil, fmt.Errorf("%w: %s", ErrObjectTooLarge, key)
+	}
+	return body, nil
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -29,6 +29,10 @@ import (
 type Storer interface {
 	PresignPut(ctx context.Context, key string, expires time.Duration) (string, error)
 	PresignGet(ctx context.Context, key string, expires time.Duration) (string, error)
+	// Get reads an object the MODULE needs, over the S3 API. Distinct from
+	// PresignGet, which builds a URL for a VIEWER against the client-facing
+	// endpoint — an address the module itself may not be able to reach.
+	Get(ctx context.Context, key string) ([]byte, error)
 	URL(key string) (string, error)
 	CreateMultipart(ctx context.Context, key, contentType string) (*MultipartUpload, error)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -26,6 +26,14 @@ import (
 )
 
 // Storer is the interface for storage operations.
+//
+// Adding a method here is source-breaking for any implementation or test double
+// outside this package, which is why an optional capability stays OFF it and is
+// offered as a separate interface instead — see PrefixDeleter in delete.go. Get
+// is on it deliberately rather than by oversight: ms.Storage hands every module
+// this interface, and reading your own object is as fundamental as writing one,
+// so a module should not need a type assertion to do it. Pre-1.0, and *Client is
+// the only implementation in the workspace.
 type Storer interface {
 	PresignPut(ctx context.Context, key string, expires time.Duration) (string, error)
 	PresignGet(ctx context.Context, key string, expires time.Duration) (string, error)


### PR DESCRIPTION
Found while fixing local dev video preview. **Blocks a video-core fix** that cannot be written without it.

## The gap

The SDK had **no server-side read at all** — only `PresignGet`. A module that needs to read its *own* object had to presign a URL and then fetch it over HTTP. video-core does exactly that: it parses and rewrites HLS playlists before serving them.

That isn't just a wasteful extra round trip to your own storage. It's **wrong**. A presigned URL is signed against the **client-facing** endpoint, and the module runs somewhere that address need not resolve:

```
video-core: master manifest: Get "http://localhost:9000/mirrorstack-dev/…"
  dial tcp [::1]:9000: connect: connection refused
```

In the dev container `localhost:9000` is the container itself. Every playlist read 502'd, and the browser reported it as a **CORS error on master.m3u8** — about as far from the cause as an error can land. Two people spent an afternoon on the wrong layer because of it.

## The addition

`Get` goes over the S3 API with the module's own credential and the endpoint that credential was minted for, so it is correct from wherever the module runs.

The rule of thumb is in the doc comment, because this distinction is the whole point:

> **bytes YOU need → `Get`; bytes the VIEWER needs → `PresignGet` or `Delivery`.**

## Two deliberate choices

- **Capped at `MaxGetBytes` (8 MiB).** This is for small module-owned control files — playlists, manifests, sidecars. A mistyped key should not turn a 4 GB source video into an OOM. Streaming large objects to a viewer is what `PresignGet` is for.
- **`LimitReader` at `MaxGetBytes+1`**, so exceeding the cap is **detected** rather than silently truncated. A truncated playlist is a subtly broken video, which is far worse to debug than a refusal.

## Scope

Additive: one method on `Storer`, one new file, no existing behaviour changed. Key is prefix-relative and validated exactly like every other method.

`go build ./... && go vet ./... && go test ./...` — 19 packages green.

## Follow-up

Needs a **patch release** (additive surface, pre-1.0 convention) before video-core can pin it — its `readStorageObject` fix depends on this method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)