### PR TITLE
feat(auth): mint a platform-notarised member assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to the MirrorStack Module SDK.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Additive only — 2 exported symbols added (`ms.MintMemberAssertion`,
+`ms.MemberAssertion`), none removed and none changed, so this is a PATCH per the
+pre-1.0 convention. (Verified by diffing `go doc -all` between `origin/main` and
+this branch: 2 added lines, 0 removed. Measured, not asserted.)
+
+⚠️ **Inert until api-platform ships the mint endpoint.** `POST
+/apps/{appID}/member-assertions` is PR 1 of #518 and exists in no deployed
+platform yet; until it does, every call returns an error. That is the intended
+sequencing — nothing changes behaviour until an app actually sends an assertion —
+but it also means a green test here proves nothing about the real endpoint. The
+tests fake dispatch with `httptest`, so the wire contract (path, field names,
+status codes) must be diffed against the platform handler's source before either
+side merges.
+
+### Added
+
+- **`ms.MintMemberAssertion(ctx, userID, ttl)`** — exchange a decision the
+  auth-provider module already made ("this request belongs to member U") for a
+  short-lived platform-signed assertion, returned as `ms.MemberAssertion`.
+  Attach its `Token` to a module request as `Authorization: Bearer <token>` and
+  dispatch turns it back into `ms.UserID(ctx)` for the module that serves it.
+
+  This closes the hole behind #518: dispatch builds a caller with literally zero
+  identity for every non-platform, non-internal path, so a module's `/public/*`
+  handler has never been able to see who is asking. An entitlement gate that
+  reads `userID == ""` denies a signed-in member correctly and uselessly — there
+  was simply nobody standing behind it.
+
+  The alternative — each consuming module calls the auth module to resolve a
+  session itself — was rejected for two structural reasons, not for speed. It
+  breaks the audit rule (*actor from ctx ONLY*): an actor a module fetched for
+  itself is not one the platform can guarantee, so the first module that forgets
+  writes a row claiming a system actor for a human action. And it hands every
+  module a credential that can act **as** that member later, for anything.
+  Notarising keeps `ms.UserID(ctx)` uniformly true and keeps the member's own
+  credential inside the module that owns members.
+
+  Only the module hosting the `auth-provider` slot may mint; the platform checks
+  the caller against a fact recorded at install. That check is what makes the
+  endpoint safe to expose at all — a delivery token can only ever address the
+  caller's own storage prefix, but an identity assertion names *somebody else*
+  and has no naturally bounded scope.
+
+  **No app role is in the claims.** Identity is not authorization: an assertion
+  says who, never what they may do, and every consuming module still asks its own
+  policy question. That separation is what keeps a member from being mistaken for
+  an operator by a module that only checked "is someone there".
+
+  🔴 Fails closed, and here the degraded return is the dangerous one. An empty or
+  malformed token attached to a request is indistinguishable at the far end from
+  no token at all: every downstream module would see an **anonymous** caller
+  while the auth module believed it had signed someone in — the member gets the
+  signed-out answer and their audit rows name no actor. So an empty token, a
+  non-positive lifetime, or a token that is not header-safe is an error, and
+  every error path returns the zero `MemberAssertion`.
+
+  Unlike `DeliveryTicket`, the credential is **exported**: handing the string
+  onward to the app's server side is the entire point, so there is nothing to
+  hide it behind. That costs the second fail-closed layer `DeliveryTicket` gets
+  from its `armed` check, which is why the response screening is pinned by its own
+  test rather than only through the mint path.
+
+  A `ttl` is a proposal the platform clamps (5 minutes today); read `ExpiresIn`
+  for what was actually granted and renew off that, never off your own proposal.
+
+### Changed
+
+- `deliveryTTLSeconds` → `dispatchTTLSeconds`, moved to `dispatch_transport.go`.
+  Internal only, no exported surface affected. "ttl is a proposal, sent as whole
+  seconds, absent when unset" is now one wire convention shared by two mint
+  surfaces, so it should not keep living in one surface's file under one
+  surface's name.
+
 ## [v0.4.3] - 2026-08-16
 
 Additive only — 3 exported symbols added (`storage.Client.Get`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 Additive only — 2 exported symbols added (`ms.MintMemberAssertion`,
 `ms.MemberAssertion`), none removed and none changed, so this is a PATCH per the
 pre-1.0 convention. (Verified by diffing `go doc -all` between `origin/main` and
-this branch: 2 added lines, 0 removed. Measured, not asserted.)
+this branch, both with `GOWORK=off`: 2 added SYMBOLS across 36 added doc lines,
+0 removed. The symbol count is the number that decides the bump; the line count
+is larger because `go doc -all` prints each symbol's full doc comment. Measured,
+not asserted — and it reconciles when re-run.)
 
 ⚠️ **Inert until api-platform ships the mint endpoint.** `POST
 /apps/{appID}/member-assertions` is PR 1 of #518 and exists in no deployed
@@ -60,8 +63,25 @@ side merges.
   no token at all: every downstream module would see an **anonymous** caller
   while the auth module believed it had signed someone in — the member gets the
   signed-out answer and their audit rows name no actor. So an empty token, a
-  non-positive lifetime, or a token that is not header-safe is an error, and
-  every error path returns the zero `MemberAssertion`.
+  token that is not header-safe, or a lifetime that is not usable is an error,
+  and every error path returns the zero `MemberAssertion`.
+
+  "Not usable" screens the value the CALLER gets, not the wire integer.
+  `time.Duration` is nanoseconds, so a response above ~9.2e9 seconds overflows
+  and wraps **negative** — which is exactly what a platform returning
+  milliseconds by mistake would produce, and it sails past a check that only
+  looks at the JSON number. A negative lifetime means a renewal timer that fires
+  immediately or a deadline already in the past, i.e. a hollow 200 that looks
+  live. There is also a 24h sanity ceiling on top: far above the platform's
+  5-minute clamp (the SDK does not enforce a policy dispatch owns, and a future
+  longer clamp must not need an SDK release) and far below anything that could
+  be mistaken for correct.
+
+  Inside a **task attempt** the mint uses the broker-attested, attempt-scoped
+  capability, never the ambient `MS_INTERNAL_SECRET`; a denied or expired
+  capability is an error with no request made. A revoked attempt must not go on
+  minting identity assertions under a process-wide secret the broker already
+  declined to renew.
 
   Unlike `DeliveryTicket`, the credential is **exported**: handing the string
   onward to the app's server side is the entire point, so there is nothing to

--- a/internal/core/delivery.go
+++ b/internal/core/delivery.go
@@ -189,7 +189,7 @@ func Delivery(ctx context.Context, prefix string, ttl time.Duration) (DeliveryTi
 	if err := validateDeliveryPrefix(prefix); err != nil {
 		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: %w", err)
 	}
-	ttlSeconds, err := deliveryTTLSeconds(ttl)
+	ttlSeconds, err := dispatchTTLSeconds(ttl)
 	if err != nil {
 		return DeliveryTicket{}, fmt.Errorf("ms.Delivery: %w", err)
 	}
@@ -349,26 +349,4 @@ func validateDeliveryRelativeKey(key string) error {
 		return fmt.Errorf("key %q must contain only [A-Za-z0-9._/-]", key)
 	}
 	return nil
-}
-
-// deliveryTTLSeconds turns a Duration proposal into the wire field.
-//
-// nil means "unset", which the platform reads as its default. A negative ttl is
-// a caller bug and is rejected rather than quietly defaulted — silently turning
-// a wrong lifetime into an hour hides the bug at the one place it is cheap to
-// see. A positive sub-second ttl rounds UP to 1s so it stays an explicit
-// proposal (the platform then clamps it to its floor) instead of truncating to
-// 0 and reading as "unset".
-func deliveryTTLSeconds(ttl time.Duration) (*int64, error) {
-	switch {
-	case ttl < 0:
-		return nil, fmt.Errorf("ttl must not be negative (got %s)", ttl)
-	case ttl == 0:
-		return nil, nil
-	}
-	seconds := int64(ttl / time.Second)
-	if ttl%time.Second != 0 {
-		seconds++
-	}
-	return &seconds, nil
 }

--- a/internal/core/dispatch_transport.go
+++ b/internal/core/dispatch_transport.go
@@ -23,6 +23,10 @@ import (
 // envelope construction and its resolve*URL path building, so the #146 prod
 // transport lands here (and in the per-surface resolvers' path logic) instead
 // of being swapped in N copies.
+//
+// dispatchTTLSeconds is here for the same reason: "ttl is a PROPOSAL, sent as
+// whole seconds, absent when unset" is one wire convention shared by every mint
+// surface (Delivery, MintMemberAssertion), not a fact about any one of them.
 
 // dispatchFallbackWarn keeps the unset-MS_DISPATCH_URL warning to one line per
 // process, so a module that makes many calls does not spam its log.
@@ -93,6 +97,29 @@ func outboundServiceSecret(ctx context.Context, operation string) (string, error
 		return capability.Token, nil
 	}
 	return moduleSessionSecret(), nil
+}
+
+// dispatchTTLSeconds turns a Duration proposal into the wire field shared by
+// every dispatch mint envelope.
+//
+// nil means "unset", which the platform reads as its default. A negative ttl is
+// a caller bug and is rejected rather than quietly defaulted — silently turning
+// a wrong lifetime into an hour hides the bug at the one place it is cheap to
+// see. A positive sub-second ttl rounds UP to 1s so it stays an explicit
+// proposal (the platform then clamps it to its floor) instead of truncating to
+// 0 and reading as "unset".
+func dispatchTTLSeconds(ttl time.Duration) (*int64, error) {
+	switch {
+	case ttl < 0:
+		return nil, fmt.Errorf("ttl must not be negative (got %s)", ttl)
+	case ttl == 0:
+		return nil, nil
+	}
+	seconds := int64(ttl / time.Second)
+	if ttl%time.Second != 0 {
+		seconds++
+	}
+	return &seconds, nil
 }
 
 // appIDFromContext reads the current app id from the request context — the

--- a/internal/core/member_assertion.go
+++ b/internal/core/member_assertion.go
@@ -44,6 +44,14 @@ import (
 // so this must move in lockstep with the endpoint.
 const memberAssertionEnvelopeVersion = 1
 
+// maxAssertionLifetime is the sanity ceiling on the lifetime a mint response may
+// claim. Deliberately far above the platform's 5-minute clamp — the SDK must not
+// second-guess a policy dispatch owns, and a future longer clamp must not need
+// an SDK release — and far below anything that could be mistaken for correct.
+// Its job is to catch a BROKEN response (a unit mix-up, a garbage integer), not
+// to enforce policy.
+const maxAssertionLifetime = 24 * time.Hour
+
 // memberAssertionUserID mirrors the platform's rule that an asserted principal
 // is a UUID. The point is not formatting: it is that a module must not be able
 // to assert a FREE-FORM principal — "admin", "*", or another module's internal
@@ -203,16 +211,32 @@ func MintMemberAssertion(ctx context.Context, userID string, ttl time.Duration) 
 // surface: a CR/LF would let a hostile or broken response append headers of its
 // own to every request the assertion is attached to.
 func newMemberAssertion(resp memberAssertionResponse) (MemberAssertion, error) {
+	// 🔴 SCREEN THE VALUE THE CALLER ACTUALLY GETS, not the wire integer.
+	// time.Duration is nanoseconds, so anything above ~9.2e9 seconds OVERFLOWS
+	// and wraps NEGATIVE — and a platform that returned MILLISECONDS by mistake,
+	// the single most common unit bug in a field shaped like this, passes a
+	// `resp.ExpiresIn <= 0` screen and hands back a negative Duration. This
+	// type's whole contract is "renew off ExpiresIn, not your own proposal", so
+	// a negative value is either a timer that fires immediately (a renewal storm
+	// against the mint endpoint) or a deadline already in the past. Both are a
+	// hollow 200 that looks live, which is the one thing this function exists to
+	// prevent.
+	expiresIn := time.Duration(resp.ExpiresIn) * time.Second
 	switch {
 	case resp.Token == "":
 		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: platform returned no assertion")
 	case !actor.ValidTransportValue(resp.Token):
 		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: platform returned an assertion that is not header-safe")
-	case resp.ExpiresIn <= 0:
+	case resp.ExpiresIn <= 0 || expiresIn <= 0:
 		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: platform returned a non-positive assertion lifetime (%ds)", resp.ExpiresIn)
+	case expiresIn > maxAssertionLifetime:
+		// A ceiling on top of the overflow guard, because a value can be absurd
+		// without wrapping: 1e9 seconds is 31 years, positive, and still not a
+		// lifetime any platform grants. The platform clamps to 5 minutes, so
+		// anything past a day is a broken response, not a generous one.
+		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: platform returned an implausible assertion lifetime (%ds)", resp.ExpiresIn)
 	}
 
-	expiresIn := time.Duration(resp.ExpiresIn) * time.Second
 	// expiresAt is a convenience, not the authority: expiresIn is the clamped
 	// number the platform actually granted. An unparseable timestamp must not
 	// fail a mint that succeeded, so derive it rather than reject.

--- a/internal/core/member_assertion.go
+++ b/internal/core/member_assertion.go
@@ -1,0 +1,241 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/mirrorstack-ai/app-module-sdk/internal/actor"
+)
+
+// Member identity assertions — the module-facing half of #518.
+//
+// WHO OWNS WHAT. The module that hosts the `auth-provider` slot owns the
+// IDENTITY DECISION (whose session is this, is it still valid); the PLATFORM
+// owns the IDENTITY CREDENTIAL other modules see. This file is the seam: the
+// auth module says "I have decided this browser is member U of app A", the
+// platform hands back a short-lived signed assertion, and dispatch turns that
+// assertion back into ms.UserID(ctx) for every module downstream. The module
+// never holds the signing key, and no other module ever holds a credential that
+// can act AS the member.
+//
+// WHY THE PLATFORM NOTARISES INSTEAD OF EACH MODULE RESOLVING. The alternative
+// — every consumer calls the auth module to turn a session into a user id —
+// fails the audit rule structurally: `actor from ctx ONLY`. An actor a module
+// fetched for itself is not an actor the platform can guarantee, so the one
+// module that forgets writes an audit row claiming a system actor for a human
+// action. It also hands every module a credential that can act as that member
+// later, for anything (the confused deputy). Notarising keeps ms.UserID(ctx)
+// uniformly true and keeps the member's own credential inside the auth module.
+//
+// 🔴 NO ROLE TRAVELS IN THE CLAIMS. Identity is not authorization. An assertion
+// says WHO, never WHAT THEY MAY DO; every consuming module still asks its own
+// policy question. That separation is what keeps a member from ever being
+// mistaken for an operator by a module that only checked "is someone there".
+//
+// 🔴 INERT UNTIL PR 1 SHIPS. POST /apps/{appID}/member-assertions does not exist
+// in any deployed platform as of this writing (it is PR 1 of #518). Every call
+// here returns an error until it does — which is the correct shape: a mint that
+// cannot happen must never look like a mint that produced an anonymous caller.
+
+// memberAssertionEnvelopeVersion is the mint envelope version. The platform
+// rejects an unknown version loudly rather than reading a future format as v1,
+// so this must move in lockstep with the endpoint.
+const memberAssertionEnvelopeVersion = 1
+
+// memberAssertionUserID mirrors the platform's rule that an asserted principal
+// is a UUID. The point is not formatting: it is that a module must not be able
+// to assert a FREE-FORM principal — "admin", "*", or another module's internal
+// key — through a field that is otherwise unconstrained. The platform re-checks
+// after authenticating the sender; this copy exists to fail in the caller's own
+// stack frame with no round trip, exactly like validateDeliveryPrefix.
+var memberAssertionUserID = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// MemberAssertion is ONE minted, platform-signed statement that a named member
+// is acting. Present Token to a module's /public/* route as
+// `Authorization: Bearer <token>` and dispatch verifies it and stamps the user
+// id the same way it already does on /platform/*.
+//
+// UNLIKE DeliveryTicket, THE CREDENTIAL IS EXPORTED, and that is a real cost
+// paid deliberately. A delivery ticket hides its token because the module's
+// contract is "you get a URL"; an assertion exists precisely so the auth module
+// can hand the string onward to the app's BFF, so there is nothing to hide it
+// behind. DeliveryTicket therefore fails closed through TWO layers (response
+// screening plus the armed check inside URL); this type has only the first.
+// Wrapping Token in an accessor would be the same single layer with extra
+// steps. So: the screening in newMemberAssertion is the whole guarantee, and it
+// is pinned by its own test rather than only through the mint path.
+//
+// The zero value carries an empty Token and is therefore unusable — which is
+// what every error path returns.
+type MemberAssertion struct {
+	// Token is the opaque platform-signed assertion. Treat it as a bearer
+	// credential: anyone holding it can act as this member until it expires.
+	Token string
+	// ExpiresAt is when the assertion dies. After it, dispatch rejects the
+	// request outright rather than downgrading it to anonymous.
+	ExpiresAt time.Time
+	// ExpiresIn is the CLAMPED lifetime the platform granted, which can be
+	// shorter than the ttl proposed. A holder that renews on a schedule must
+	// read THIS, not its own proposal — renewing off the proposal is how a
+	// clamped credential expires mid-session.
+	ExpiresIn time.Duration
+}
+
+// memberAssertionRequest is the mint envelope. Note what is ABSENT, and it is
+// the same absence the delivery envelope has: no module id and no app id. The
+// platform resolves the app from the URL and the SENDING MODULE from the
+// credential, so there is no field here a caller could point at another app's
+// members or use to impersonate another module's right to assert.
+//
+// TTLSeconds is a pointer so "unset" (platform default) is distinguishable on
+// the wire from an explicit 0.
+type memberAssertionRequest struct {
+	V          int    `json:"v"`
+	UserID     string `json:"userId"`
+	TTLSeconds *int64 `json:"ttlSeconds,omitempty"`
+}
+
+type memberAssertionResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expiresAt"`
+	ExpiresIn int64  `json:"expiresIn"`
+}
+
+// resolveMemberAssertionURL builds the platform-dispatch mint URL:
+//
+//	{base}/apps/{appID}/member-assertions
+//
+// base is MS_DISPATCH_URL with the host.docker.internal:8083 dev fallback when
+// unset — the same resolution Call, Emit, Notify and Delivery use, via
+// dispatchBaseFor so a task attempt's broker-attested routing wins over process
+// state.
+func resolveMemberAssertionURL(ctx context.Context, appID string) string {
+	return fmt.Sprintf("%s/apps/%s/member-assertions", dispatchBaseFor(ctx), appID)
+}
+
+// MintMemberAssertion exchanges a decision this module already made — "this
+// request belongs to member userID" — for a platform-signed assertion other
+// modules can trust.
+//
+// ONLY THE MODULE HOSTING THE auth-provider SLOT MAY CALL THIS. The platform
+// checks that at mint time against a fact recorded when the app was installed;
+// any other module gets an error, whatever it sends. That check is the whole
+// reason this endpoint is safe to expose at all: unlike a delivery token, which
+// can only ever address the caller's own storage prefix, an identity assertion
+// names SOMEBODY ELSE and has no naturally bounded scope.
+//
+// userID must be the member's UUID as the auth module knows it.
+//
+// ttl is a PROPOSAL. The platform clamps it (5 minutes today) and reports the
+// result as ExpiresIn; a zero ttl takes the platform default. Propose no more
+// than the remaining life of the session the assertion is derived from.
+//
+// Not module-bound (no *Module receiver), and deliberately so — same shape and
+// same reason as Delivery and AppID: the platform derives the calling module
+// from the CREDENTIAL, never from anything sent, and a receiver would falsely
+// suggest a module id travels in the request.
+//
+// PACKAGE-LEVEL FUNCTION, NOT AN INTERFACE METHOD, and this is the deliberate
+// answer to the PrefixDeleter-vs-Storer question. Storer's rule is that a method
+// goes on the interface only when it is fundamental to what every holder of that
+// interface does, and stays BESIDE it otherwise, because adding one is
+// source-breaking for every implementation and test double outside the package.
+// Minting an assertion is fundamental to nothing a module already holds: it is
+// not a storage operation, not a cache operation, and it has no second
+// implementation to abstract over — there is exactly one platform. Putting it on
+// an interface would invent a seam whose only purpose is to let something OTHER
+// than the platform mint identity, which is the one thing this design exists to
+// prevent. It is a free function for the same reason Delivery is.
+//
+// 🔴 Fail closed. Every error path returns the zero MemberAssertion, whose
+// Token is empty. There is no degraded return, because the degraded return here
+// is the dangerous one: an empty or malformed token sent on a request makes
+// every downstream module see an ANONYMOUS caller while the auth module believes
+// it signed someone in — a member who is quietly served the signed-out answer,
+// and an audit row that names no actor for a human action.
+func MintMemberAssertion(ctx context.Context, userID string, ttl time.Duration) (MemberAssertion, error) {
+	appID, err := appIDFromContext(ctx, "MintMemberAssertion")
+	if err != nil {
+		return MemberAssertion{}, err
+	}
+	if err := validateAssertedUserID(userID); err != nil {
+		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: %w", err)
+	}
+	ttlSeconds, err := dispatchTTLSeconds(ttl)
+	if err != nil {
+		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: %w", err)
+	}
+	secret, err := outboundServiceSecret(ctx, "MintMemberAssertion")
+	if err != nil {
+		return MemberAssertion{}, err
+	}
+
+	var resp memberAssertionResponse
+	if err := postDispatchJSONInto(ctx, "ms.MintMemberAssertion", resolveMemberAssertionURL(ctx, appID), appID,
+		memberAssertionRequest{V: memberAssertionEnvelopeVersion, UserID: userID, TTLSeconds: ttlSeconds},
+		&resp,
+		map[string]string{"X-MS-Service-Secret": secret},
+	); err != nil {
+		return MemberAssertion{}, err
+	}
+	return newMemberAssertion(resp)
+}
+
+// newMemberAssertion turns a 200 into an assertion, or into an error.
+//
+// A 2xx is NOT on its own evidence that a usable credential came back. An empty
+// token attached to a request is indistinguishable at the far end from no token
+// at all, so a caller that trusted a hollow 200 would ship a signed-out
+// experience to a signed-in member and never see an error. Everything below is
+// therefore checked before a MemberAssertion exists at all.
+//
+// The token's SHAPE is deliberately not pinned. Delivery makes the same choice
+// for the same reason: asserting the platform's token format here would couple
+// the SDK to a token version, making a future msm2 a breaking SDK change, and
+// dispatch is the authority that verifies signature, claims, expiry and app
+// binding anyway. What must be true is only that the bytes survive the transport
+// they will ride — an Authorization header — which is exactly the transport-only
+// contract actor.ValidTransportValue already states for the equally opaque
+// delegation token, so it is reused rather than re-derived. Its rejected set
+// (empty, over 4096 bytes, and any of `, \t\r\n`) is the header-injection
+// surface: a CR/LF would let a hostile or broken response append headers of its
+// own to every request the assertion is attached to.
+func newMemberAssertion(resp memberAssertionResponse) (MemberAssertion, error) {
+	switch {
+	case resp.Token == "":
+		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: platform returned no assertion")
+	case !actor.ValidTransportValue(resp.Token):
+		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: platform returned an assertion that is not header-safe")
+	case resp.ExpiresIn <= 0:
+		return MemberAssertion{}, fmt.Errorf("ms.MintMemberAssertion: platform returned a non-positive assertion lifetime (%ds)", resp.ExpiresIn)
+	}
+
+	expiresIn := time.Duration(resp.ExpiresIn) * time.Second
+	// expiresAt is a convenience, not the authority: expiresIn is the clamped
+	// number the platform actually granted. An unparseable timestamp must not
+	// fail a mint that succeeded, so derive it rather than reject.
+	expiresAt, err := time.Parse(time.RFC3339, resp.ExpiresAt)
+	if err != nil {
+		expiresAt = time.Now().UTC().Add(expiresIn)
+	}
+	return MemberAssertion{
+		Token:     resp.Token,
+		ExpiresAt: expiresAt.UTC(),
+		ExpiresIn: expiresIn,
+	}, nil
+}
+
+// validateAssertedUserID keeps a free-form principal from ever reaching the
+// wire. The platform re-checks after authenticating the sender — this copy
+// exists to fail in the caller's own stack frame, not to be the boundary.
+func validateAssertedUserID(userID string) error {
+	switch {
+	case userID == "":
+		return fmt.Errorf("userID is required")
+	case !memberAssertionUserID.MatchString(userID):
+		return fmt.Errorf("userID %q must be a UUID; a module may not assert a free-form principal", userID)
+	}
+	return nil
+}

--- a/internal/core/member_assertion_test.go
+++ b/internal/core/member_assertion_test.go
@@ -1,0 +1,471 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mirrorstack-ai/app-module-sdk/auth"
+	"github.com/mirrorstack-ai/app-module-sdk/internal/runtime"
+)
+
+const (
+	testAssertionAppID  = "a-456"
+	testAssertionUserID = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+	testAssertionToken  = "msm1.eyJ0eXAiOiJtZW1iZXIifQ.v3qShrO11hUS3ADd1nkukIeammYOYxJdKKBGbP-k3Ws"
+)
+
+// okAssertionResponse is the shape a healthy platform returns. Tests mutate a
+// copy of it so a failure case differs from success in exactly one field.
+func okAssertionResponse() memberAssertionResponse {
+	return memberAssertionResponse{
+		Token:     testAssertionToken,
+		ExpiresAt: "2026-08-16T13:04:05Z",
+		ExpiresIn: 300,
+	}
+}
+
+// assertionRecord is what actually went on the wire. Deliberately NOT reusing
+// mintRecord from delivery_test.go: the envelopes differ, and asserting the
+// delivery envelope's fields here would silently pass on an empty body.
+type assertionRecord struct {
+	method  string
+	path    string
+	appID   string
+	secret  string
+	body    memberAssertionRequest
+	rawBody []byte
+	calls   int
+}
+
+func newAssertionServer(t *testing.T, handler func(w http.ResponseWriter, rec *assertionRecord)) *assertionRecord {
+	t.Helper()
+	rec := &assertionRecord{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.calls++
+		rec.method = r.Method
+		rec.path = r.URL.Path
+		rec.appID = r.Header.Get("X-MS-App-ID")
+		rec.secret = r.Header.Get("X-MS-Service-Secret")
+		rec.rawBody, _ = io.ReadAll(r.Body)
+		_ = json.Unmarshal(rec.rawBody, &rec.body)
+		handler(w, rec)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("MS_DISPATCH_URL", srv.URL)
+	return rec
+}
+
+func writeAssertion(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func assertionCtx() context.Context {
+	return auth.Set(context.Background(), auth.Identity{AppID: testAssertionAppID})
+}
+
+func TestResolveMemberAssertionURL_Building(t *testing.T) {
+	cases := []struct {
+		name     string
+		dispatch string
+		want     string
+	}{
+		{"dev fallback when unset", "", devDispatchFallback + "/apps/a-456/member-assertions"},
+		{"explicit base", "http://dispatch:8083", "http://dispatch:8083/apps/a-456/member-assertions"},
+		{"trailing slash trimmed", "http://dispatch:8083/", "http://dispatch:8083/apps/a-456/member-assertions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MS_DISPATCH_URL", tc.dispatch)
+			if got := resolveMemberAssertionURL(context.Background(), testAssertionAppID); got != tc.want {
+				t.Errorf("resolveMemberAssertionURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A task attempt's broker-attested routing must WIN over process state. A warm
+// Lambda can run concurrent attempts, so routing can never be installed through
+// an environment variable — and dispatchBaseFor(ctx) degrading to dispatchBase()
+// is otherwise a silent change that no other assertion in this file can see.
+func TestResolveMemberAssertionURL_TaskRoutingBeatsProcessState(t *testing.T) {
+	t.Setenv("MS_DISPATCH_URL", "http://process-global:8083")
+	ctx := runtime.WithTaskDispatchURL(context.Background(), "http://attempt-scoped:9090/")
+
+	want := "http://attempt-scoped:9090/apps/" + testAssertionAppID + "/member-assertions"
+	if got := resolveMemberAssertionURL(ctx, testAssertionAppID); got != want {
+		t.Errorf("resolveMemberAssertionURL = %q, want %q", got, want)
+	}
+}
+
+// The happy path, and the wire request that produced it. The credential is a
+// header, never a body field: the platform derives the ASSERTING module from it
+// and checks that module against the app's recorded auth provider, so there must
+// be nothing in the envelope a caller could point elsewhere.
+func TestMintMemberAssertion_MintsAndSendsAnIdentityFreeEnvelope(t *testing.T) {
+	rec := newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+		writeAssertion(w, http.StatusOK, okAssertionResponse())
+	})
+	t.Setenv("MS_INTERNAL_SECRET", "module-credential")
+
+	got, err := MintMemberAssertion(assertionCtx(), testAssertionUserID, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("MintMemberAssertion: %v", err)
+	}
+
+	if got.Token != testAssertionToken {
+		t.Errorf("Token = %q, want %q", got.Token, testAssertionToken)
+	}
+	if got.ExpiresIn != 5*time.Minute {
+		t.Errorf("ExpiresIn = %s, want 5m (the CLAMPED value the platform granted)", got.ExpiresIn)
+	}
+	if got.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt is zero; a holder cannot schedule a renewal")
+	}
+	if rec.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", rec.method)
+	}
+	if rec.path != "/apps/"+testAssertionAppID+"/member-assertions" {
+		t.Errorf("path = %q, want /apps/%s/member-assertions", rec.path, testAssertionAppID)
+	}
+	if rec.appID != testAssertionAppID {
+		t.Errorf("X-MS-App-ID = %q, want %q", rec.appID, testAssertionAppID)
+	}
+	if rec.secret != "module-credential" {
+		t.Errorf("X-MS-Service-Secret = %q, want the module credential", rec.secret)
+	}
+	if rec.body.V != memberAssertionEnvelopeVersion {
+		t.Errorf("envelope v = %d, want %d", rec.body.V, memberAssertionEnvelopeVersion)
+	}
+	if rec.body.UserID != testAssertionUserID {
+		t.Errorf("envelope userId = %q, want %q", rec.body.UserID, testAssertionUserID)
+	}
+	// A module id in the envelope would let any module claim the auth-provider
+	// right; an app id would let it assert into another app. Neither field may
+	// exist on the wire at all — identity comes from the credential and the URL.
+	var raw map[string]any
+	if err := json.Unmarshal(rec.rawBody, &raw); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	for _, forbidden := range []string{"module", "moduleID", "moduleId", "app", "appID", "appId"} {
+		if _, ok := raw[forbidden]; ok {
+			t.Errorf("envelope carries %q; identity must come from the credential and the URL only", forbidden)
+		}
+	}
+	// No role either: identity is not authorization, and a role in the mint
+	// envelope would be a module deciding its own privilege.
+	for _, forbidden := range []string{"role", "appRole", "scope", "scopes", "permissions"} {
+		if _, ok := raw[forbidden]; ok {
+			t.Errorf("envelope carries %q; an assertion says WHO, never what they may do", forbidden)
+		}
+	}
+}
+
+// 🔴 THE FAIL-CLOSED TEST. Every way minting can fail must produce an error and
+// an EMPTY token. A non-empty token alongside an error would be attached to real
+// requests: dispatch would reject it and every module downstream would see an
+// anonymous caller, so a member who believes they are signed in gets the
+// signed-out answer and their audit rows name no actor.
+func TestMintMemberAssertion_MintFailureReturnsAnErrorAndNoToken(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		body    any
+		noServe bool   // reply something unparseable: a broken or wrong-version dispatch
+		raw     string // reply these exact bytes instead of encoding body
+	}{
+		{name: "signing key unconfigured", status: http.StatusServiceUnavailable,
+			body: map[string]any{"error": map[string]string{"code": "token_signing_unavailable", "message": "member assertions are not available"}}},
+		{name: "caller is not this app's auth provider", status: http.StatusForbidden,
+			body: map[string]any{"error": map[string]string{"code": "not_auth_provider", "message": "sender does not host the auth-provider slot"}}},
+		{name: "sender not recognised", status: http.StatusForbidden,
+			body: map[string]any{"error": map[string]string{"code": "unknown_sender", "message": "sender is not a live module"}}},
+		{name: "app not found", status: http.StatusNotFound,
+			body: map[string]any{"error": map[string]string{"code": "app_not_found", "message": "app not found"}}},
+		// Until #518 PR 1 deploys, this is the response a real platform gives.
+		{name: "endpoint does not exist yet", status: http.StatusNotFound, body: nil, noServe: true},
+		{name: "user id rejected", status: http.StatusBadRequest,
+			body: map[string]any{"error": map[string]string{"code": "invalid_user", "message": "userId must be a uuid"}}},
+		{name: "unparseable success body", status: http.StatusOK, body: nil, noServe: true},
+		// 🔴 A DECODE ERROR CAN STILL LEAVE A TOKEN IN THE STRUCT. encoding/json
+		// keeps going past a type error and populates the fields it could, so a
+		// platform that returns expiresIn as a string hands the transport an
+		// error AND a populated Token. Anything that carried that token out
+		// alongside the error would attach an unverifiable credential to real
+		// requests. The zero value is the only correct return.
+		{name: "200 that half-decodes, leaving a token behind", status: http.StatusOK,
+			raw: `{"token":"leaked-partial-token","expiresAt":"2026-08-16T13:04:05Z","expiresIn":"300"}`},
+		{name: "200 with an empty token", status: http.StatusOK, body: func() memberAssertionResponse {
+			r := okAssertionResponse()
+			r.Token = ""
+			return r
+		}()},
+		{name: "200 with a token carrying CRLF", status: http.StatusOK, body: func() memberAssertionResponse {
+			r := okAssertionResponse()
+			r.Token = "msm1.abc\r\nX-MS-App-Role: owner"
+			return r
+		}()},
+		{name: "200 with a token carrying a space", status: http.StatusOK, body: func() memberAssertionResponse {
+			r := okAssertionResponse()
+			r.Token = "msm1.abc def"
+			return r
+		}()},
+		{name: "200 with an oversized token", status: http.StatusOK, body: func() memberAssertionResponse {
+			r := okAssertionResponse()
+			r.Token = "msm1." + strings.Repeat("a", 5000)
+			return r
+		}()},
+		{name: "200 with a zero lifetime", status: http.StatusOK, body: func() memberAssertionResponse {
+			r := okAssertionResponse()
+			r.ExpiresIn = 0
+			return r
+		}()},
+		{name: "200 with a negative lifetime", status: http.StatusOK, body: func() memberAssertionResponse {
+			r := okAssertionResponse()
+			r.ExpiresIn = -1
+			return r
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+				if tc.noServe || tc.raw != "" {
+					payload := tc.raw
+					if payload == "" {
+						payload = "not json at all"
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(tc.status)
+					_, _ = w.Write([]byte(payload))
+					return
+				}
+				writeAssertion(w, tc.status, tc.body)
+			})
+
+			got, err := MintMemberAssertion(assertionCtx(), testAssertionUserID, 5*time.Minute)
+			if err == nil {
+				t.Fatalf("MintMemberAssertion succeeded on a failed mint and returned %+v", got)
+			}
+			// The load-bearing assertion: not merely "an error", but NOTHING a
+			// caller could attach to a request.
+			if got.Token != "" {
+				t.Fatalf("MintMemberAssertion returned token %q alongside its error; a failed mint must yield NO assertion", got.Token)
+			}
+			if got.ExpiresIn != 0 || !got.ExpiresAt.IsZero() {
+				t.Fatalf("failed mint returned a live-looking assertion %+v, want the zero value", got)
+			}
+		})
+	}
+}
+
+// DeliveryTicket's fail-closed guarantee has two layers — response screening
+// plus the armed check inside URL — so a mutation to either alone still fails
+// closed. A MemberAssertion has only ONE, because the token must be exported for
+// the auth module to hand onward. This test pins that single layer directly, so
+// a mutation that deletes it is visible here and not only through the mint path.
+func TestNewMemberAssertion_RejectsAnUnusableMintResponse(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*memberAssertionResponse)
+		wantErr string // substring the error must carry; "" = must succeed
+	}{
+		{name: "healthy response", mutate: func(*memberAssertionResponse) {}},
+		// 🔴 "the platform returned NOTHING" and "the platform returned GARBAGE"
+		// are different bugs in different places, so they must not collapse into
+		// one message. Asserting the wording is also what keeps the explicit
+		// empty check alive: actor.ValidTransportValue happens to reject "" too,
+		// so without this the line would be invisible to every test — and this
+		// file's emptiness guarantee would silently depend on another package's
+		// transport rule never relaxing.
+		{name: "empty token", mutate: func(r *memberAssertionResponse) { r.Token = "" }, wantErr: "returned no assertion"},
+		// The token rides an Authorization header. A CR/LF would let a broken or
+		// hostile response append headers of its own to every request the
+		// assertion is attached to.
+		{name: "token carrying CR", mutate: func(r *memberAssertionResponse) { r.Token = "msm1.abc\rdef" }, wantErr: "not header-safe"},
+		{name: "token carrying LF", mutate: func(r *memberAssertionResponse) { r.Token = "msm1.abc\ndef" }, wantErr: "not header-safe"},
+		{name: "token carrying a tab", mutate: func(r *memberAssertionResponse) { r.Token = "msm1.abc\tdef" }, wantErr: "not header-safe"},
+		{name: "token carrying a space", mutate: func(r *memberAssertionResponse) { r.Token = "msm1.abc def" }, wantErr: "not header-safe"},
+		{name: "token carrying a comma", mutate: func(r *memberAssertionResponse) { r.Token = "msm1.abc,def" }, wantErr: "not header-safe"},
+		{name: "token over the transport cap", mutate: func(r *memberAssertionResponse) { r.Token = strings.Repeat("a", 4097) }, wantErr: "not header-safe"},
+		{name: "token exactly at the transport cap is fine", mutate: func(r *memberAssertionResponse) { r.Token = strings.Repeat("a", 4096) }},
+		{name: "zero lifetime", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = 0 }, wantErr: "non-positive assertion lifetime"},
+		{name: "negative lifetime", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = -1 }, wantErr: "non-positive assertion lifetime"},
+		// The token FORMAT is deliberately not pinned: dispatch owns it, and
+		// asserting msm1 here would make a future msm2 a breaking SDK change.
+		{name: "a future token version is accepted, not second-guessed",
+			mutate: func(r *memberAssertionResponse) { r.Token = "msm2.abc.def" }},
+		{name: "unparseable expiresAt falls back rather than failing a good mint",
+			mutate: func(r *memberAssertionResponse) { r.ExpiresAt = "not a timestamp" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := okAssertionResponse()
+			tc.mutate(&resp)
+
+			got, err := newMemberAssertion(resp)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("newMemberAssertion accepted an unusable response and returned %+v", got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error = %q, want it to name the actual defect (%q)", err, tc.wantErr)
+				}
+				if got.Token != "" {
+					t.Fatalf("rejected response still yielded token %q", got.Token)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newMemberAssertion: %v", err)
+			}
+			if got.Token != resp.Token {
+				t.Errorf("Token = %q, want %q", got.Token, resp.Token)
+			}
+			if got.ExpiresIn != time.Duration(resp.ExpiresIn)*time.Second {
+				t.Errorf("ExpiresIn = %s, want %ds", got.ExpiresIn, resp.ExpiresIn)
+			}
+			if got.ExpiresAt.IsZero() {
+				t.Error("ExpiresAt is zero; a holder cannot schedule a renewal")
+			}
+		})
+	}
+}
+
+// A module must not be able to assert a FREE-FORM principal. These are rejected
+// locally, in the caller's own stack frame, with ZERO round trips — the platform
+// re-checks, but a caller should not need a 400 to learn it passed a username.
+func TestMintMemberAssertion_RejectsANonUUIDPrincipalWithoutCallingThePlatform(t *testing.T) {
+	cases := []string{
+		"",
+		"admin",
+		"*",
+		"me@example.com",
+		"7c9e6679-7425-40de-944b-e07fc1f90ae",   // one char short
+		"7c9e6679-7425-40de-944b-e07fc1f90ae77", // one char long
+		"7c9e6679742540de944be07fc1f90ae7",      // unhyphenated
+		" 7c9e6679-7425-40de-944b-e07fc1f90ae7",
+		"7c9e6679-7425-40de-944b-e07fc1f90ae7 ",
+		"7c9e6679-7425-40de-944b-e07fc1f90ae7\nX-MS-User-ID: someone-else",
+		"7c9e6679-7425-40de-944b-e07fc1z90ae7", // 'z' is not hex
+	}
+
+	for _, userID := range cases {
+		t.Run(strings.ReplaceAll(userID, "\n", "\\n"), func(t *testing.T) {
+			rec := newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+				writeAssertion(w, http.StatusOK, okAssertionResponse())
+			})
+
+			got, err := MintMemberAssertion(assertionCtx(), userID, 5*time.Minute)
+			if err == nil {
+				t.Fatalf("MintMemberAssertion(%q) succeeded and returned %+v", userID, got)
+			}
+			if got.Token != "" {
+				t.Errorf("returned token %q, want none", got.Token)
+			}
+			if rec.calls != 0 {
+				t.Errorf("rejected locally but still made %d mint call(s)", rec.calls)
+			}
+		})
+	}
+}
+
+// ttl is a PROPOSAL and travels as whole seconds. "Unset" must stay
+// distinguishable from an explicit 0 on the wire, or the platform's default
+// silently replaces a caller's intent. Asserted on the RAW JSON, not the decoded
+// struct: a decoded *int64 cannot tell an absent field from a null one.
+func TestMintMemberAssertion_TTLPassthrough(t *testing.T) {
+	cases := []struct {
+		name    string
+		ttl     time.Duration
+		want    string // raw JSON value expected for ttlSeconds; "" = field absent
+		wantErr bool
+	}{
+		{name: "the five-minute default lifetime", ttl: 5 * time.Minute, want: "300"},
+		{name: "above the platform ceiling is still sent verbatim and clamped there", ttl: time.Hour, want: "3600"},
+		{name: "zero omits the field so the platform default applies", ttl: 0, want: ""},
+		{name: "sub-second rounds up to an explicit 1s, never to absent", ttl: 500 * time.Millisecond, want: "1"},
+		{name: "fractional rounds up", ttl: 90500 * time.Millisecond, want: "91"},
+		{name: "negative is a caller bug, not a default", ttl: -time.Second, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+				writeAssertion(w, http.StatusOK, okAssertionResponse())
+			})
+
+			_, err := MintMemberAssertion(assertionCtx(), testAssertionUserID, tc.ttl)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ttl %s: want an error", tc.ttl)
+				}
+				if rec.calls != 0 {
+					t.Errorf("ttl %s: rejected locally but still made %d mint call(s)", tc.ttl, rec.calls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ttl %s: %v", tc.ttl, err)
+			}
+
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(rec.rawBody, &raw); err != nil {
+				t.Fatalf("unmarshal envelope: %v", err)
+			}
+			field, present := raw["ttlSeconds"]
+			if tc.want == "" {
+				if present {
+					t.Errorf("ttl %s: ttlSeconds = %s, want the field to be ABSENT", tc.ttl, field)
+				}
+				return
+			}
+			if !present {
+				t.Fatalf("ttl %s: ttlSeconds absent, want %s", tc.ttl, tc.want)
+			}
+			if string(field) != tc.want {
+				t.Errorf("ttl %s: ttlSeconds = %s, want %s", tc.ttl, field, tc.want)
+			}
+		})
+	}
+}
+
+// An app-scoped context is required: the mint URL is app-scoped and the platform
+// re-resolves the app from it, so an unscoped call would mint against whatever
+// app the path happened to name.
+func TestMintMemberAssertion_RequiresAnAppScopedContext(t *testing.T) {
+	rec := newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+		writeAssertion(w, http.StatusOK, okAssertionResponse())
+	})
+
+	got, err := MintMemberAssertion(context.Background(), testAssertionUserID, 5*time.Minute)
+	if err == nil {
+		t.Fatalf("MintMemberAssertion without an app scope returned %+v, want an error", got)
+	}
+	if got.Token != "" {
+		t.Errorf("returned token %q, want none", got.Token)
+	}
+	if rec.calls != 0 {
+		t.Errorf("made %d mint call(s) with no app scope, want 0", rec.calls)
+	}
+}
+
+// The zero value is what every error path returns, and it must be unusable on
+// its own — a caller that ignores the error still has nothing to attach.
+func TestMemberAssertion_ZeroValueCarriesNoCredential(t *testing.T) {
+	var zero MemberAssertion
+	if zero.Token != "" {
+		t.Errorf("zero MemberAssertion carries token %q, want none", zero.Token)
+	}
+	if zero.ExpiresIn != 0 || !zero.ExpiresAt.IsZero() {
+		t.Errorf("zero MemberAssertion looks live: %+v", zero)
+	}
+}

--- a/internal/core/member_assertion_test.go
+++ b/internal/core/member_assertion_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -115,7 +116,12 @@ func TestMintMemberAssertion_MintsAndSendsAnIdentityFreeEnvelope(t *testing.T) {
 	})
 	t.Setenv("MS_INTERNAL_SECRET", "module-credential")
 
-	got, err := MintMemberAssertion(assertionCtx(), testAssertionUserID, 5*time.Minute)
+	// The PROPOSAL is an hour; okAssertionResponse grants 300s. The two numbers
+	// must DIFFER, or an implementation that echoed the caller's proposal back
+	// instead of reading the response would pass this test identically — and the
+	// documented contract ("renew off ExpiresIn, not your own proposal") would be
+	// asserted by a comment rather than by the test.
+	got, err := MintMemberAssertion(assertionCtx(), testAssertionUserID, time.Hour)
 	if err != nil {
 		t.Fatalf("MintMemberAssertion: %v", err)
 	}
@@ -124,7 +130,7 @@ func TestMintMemberAssertion_MintsAndSendsAnIdentityFreeEnvelope(t *testing.T) {
 		t.Errorf("Token = %q, want %q", got.Token, testAssertionToken)
 	}
 	if got.ExpiresIn != 5*time.Minute {
-		t.Errorf("ExpiresIn = %s, want 5m (the CLAMPED value the platform granted)", got.ExpiresIn)
+		t.Errorf("ExpiresIn = %s, want 5m — the CLAMPED value the platform granted, not the 1h proposed", got.ExpiresIn)
 	}
 	if got.ExpiresAt.IsZero() {
 		t.Error("ExpiresAt is zero; a holder cannot schedule a renewal")
@@ -141,19 +147,29 @@ func TestMintMemberAssertion_MintsAndSendsAnIdentityFreeEnvelope(t *testing.T) {
 	if rec.secret != "module-credential" {
 		t.Errorf("X-MS-Service-Secret = %q, want the module credential", rec.secret)
 	}
-	if rec.body.V != memberAssertionEnvelopeVersion {
-		t.Errorf("envelope v = %d, want %d", rec.body.V, memberAssertionEnvelopeVersion)
-	}
-	if rec.body.UserID != testAssertionUserID {
-		t.Errorf("envelope userId = %q, want %q", rec.body.UserID, testAssertionUserID)
-	}
-	// A module id in the envelope would let any module claim the auth-provider
-	// right; an app id would let it assert into another app. Neither field may
-	// exist on the wire at all — identity comes from the credential and the URL.
+	// 🔴 ASSERTED ON THE RAW JSON, WITH LITERALS.
+	//
+	// `rec.body` is decoded through memberAssertionRequest — the SAME struct the
+	// production code encodes with — so a JSON tag rename changes both sides at
+	// once and no assertion over it can ever see the drift. Comparing the decoded
+	// V against memberAssertionEnvelopeVersion is worse still: it compares the
+	// constant to itself. The platform 400s a wrong `v` loudly and 400s an
+	// unknown field name just as hard, so a one-character drift here is a 100%
+	// mint failure in production against a fully green SDK suite. Every field
+	// name and the version LITERAL are therefore pinned by bytes.
 	var raw map[string]any
 	if err := json.Unmarshal(rec.rawBody, &raw); err != nil {
 		t.Fatalf("unmarshal envelope: %v", err)
 	}
+	if v, ok := raw["v"]; !ok || v != float64(1) {
+		t.Errorf(`envelope["v"] = %v (present=%v), want the literal 1`, v, ok)
+	}
+	if u, ok := raw["userId"]; !ok || u != testAssertionUserID {
+		t.Errorf(`envelope["userId"] = %v (present=%v), want %q`, u, ok, testAssertionUserID)
+	}
+	// A module id in the envelope would let any module claim the auth-provider
+	// right; an app id would let it assert into another app. Neither field may
+	// exist on the wire at all — identity comes from the credential and the URL.
 	for _, forbidden := range []string{"module", "moduleID", "moduleId", "app", "appID", "appId"} {
 		if _, ok := raw[forbidden]; ok {
 			t.Errorf("envelope carries %q; identity must come from the credential and the URL only", forbidden)
@@ -165,6 +181,47 @@ func TestMintMemberAssertion_MintsAndSendsAnIdentityFreeEnvelope(t *testing.T) {
 		if _, ok := raw[forbidden]; ok {
 			t.Errorf("envelope carries %q; an assertion says WHO, never what they may do", forbidden)
 		}
+	}
+}
+
+// 🔴 THE RESPONSE CONTRACT, PINNED BY BYTES.
+//
+// Every other test in this file decodes the platform's reply through
+// memberAssertionResponse — the same struct the production code reads with — so
+// renaming `token` to `assertion` or `expiresIn` to `ttl` changes both halves
+// together and nothing notices. This one serves a LITERAL body: the exact JSON
+// the platform handler emits (internal/dispatch/handler/member_assertion_router.go,
+// memberAssertionResponse), copied field-for-field rather than generated from
+// this package's own types.
+//
+// If this test starts failing after a platform change, the answer is not to edit
+// the literal until it passes — it is that the wire contract moved and both
+// sides need a version.
+func TestMintMemberAssertion_ReadsThePlatformsLiteralWireResponse(t *testing.T) {
+	const platformBody = `{"token":"msm1.eyJ0eXAiOiJtZW1iZXJfYXNzZXJ0aW9uIn0.c2ln","expiresAt":"2026-08-16T13:04:05Z","expiresIn":300}`
+
+	newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(platformBody))
+	})
+	t.Setenv("MS_INTERNAL_SECRET", "module-credential")
+
+	got, err := MintMemberAssertion(assertionCtx(), testAssertionUserID, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("MintMemberAssertion on the platform's literal response: %v", err)
+	}
+	if got.Token != "msm1.eyJ0eXAiOiJtZW1iZXJfYXNzZXJ0aW9uIn0.c2ln" {
+		t.Errorf("Token = %q; the `token` field is not being read", got.Token)
+	}
+	if got.ExpiresIn != 5*time.Minute {
+		t.Errorf("ExpiresIn = %s, want 5m; the `expiresIn` field is not being read", got.ExpiresIn)
+	}
+	want := time.Date(2026, 8, 16, 13, 4, 5, 0, time.UTC)
+	if !got.ExpiresAt.Equal(want) {
+		// A misread expiresAt falls back to now+expiresIn rather than erroring,
+		// so only comparing the actual instant can see it.
+		t.Errorf("ExpiresAt = %s, want %s; the `expiresAt` field is not being read", got.ExpiresAt, want)
 	}
 }
 
@@ -298,6 +355,19 @@ func TestNewMemberAssertion_RejectsAnUnusableMintResponse(t *testing.T) {
 		{name: "token exactly at the transport cap is fine", mutate: func(r *memberAssertionResponse) { r.Token = strings.Repeat("a", 4096) }},
 		{name: "zero lifetime", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = 0 }, wantErr: "non-positive assertion lifetime"},
 		{name: "negative lifetime", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = -1 }, wantErr: "non-positive assertion lifetime"},
+		// 🔴 A POSITIVE WIRE INTEGER THAT BECOMES A NEGATIVE DURATION. Duration is
+		// nanoseconds, so anything past ~9.2e9 seconds wraps. A platform that
+		// returned MILLISECONDS by mistake lands squarely here, passes a screen
+		// that only looks at resp.ExpiresIn, and hands the caller a deadline in
+		// the past — a renewal storm, or an assertion the holder believes is dead
+		// the instant it arrives.
+		{name: "lifetime that overflows a Duration", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = 1 << 34 }, wantErr: "assertion lifetime"},
+		{name: "lifetime that overflows harder", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = 1 << 40 }, wantErr: "assertion lifetime"},
+		// Positive, non-overflowing, and still not a lifetime any platform grants.
+		{name: "absurd but non-overflowing lifetime", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = 1_000_000_000 }, wantErr: "implausible assertion lifetime"},
+		// The ceiling must not clip a plausible grant: the SDK does not enforce
+		// the platform's clamp, only catches a broken response.
+		{name: "an hour is well within the sanity ceiling", mutate: func(r *memberAssertionResponse) { r.ExpiresIn = 3600 }},
 		// The token FORMAT is deliberately not pinned: dispatch owns it, and
 		// asserting msm1 here would make a future msm2 a breaking SDK change.
 		{name: "a future token version is accepted, not second-guessed",
@@ -455,6 +525,86 @@ func TestMintMemberAssertion_RequiresAnAppScopedContext(t *testing.T) {
 	}
 	if rec.calls != 0 {
 		t.Errorf("made %d mint call(s) with no app scope, want 0", rec.calls)
+	}
+}
+
+// stubCapabilityProvider is a task attempt's broker-attested outbound
+// credential source.
+type stubCapabilityProvider struct {
+	capability runtime.ModuleCallCapability
+	err        error
+	calls      int
+}
+
+func (s *stubCapabilityProvider) ModuleCallCapability(context.Context) (runtime.ModuleCallCapability, error) {
+	s.calls++
+	return s.capability, s.err
+}
+
+// 🔴 INSIDE A TASK ATTEMPT THE BROKER'S CREDENTIAL WINS, AND A DENIED ONE FAILS
+// CLOSED.
+//
+// outboundServiceSecret exists so that a denied or expired broker capability is
+// an ERROR, never a fall back to ambient MS_INTERNAL_SECRET — its own doc
+// comment says so. Nothing measured it: every other test in this file sets
+// MS_INTERNAL_SECRET and takes the fallback branch, so collapsing the whole call
+// to moduleSessionSecret() left the suite green. This is the exact sibling of
+// the dispatchBaseFor blind spot that TestResolveMemberAssertionURL_TaskRoutingBeatsProcessState
+// closes for routing; the consequence is worse for the credential, because a
+// REVOKED attempt would go on minting identity assertions naming arbitrary
+// members under a process-wide secret the broker had already declined to renew.
+func TestMintMemberAssertion_TaskCapabilityBeatsProcessCredentialAndFailsClosed(t *testing.T) {
+	t.Run("an attempt-scoped capability is what goes on the wire", func(t *testing.T) {
+		rec := newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+			writeAssertion(w, http.StatusOK, okAssertionResponse())
+		})
+		t.Setenv("MS_INTERNAL_SECRET", "ambient-process-secret")
+		provider := &stubCapabilityProvider{capability: runtime.ModuleCallCapability{
+			Token: "attempt-scoped", ExpiresAt: time.Now().Add(time.Hour),
+		}}
+		ctx := runtime.WithModuleCallCapabilityProvider(assertionCtx(), provider)
+
+		if _, err := MintMemberAssertion(ctx, testAssertionUserID, 5*time.Minute); err != nil {
+			t.Fatalf("MintMemberAssertion: %v", err)
+		}
+		if rec.secret != "attempt-scoped" {
+			t.Errorf("X-MS-Service-Secret = %q, want the attempt-scoped capability, not process state", rec.secret)
+		}
+		if provider.calls == 0 {
+			t.Error("the capability provider was never consulted")
+		}
+	})
+
+	// Each of these is a credential the broker has refused to vouch for. The
+	// ambient MS_INTERNAL_SECRET is set in every case and must never be reached.
+	for _, tc := range []struct {
+		name     string
+		provider *stubCapabilityProvider
+	}{
+		{"refresh denied", &stubCapabilityProvider{err: errors.New("attempt revoked")}},
+		{"empty capability token", &stubCapabilityProvider{capability: runtime.ModuleCallCapability{ExpiresAt: time.Now().Add(time.Hour)}}},
+		{"expired capability", &stubCapabilityProvider{capability: runtime.ModuleCallCapability{
+			Token: "attempt-scoped", ExpiresAt: time.Now().Add(-time.Second),
+		}}},
+	} {
+		t.Run(tc.name+" fails closed", func(t *testing.T) {
+			rec := newAssertionServer(t, func(w http.ResponseWriter, _ *assertionRecord) {
+				writeAssertion(w, http.StatusOK, okAssertionResponse())
+			})
+			t.Setenv("MS_INTERNAL_SECRET", "ambient-process-secret")
+			ctx := runtime.WithModuleCallCapabilityProvider(assertionCtx(), tc.provider)
+
+			got, err := MintMemberAssertion(ctx, testAssertionUserID, 5*time.Minute)
+			if err == nil {
+				t.Fatalf("MintMemberAssertion succeeded on a refused capability and returned %+v", got)
+			}
+			if got.Token != "" {
+				t.Errorf("returned token %q on a refused capability", got.Token)
+			}
+			if rec.calls != 0 {
+				t.Errorf("made %d mint call(s) after the broker refused the credential; the ambient secret must never be a fallback", rec.calls)
+			}
+		})
 	}
 }
 

--- a/mirrorstack.go
+++ b/mirrorstack.go
@@ -246,6 +246,46 @@ func Delivery(ctx context.Context, prefix string, ttl time.Duration) (DeliveryTi
 	return core.Delivery(ctx, prefix, ttl)
 }
 
+// --- Member identity assertions ---
+
+// MemberAssertion is one short-lived, platform-signed statement that a named
+// member is acting. Attach Token to a module request as
+// `Authorization: Bearer <token>` and dispatch turns it back into
+// ms.UserID(ctx) for the module that serves it.
+//
+// Token is a bearer credential — anyone holding it acts as that member until it
+// expires — so keep it server-side. Renew off ExpiresIn, which is the lifetime
+// the platform actually granted, not the ttl you proposed.
+type MemberAssertion = core.MemberAssertion
+
+// MintMemberAssertion exchanges a decision THIS module already made — "this
+// request belongs to member userID" — for a platform-signed assertion every
+// other module can trust.
+//
+// Only the module hosting the `auth-provider` slot may call it: the platform
+// checks the caller against a fact recorded at install, so any other module gets
+// an error whatever it sends. You own WHO the member is; the platform only
+// notarises it, which is what lets other modules read ms.UserID(ctx) without
+// ever holding a credential that can act as that member.
+//
+// 🔴 No app role is in the claims. Identity is not authorization: an assertion
+// says who, never what they may do, and every consuming module still asks its
+// own policy question.
+//
+// 🔴 An error means NO assertion. It never degrades to an anonymous or empty
+// token — an empty token on a request is indistinguishable from no token, so the
+// degraded return would show a signed-in member the signed-out answer while
+// every audit row for their actions names no actor.
+//
+// ttl is a proposal the platform clamps (5 minutes today); zero takes the
+// platform default.
+//
+// NOT AVAILABLE YET: the mint endpoint ships with #518 PR 1. Until a platform
+// carrying it is deployed, every call returns an error.
+func MintMemberAssertion(ctx context.Context, userID string, ttl time.Duration) (MemberAssertion, error) {
+	return core.MintMemberAssertion(ctx, userID, ttl)
+}
+
 // MetricOption configures a metric at declaration. The KIND is itself an option
 // (Counter / Gauge), alongside Unit and Price.
 type MetricOption = meter.MetricOption


### PR DESCRIPTION
PR 2 of the #518 Option A wave — the module-facing half.

Refs mirrorstack-ai/mirrorstack-core-v2#518.

## What this does

Adds `ms.MintMemberAssertion(ctx, userID, ttl) (ms.MemberAssertion, error)`: the module that hosts the `auth-provider` slot exchanges a decision it has already made — "this request belongs to member U" — for a short-lived, platform-signed assertion. Attach its `Token` to a module request as `Authorization: Bearer <token>` and dispatch turns it back into `ms.UserID(ctx)` for the module that serves it.

It rides the exact rail `ms.Delivery` already uses: `appIDFromContext`, `outboundServiceSecret`, `postDispatchJSONInto` against an app-scoped dispatch URL with `X-MS-Service-Secret` as an opt-in header. **Consumers need nothing** — `ms.UserID(ctx)` already reads what dispatch stamps.

A package-level function, not an interface method, and deliberately: a method goes on an interface only when it is fundamental to what every holder of that interface does. Minting an assertion abstracts over nothing — there is exactly one platform — and an interface here would invent a seam whose only purpose is to let something other than the platform mint identity, which is the one thing this design exists to prevent.

Also renames `deliveryTTLSeconds` → `dispatchTTLSeconds` and moves it to `dispatch_transport.go`. Internal only; "ttl is a proposal, sent as whole seconds, absent when unset" is now one wire convention shared by two mint surfaces and should not live in one surface's file under one surface's name.

No `VERSION` bump — the release is a separate `release`-labelled PR.

## Why the platform notarises rather than decides

The auth module owns identity; the platform owns transport. **The same split shipped for gated CDN delivery** — there video-core decides entitlement and the platform mints the delivery credential; here user-core decides who a member is and the platform mints the identity credential every other module sees.

The alternative — every consuming module calls the auth module and resolves a session for itself — was rejected for two structural reasons:

- **It breaks the audit rule.** *Actor from ctx ONLY.* An actor a module fetched for itself is not one the platform can guarantee, so the first module that forgets writes an audit row claiming a system actor for a human action. Notarising keeps `ms.UserID(ctx)` uniformly true.
- **It creates a confused deputy.** The member's session token would traverse every module it was sent to, handing each one a credential that can act *as that member* later, for anything. Notarising keeps the member's own credential inside the module that owns members.

**No role travels in the claims.** An assertion says WHO, never what they may do; every consuming module still asks its own policy question.

## Invariants pinned by tests

**The request, on the raw wire**
- `v` and `userId` are asserted against **literals in the raw JSON**, never against this package's own struct tags — a tag rename moves the encoder and the decoder together, so a struct-level assertion can never see the drift, and comparing the decoded version against the constant compares the constant to itself. The platform rejects a wrong `v` loudly, so drift here is a 100% mint failure against an otherwise green SDK.
- **No `module`, `moduleID`, `app` or `appId` field exists on the wire at all** — the platform derives the sending module from the credential and the app from the URL, so there must be nothing in the envelope a caller could point elsewhere.
- **No `role`, `scope` or `permissions` field either.**
- The credential travels as `X-MS-Service-Secret`, and `X-MS-App-ID` names the app scope.
- `ttl` is a proposal in whole seconds; "unset" stays distinguishable from an explicit `0` — asserted on the raw JSON, since a decoded `*int64` cannot tell an absent field from a null one. Sub-second rounds up to an explicit `1`, never down to absent. A negative ttl is a caller bug rejected locally.

**The response, pinned by bytes**
- One test serves the **platform handler's literal response body**, copied field-for-field from its source rather than generated from this package's types, so `token`, `expiresAt` and `expiresIn` are each pinned by name.
- The happy path proposes **1h against a 300s grant**, so `ExpiresIn` is the clamped value the platform granted and not an echo of the caller's own proposal — the number a holder must renew off.

**Fail closed — and here the degraded return is the dangerous one.** An empty or malformed token attached to a request is indistinguishable at the far end from no token at all: every downstream module would see an *anonymous* caller while the auth module believed it had signed someone in. So every failure returns the zero `MemberAssertion` and never a token alongside an error:
- Every mint-side failure (403, 404, 503, a 400 on the user id, the endpoint not existing yet) and every response-side one.
- **A 200 that half-decodes.** `encoding/json` keeps going past a type error and populates what it could, so a platform returning `expiresIn` as a string hands the transport an error *and* a populated `Token`. That case is in the table.
- Empty token, a token carrying CR/LF/tab/space/comma, and a token over the 4096-byte transport cap — the header-injection surface, since the token rides `Authorization`.
- **A lifetime that is not usable, screened on the value the caller gets rather than the wire integer.** `time.Duration` is nanoseconds, so a response above ~9.2e9 seconds overflows and wraps negative — exactly what a platform returning milliseconds by mistake produces, and it sails past a check that only reads the JSON number. A negative lifetime is a renewal timer that fires immediately or a deadline already in the past. There is a 24h sanity ceiling above that for values absurd without overflowing, set far above the platform's 5-minute clamp so the SDK never enforces a policy dispatch owns.
- A free-form principal (`admin`, `*`, an email, a UUID with a newline, a near-miss UUID) is rejected **locally, with zero round trips**.
- An unscoped context is an error with zero round trips.
- The zero value carries no credential.

**Task plane**
- Routing: a task attempt's broker-attested dispatch URL beats `MS_DISPATCH_URL`. A warm Lambda runs concurrent attempts, so routing can never be installed through a process-global env var.
- Credential: the **attempt-scoped capability is what goes on the wire** over an ambient `MS_INTERNAL_SECRET`, and a denied, empty or expired capability is an **error with zero requests made**. A revoked attempt must not go on minting identity assertions naming arbitrary members under a process-wide secret the broker had already declined to renew.

The token's **format is deliberately not pinned** — dispatch owns it, and asserting `msm1` would make a future `msm2` a breaking SDK change. What is asserted is only that the bytes survive the transport they will ride.

Every security-relevant test was mutation-proven, including the nine mutations that motivated the review-follow-up commit.

## What is deliberately NOT included

- **PR 3 — the user-core route.** `POST /public/session/assert`, where the app's BFF presents the session it holds and user-core validates it and returns an assertion minted through this function. Different repo, different PR. No new secret for the app to hold.
- **PR 4 — the app BFF wiring.** Blocked on `web-custom-apps/app-kaohsiung-association` having zero tracked git files — no branch, no PR, no rollback — so it must be a deliberate, separately-reviewed step.
- **No consumer-side API.** Modules read `ms.UserID(ctx)` exactly as they do today; nothing here changes what a consumer writes.

## This change is INERT until a caller exists

`POST /apps/{appID}/member-assertions` exists in no deployed platform until PR 1 ships, so until then every call returns an error — which is the correct shape: a mint that cannot happen must never look like a mint that produced an anonymous caller.

⚠️ The tests fake dispatch with `httptest`, so a green suite here proves nothing about the real endpoint. The wire contract must be diffed field-by-field against the platform handler's source before either side merges — which is why the request's `v`/`userId` and the whole response body are now pinned against literals rather than against this package's own structs.
