### PR TITLE
feat: declare module client build output in the live manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,42 @@ func createItem(w http.ResponseWriter, r *http.Request) {
 
 No config files. No YAML. Code is the single source of truth.
 
+### Module client
+
+A module can declare a separately built client for custom web applications:
+
+```go
+import "github.com/mirrorstack-ai/app-module-sdk/system"
+
+ms.Init(ms.Config{
+    ID:   "media",
+    Name: "Media",
+    Client: &system.ClientSpec{
+        Dir:       "client",
+        OutputDir: "dist",
+    },
+})
+```
+
+- **Paths:** `Dir` is relative to the module root; `OutputDir` is relative to
+  `Dir`. Both are non-empty canonical relative paths using `/` separators.
+- **Declaration:** use the inline literal above because the CLI reads it before
+  the module starts.
+- **Build:** install dependencies locally for the runner's Linux architecture
+  and provide a non-empty `package.json#scripts.build`. The CLI runs
+  `npm run build` and requires non-empty `index.js` and `index.d.ts` roots.
+- **Development:** `mirrorstack dev --tunnel` builds, publishes, and watches by
+  default; the explicit `mirrorstack dev --tunnel --watch` form behaves the
+  same. Use `--watch=false` for a one-shot build. `--share` is not required.
+- **Runner:** Compose must use a Linux runner built from the matching CLI
+  checkout. In `ms-app-modules`, run
+  `./scripts/build-dev-runner.sh /path/to/mirrorstack-cli` once and after CLI
+  changes; preflight rejects a missing/non-executable runner or an incompatible
+  CLI version or runner protocol. It does not fingerprint same-version source
+  changes.
+- **Ownership:** MirrorStack owns installed package identity, version, registry,
+  and the fixed build command; modules declare only source and output paths.
+
 ### Struct API (for testing)
 
 ```go

--- a/internal/core/module.go
+++ b/internal/core/module.go
@@ -96,6 +96,12 @@ type Config struct {
 	// route can dynamically import the named exports declared in
 	// RegisterUI.DefaultPages. Optional — when empty, the /web route 404s.
 	WebDir string
+
+	// Client declares an optional custom-app client project. Dir is relative to
+	// the module root; OutputDir is relative to Dir. The CLI builds and publishes
+	// this output during `mirrorstack dev --tunnel`. Package identity, versions,
+	// registry details, and the build command are controlled by MirrorStack.
+	Client *system.ClientSpec
 }
 
 // Module is the core SDK instance.
@@ -208,6 +214,23 @@ var moduleIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,35}$`)
 // the real gate; this regex catches obvious shape errors at New() time.
 var moduleSlugPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,15}$`)
 
+func validateClientPath(field, value string) error {
+	if value == "" || value == "." || strings.ContainsAny(value, "\\:\x00") || !fs.ValidPath(value) {
+		return fmt.Errorf("mirrorstack: Config.Client.%s %q must be a non-empty canonical relative path using forward slashes", field, value)
+	}
+	return nil
+}
+
+func validateClientSpec(client *system.ClientSpec) error {
+	if client == nil {
+		return nil
+	}
+	if err := validateClientPath("Dir", client.Dir); err != nil {
+		return err
+	}
+	return validateClientPath("OutputDir", client.OutputDir)
+}
+
 // New creates a new Module.
 func New(cfg Config) (*Module, error) {
 	if cfg.ID == "" {
@@ -225,6 +248,9 @@ func New(cfg Config) (*Module, error) {
 	}
 	if cfg.Slug != "" && !moduleSlugPattern.MatchString(cfg.Slug) {
 		return nil, fmt.Errorf("mirrorstack: Config.Slug %q must match %s (lowercase, starts with letter, hyphens allowed, max 16 chars)", cfg.Slug, moduleSlugPattern)
+	}
+	if err := validateClientSpec(cfg.Client); err != nil {
+		return nil, err
 	}
 	m := &Module{
 		config:         cfg,
@@ -811,9 +837,9 @@ func (m *Module) mountSystemRoutes() {
 			// http.MaxBytesReader wraps only ever shrinks the effective limit
 			// to the smaller of the two.
 			smallBody := httputil.MaxBytes(64 * 1024)
-			r.With(smallBody).Get("/manifest", system.ManifestHandler(
+			r.With(smallBody).Get("/manifest", system.ManifestHandlerWithClient(
 				m.config.ID, m.config.Slug, m.config.Name, m.config.Icon, m.config.Tags,
-				m.config.SQL, m.config.Versions, m.registry, m.contribReg,
+				m.config.SQL, m.config.Versions, m.registry, m.contribReg, m.config.Client,
 			))
 			r.Route("/lifecycle", func(r chi.Router) {
 				// App and module migrations are separate tracks on disjoint

--- a/internal/core/module_test.go
+++ b/internal/core/module_test.go
@@ -115,6 +115,70 @@ func TestNew_EmptyID(t *testing.T) {
 	}
 }
 
+func TestNew_AcceptsCanonicalClientPaths(t *testing.T) {
+	t.Parallel()
+
+	client := &system.ClientSpec{Dir: "packages/user-core/client", OutputDir: "dist/browser"}
+	m, err := New(Config{ID: "media", Client: client})
+	if err != nil {
+		t.Fatalf("New() rejected canonical client paths: %v", err)
+	}
+	if m.Config().Client == nil || *m.Config().Client != *client {
+		t.Errorf("Config.Client = %+v, want %+v", m.Config().Client, client)
+	}
+}
+
+func TestNew_RejectsUnsafeClientPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		dir         string
+		outputDir   string
+		wantInError string
+	}{
+		{name: "empty dir", dir: "", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "dot dir", dir: ".", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "absolute dir", dir: "/client", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "Windows absolute dir", dir: `C:/client`, outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "Windows drive-relative dir", dir: `C:client`, outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "traversal dir", dir: "../client", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "nested traversal dir", dir: "packages/../client", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "backslash dir", dir: `client\src`, outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "dot segment dir", dir: "client/./src", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "trailing slash dir", dir: "client/", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "NUL dir", dir: "client\x00src", outputDir: "dist", wantInError: "Client.Dir"},
+		{name: "empty output", dir: "client", outputDir: "", wantInError: "Client.OutputDir"},
+		{name: "dot output", dir: "client", outputDir: ".", wantInError: "Client.OutputDir"},
+		{name: "absolute output", dir: "client", outputDir: "/dist", wantInError: "Client.OutputDir"},
+		{name: "Windows absolute output", dir: "client", outputDir: `C:/dist`, wantInError: "Client.OutputDir"},
+		{name: "traversal output", dir: "client", outputDir: "../dist", wantInError: "Client.OutputDir"},
+		{name: "backslash output", dir: "client", outputDir: `dist\browser`, wantInError: "Client.OutputDir"},
+		{name: "duplicate separator output", dir: "client", outputDir: "dist//browser", wantInError: "Client.OutputDir"},
+		{name: "trailing slash output", dir: "client", outputDir: "dist/", wantInError: "Client.OutputDir"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := New(Config{
+				ID: "media",
+				Client: &system.ClientSpec{
+					Dir:       tt.dir,
+					OutputDir: tt.outputDir,
+				},
+			})
+			if err == nil {
+				t.Fatal("New() accepted an unsafe client path")
+			}
+			if !strings.Contains(err.Error(), tt.wantInError) {
+				t.Errorf("New() error = %q, want it to name %s", err, tt.wantInError)
+			}
+		})
+	}
+}
+
 func TestNew_RejectsBadID(t *testing.T) {
 	bad := []string{
 		"Media",                                 // uppercase
@@ -631,6 +695,30 @@ func TestManifest_Returns200WithSecret(t *testing.T) {
 	}
 	if got.ID != "media" || got.Defaults.Name != "Media" || got.Defaults.Icon != "perm_media" {
 		t.Errorf("manifest identity wrong: %+v", got)
+	}
+	if got.Client != nil || strings.Contains(rec.Body.String(), `"client"`) {
+		t.Errorf("undeclared client must be omitted from the authenticated manifest: %s", rec.Body.String())
+	}
+}
+
+func TestManifest_ClientFromConfig(t *testing.T) {
+	t.Setenv("MS_INTERNAL_SECRET", "secret")
+	client := &system.ClientSpec{Dir: "client", OutputDir: "dist"}
+	m, err := New(Config{ID: "media", Name: "Media", Client: client})
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+
+	rec := doRequestWithSecret(t, m.Router(), "GET", "/__mirrorstack/platform/manifest", "secret")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var got system.ManifestPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if got.Client == nil || *got.Client != *client {
+		t.Errorf("manifest client = %+v, want %+v", got.Client, client)
 	}
 }
 

--- a/system/manifest.go
+++ b/system/manifest.go
@@ -40,12 +40,16 @@ type ManifestPayload struct {
 	// text), resolved from the module's i18n catalog (ms.Config.DescriptionLabel).
 	// Omitted when the module declared none, in which case the platform falls
 	// back to Description. Mirrors Permission.Descriptions / MetricDecl.Labels.
-	DescriptionLabels map[string]string                   `json:"descriptionLabels,omitempty"`
-	Dependencies      []registry.Dependency               `json:"dependencies"`
-	Migration         MigrationVersions                   `json:"migration"`
-	Versions          map[string]MigrationVersions        `json:"versions"`
-	Routes            map[registry.Scope][]registry.Route `json:"routes"`
-	Events            ManifestEvents                      `json:"events"`
+	DescriptionLabels map[string]string `json:"descriptionLabels,omitempty"`
+	// Client declares the module-local source and build-output directories for
+	// the optional custom-app client. The CLI consumes these paths during local
+	// development; package identity and versioning remain platform-owned.
+	Client       *ClientSpec                         `json:"client,omitempty"`
+	Dependencies []registry.Dependency               `json:"dependencies"`
+	Migration    MigrationVersions                   `json:"migration"`
+	Versions     map[string]MigrationVersions        `json:"versions"`
+	Routes       map[registry.Scope][]registry.Route `json:"routes"`
+	Events       ManifestEvents                      `json:"events"`
 	// Exposes lists the tables this module marks readable (SELECT-eligible)
 	// by a depending module (ms.ExposeTable). The platform catalog issues
 	// GRANT SELECT against the depending module's DB role after the app
@@ -78,6 +82,15 @@ type ManifestPayload struct {
 	// the registration after app-owner approval. Always present; empty
 	// array when the module contributes nothing.
 	ContributesTo []registry.OutboundContribution `json:"contributesTo"`
+}
+
+// ClientSpec identifies the module-local client project and its compiled
+// output. Both paths are canonical, slash-separated paths relative to their
+// containing project: Dir is relative to the module root and OutputDir is
+// relative to Dir. Module construction validates this contract.
+type ClientSpec struct {
+	Dir       string `json:"dir"`
+	OutputDir string `json:"outputDir"`
 }
 
 // ManifestResources is the module's opt-in runtime-resource contract. Empty is
@@ -231,6 +244,17 @@ func buildManifestMCP(reg *registry.Registry) ManifestMCP {
 // contribReg is the module's contribution-slot registry. Pass nil to omit
 // declared contributions from the manifest entirely (e.g. tests).
 func ManifestHandler(id, slug, name, icon string, tags []string, sqlFS fs.FS, versions map[string]MigrationVersions, reg *registry.Registry, contribReg *contributions.Registry) http.HandlerFunc {
+	return manifestHandler(id, slug, name, icon, tags, sqlFS, versions, reg, contribReg, nil)
+}
+
+// ManifestHandlerWithClient is the client-aware manifest entry used by the
+// SDK's module wiring. ManifestHandler remains unchanged for source
+// compatibility with callers that construct a manifest handler directly.
+func ManifestHandlerWithClient(id, slug, name, icon string, tags []string, sqlFS fs.FS, versions map[string]MigrationVersions, reg *registry.Registry, contribReg *contributions.Registry, client *ClientSpec) http.HandlerFunc {
+	return manifestHandler(id, slug, name, icon, tags, sqlFS, versions, reg, contribReg, client)
+}
+
+func manifestHandler(id, slug, name, icon string, tags []string, sqlFS fs.FS, versions map[string]MigrationVersions, reg *registry.Registry, contribReg *contributions.Registry, client *ClientSpec) http.HandlerFunc {
 	if versions == nil {
 		versions = map[string]MigrationVersions{}
 	}
@@ -263,6 +287,7 @@ func ManifestHandler(id, slug, name, icon string, tags []string, sqlFS fs.FS, ve
 			Defaults:          ManifestDefaults{Name: name, Icon: icon, Tags: tags, NameLabels: i18n.Lookup("module.name"), TagLabels: i18n.LookupList(tagCatalogKey, tagLabelSep)},
 			Description:       reg.Description(),
 			DescriptionLabels: reg.DescriptionLabels(),
+			Client:            client,
 			Dependencies:      reg.Dependencies(),
 			Migration:         MigrationVersions{App: appVersion, Module: moduleVersion},
 			Versions:          versions,

--- a/system/manifest_test.go
+++ b/system/manifest_test.go
@@ -46,6 +46,54 @@ func TestManifest_IDAndDefaults(t *testing.T) {
 	}
 }
 
+func TestManifest_ClientDeclaration(t *testing.T) {
+	t.Parallel()
+
+	client := &ClientSpec{Dir: "client", OutputDir: "dist"}
+	handler := ManifestHandlerWithClient(
+		"media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil, client,
+	)
+	rec := manifestResponse(t, handler)
+	got := decodeManifest(t, handler)
+
+	if got.Client == nil {
+		t.Fatal("client declaration missing from manifest")
+	}
+	if *got.Client != *client {
+		t.Errorf("client = %+v, want %+v", *got.Client, *client)
+	}
+	if !strings.Contains(rec.Body.String(), `"client":{"dir":"client","outputDir":"dist"}`) {
+		t.Errorf("manifest client wire shape is not exact: %s", rec.Body.String())
+	}
+
+	withoutClient := manifestResponse(t, ManifestHandler(
+		"media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil,
+	))
+	if rec.Header().Get("X-MS-Manifest-Hash") == withoutClient.Header().Get("X-MS-Manifest-Hash") {
+		t.Fatal("manifest hash did not change after declaring a client")
+	}
+}
+
+func TestManifest_ClientOmittedWhenNil(t *testing.T) {
+	t.Parallel()
+
+	compatRec := manifestResponse(t, ManifestHandler(
+		"media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil,
+	))
+	clientAwareRec := manifestResponse(t, ManifestHandlerWithClient(
+		"media", "", "Media", "perm_media", nil, nil, nil, registry.New(), nil, nil,
+	))
+	if strings.Contains(clientAwareRec.Body.String(), `"client"`) {
+		t.Errorf("client field must be omitted for nil declarations: %s", clientAwareRec.Body.String())
+	}
+	if clientAwareRec.Body.String() != compatRec.Body.String() {
+		t.Errorf("nil client changed the compatibility manifest body\nclient-aware: %s\ncompat: %s", clientAwareRec.Body.String(), compatRec.Body.String())
+	}
+	if clientAwareRec.Header().Get("X-MS-Manifest-Hash") != compatRec.Header().Get("X-MS-Manifest-Hash") {
+		t.Error("nil client changed the compatibility manifest hash")
+	}
+}
+
 func TestManifest_StorageDeclarationIsExplicit(t *testing.T) {
 	base := registry.New()
 	baseRec := manifestResponse(t, ManifestHandler("media", "", "Media", "perm_media", nil, nil, nil, base, nil))


### PR DESCRIPTION
## Summary

- Add optional `Config.Client` / `system.ClientSpec` metadata with only canonical relative source and output paths.
- Emit `manifest.client` without module-authored package identity, version, registry, or build command.
- Preserve the existing manifest-handler API and nil manifest shape.

## Verification

- `go test ./...`
- Local review-like-me prescreen: 0 mechanical findings.
- Self-review: **APPROVE** — born-clean SDK surface, real User Core consumer, validation at construction, compatibility covered by tests.

## Release sequencing

This feature PR does not change `VERSION` or `CHANGELOG.md`. A dedicated patch release PR follows after merge.

Closes #185
Tracker: mirrorstack-ai/mirrorstack-core-v2#742